### PR TITLE
quick fix for the death timeline on summary page

### DIFF
--- a/packages/shared/src/components/CombatReport/CombatSummary/index.tsx
+++ b/packages/shared/src/components/CombatReport/CombatSummary/index.tsx
@@ -62,7 +62,7 @@ export const CombatSummary = () => {
               </thead>
               <tbody>
                 <tr>
-                  <td className="bg-base-200">
+                  <td className="bg-base-200 align-top">
                     <CombatUnitTimelineView
                       unit={allPlayerDeath[0].unit}
                       startTime={allPlayerDeath[0].deathRecord.timestamp - 20 * 1000}


### PR DESCRIPTION
previously <td> automatically places the child vertically centered. now it snaps to the top -

![image](https://user-images.githubusercontent.com/3233006/204925365-ec7ce8a5-f6be-4689-be88-ad1f923291f8.png)
