### PR TITLE
Refetch queries on window focus

### DIFF
--- a/packages/desktop/pages/_app.tsx
+++ b/packages/desktop/pages/_app.tsx
@@ -38,7 +38,6 @@ const client = new ApolloClient({
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
-      refetchOnWindowFocus: false,
       staleTime: 600,
       retry: (_failureCount: unknown, error: unknown) => {
         if ((error as Error)?.message === 'Fetch error 404') {


### PR DESCRIPTION
Turned this off to reduce the re-querying of stuff initially but I don't think the UX has been good.

I've noticed my match history goes stale for much much longer than I'd like. Until we can code something more sophisticated this should help a lot.