### PR TITLE
Refactor shuffles to use canonical ids as well, write id of last roun…

### DIFF
--- a/packages/parser/src/pipeline/classic/segmentToCombat.ts
+++ b/packages/parser/src/pipeline/classic/segmentToCombat.ts
@@ -59,7 +59,7 @@ export const segmentToCombat = () => {
             },
             durationInSeconds: (nullthrows(combat.endInfo).timestamp - nullthrows(combat.startInfo).timestamp) / 1000,
             endInfo: nullthrows(combat.endInfo),
-            winningTeamId: 'TODO: WRITE THIS!',
+            winningTeamId: nullthrows(combat.endInfo?.winningTeamId),
           };
           return plainCombatDataObject;
         }

--- a/packages/parser/src/pipeline/retail/segmentToCombat.ts
+++ b/packages/parser/src/pipeline/retail/segmentToCombat.ts
@@ -122,7 +122,7 @@ function decodeShuffleRound(
   const endTime = combat.endInfo ? combat.endInfo.timestamp : deathRecords[0].timestamp;
 
   const rv: IShuffleRound = {
-    id: combat.id,
+    id: computeCanonicalHash(segment.lines),
     wowVersion: 'retail',
     dataType: 'ShuffleRound',
     startInfo: nullthrows(combat.startInfo),
@@ -186,7 +186,7 @@ export const segmentToCombat = () => {
             const shuf: IShuffleMatch = {
               wowVersion: 'retail',
               dataType: 'ShuffleMatch',
-              id: decoded.combat.id, // TODO: which id to use??
+              id: decoded.shuffle.id, // Using id of last round
               startTime: recentShuffleRoundsBuffer[0].startTime,
               endTime: decoded.combat.endTime,
               result: decoded.combat.result,

--- a/packages/parser/test/soloshuffle.test.ts
+++ b/packages/parser/test/soloshuffle.test.ts
@@ -43,6 +43,7 @@ describe('solo shuffle tests', () => {
 
       expect(shuffle.rounds.length).toBe(6);
       expect(shuffle.dataType).toBe('ShuffleMatch');
+      expect(shuffle.id).toBe(lastRound.id);
     });
 
     it('should parse round 0', () => {
@@ -68,6 +69,7 @@ describe('solo shuffle tests', () => {
       team1Ids.forEach((id) => expect(round.units[id].info?.teamId).toBe('1'));
       team0Ids.forEach((id) => expect(round.units[id].info?.teamId).toBe('0'));
 
+      expect(round.id).toBe('68bd3de521023a67016dc234d2473558');
       expect(round.dataType).toBe('ShuffleRound');
       expect(round.sequenceNumber).toBe(0);
       expect(round.winningTeamId).toBe('0');


### PR DESCRIPTION
…d as match id