### PR TITLE
make the repo more friendly to contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,5 +5,52 @@
 We use [NPM workspaces](https://docs.npmjs.com/cli/v8/using-npm/workspaces) to manage the monorepo. There are a few key characteristics that are unique when compared to other monorepo frameworks such as lerna or yarn workspaces:
 
 - Each sub package maintains its own list of dependencies and devDependencies in its package.json.
-- `npm install` at the root directory will trigger npm workspaces to "rebuild" (bootstrap) the dependency graph
+- `npm ci` at the root directory will trigger npm workspaces to "rebuild" (bootstrap) the dependency graph
 - There are a few convenient npm scripts defined in the root package.json to help make it easier to add dependencies to a sub package. For example, `npm run add:web external-package` will install the external dependency to the web package. It can be further augmented to install devDependencies: `npm run add:web external-package -- --save-dev`.
+
+## Setting up your local dev environment
+
+### Clean install
+
+Once you've cloned the repo, cd into the root directory and run the following command to do a clean install of all dependencies.
+
+```bash
+npm ci
+```
+
+### Credentials to access backend
+
+We use Google Cloud Platform as our backend. In order to test most of the core functionality locally, you will need to obtain credentials to access our development project in Google Cloud.
+
+Join our [discord server](https://discord.gg/NFTPK9tmJK) and talk to us to proceed. We will share a development credentials with you and you will need to place it at /packages/cloud/wowarenalogs-public-dev.json. This will provide your local setup with necessary access to a development environment of our Google Cloud backend.
+
+### Environment variables
+
+Our frontend, both /packages/desktop and /packages/web, use Next.js as the framework. In order for the frontend to work correctly, you need to set a few environment variables locally.
+
+The easiest way to do this is by creating a `.env.local` file under both /packages/desktop and /packages/web, and put in the following content:
+
+```
+NEXTAUTH_SECRET=wowarenalogs_not_really_a_secret
+BLIZZARD_CLIENT_ID=dummy_client_id
+BLIZZARD_CLIENT_SECRET=dummy_client_secret
+```
+
+Note that this currently will not allow you to test Battle.net authentication. We're still figuring out what's the best way to allow contributors to gain access.
+
+## Running the app
+
+Use the following command to run the app locally with hot reload:
+
+```
+npm run dev:app
+```
+
+Check out the other npm scripts listed under the root package.json to see what else you can do.
+
+## Submitting pull requests
+
+We welcome pull requests. When you create one that you would like to merge into our main branch, please make sure of the followings:
+
+- Provide sufficient context in the PR description to describe what you are intended to do.
+- Attach screenshots if applicable to demonstrate how the change was/can be tested.

--- a/packages/cloud/package.json
+++ b/packages/cloud/package.json
@@ -8,10 +8,10 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "build": "shx rm -rf dist && tsc && cd ../.. && npm run build:parser && shx mkdir ./packages/cloud/dist/parser && shx cp -r ./packages/parser/dist ./packages/cloud/dist/parser/dist",
-    "deploy:dev": "npm run build && serverless deploy --stage dev",
-    "deploy:prod": "npm run build && serverless deploy --stage prod",
+    "deploy:dev": "npm run build && serverless deploy --config serverless.dev.yml",
+    "deploy:prod": "npm run build && serverless deploy --config serverless.prod.yml",
     "start:reprocess-anon": "npm run build && cross-env NODE_ENV=development node ./dist/cloud/src/operations/reprocessAnonHandler.js",
-    "start:generate-map-image": "npm run build && node ./dist/cloud/src/operations/generateMapImage.js",
+    "start:generate-map-image": "npm run build && cross-env NODE_ENV=development node ./dist/cloud/src/operations/generateMapImage.js",
     "test:refresh-spell-icons": "npm run build && cross-env NODE_ENV=development node ./dist/cloud/test/test_refresh_spell_icons.js"
   },
   "devDependencies": {

--- a/packages/cloud/serverless.dev.yml
+++ b/packages/cloud/serverless.dev.yml
@@ -1,0 +1,44 @@
+service: gcp-wowarenalogs
+
+provider:
+  name: google
+  stage: prod
+  runtime: nodejs14
+  region: us-central1
+  project: wowarenalogs-public-dev
+  credentials: wowarenalogs-public-dev.json
+
+plugins:
+  - serverless-google-cloudfunctions
+
+package:
+  include:
+    - 'index.js'
+    - 'dist/**'
+
+functions:
+  writeMatchStub:
+    memorySize: 1024
+    handler: writeMatchStubHandler
+    environment:
+      ENV_MATCH_STUBS_FIRESTORE: match-stubs-prod
+      ENV_LOG_FILES_BUCKET: ${self:provider.project}-log-files-prod
+      ENV_GCP_PROJECT: ${self:provider.project}
+      ENV_SERVICE_NAME: ${self:service}
+    events:
+      - event:
+          eventType: google.storage.object.finalize
+          resource: projects/wowarenalogs/buckets/${self:provider.project}-log-files-prod
+
+  writeAnonLog:
+    memorySize: 1024
+    handler: writeAnonLogHandler
+    environment:
+      ENV_MATCH_STUBS_FIRESTORE: match-anon-stubs-prod
+      ENV_LOG_FILES_BUCKET: ${self:provider.project}-anon-log-files-prod
+      ENV_GCP_PROJECT: ${self:provider.project}
+      ENV_SERVICE_NAME: ${self:service}
+    events:
+      - event:
+          eventType: google.storage.object.finalize
+          resource: projects/wowarenalogs/buckets/${self:provider.project}-log-files-prod

--- a/packages/cloud/serverless.prod.yml
+++ b/packages/cloud/serverless.prod.yml
@@ -2,11 +2,11 @@ service: gcp-wowarenalogs
 
 provider:
   name: google
-  stage: ${opt:stage}
+  stage: prod
   runtime: nodejs14
   region: us-central1
   project: wowarenalogs
-  credentials: ${self:provider.project}.json
+  credentials: wowarenalogs.json
 
 plugins:
   - serverless-google-cloudfunctions
@@ -21,29 +21,27 @@ functions:
     memorySize: 1024
     handler: writeMatchStubHandler
     environment:
-      ENV_STAGE: ${opt:stage}
-      ENV_MATCH_STUBS_FIRESTORE: match-stubs-${opt:stage}
-      ENV_LOG_FILES_BUCKET: ${self:provider.project}-log-files-${opt:stage}
+      ENV_MATCH_STUBS_FIRESTORE: match-stubs-prod
+      ENV_LOG_FILES_BUCKET: ${self:provider.project}-log-files-prod
       ENV_GCP_PROJECT: ${self:provider.project}
       ENV_SERVICE_NAME: ${self:service}
     events:
       - event:
           eventType: google.storage.object.finalize
-          resource: projects/wowarenalogs/buckets/${self:provider.project}-log-files-${opt:stage}
+          resource: projects/wowarenalogs/buckets/${self:provider.project}-log-files-prod
 
   writeAnonLog:
     memorySize: 1024
     handler: writeAnonLogHandler
     environment:
-      ENV_STAGE: ${opt:stage}
-      ENV_MATCH_STUBS_FIRESTORE: match-anon-stubs-${opt:stage}
-      ENV_LOG_FILES_BUCKET: ${self:provider.project}-anon-log-files-${opt:stage}
+      ENV_MATCH_STUBS_FIRESTORE: match-anon-stubs-prod
+      ENV_LOG_FILES_BUCKET: ${self:provider.project}-anon-log-files-prod
       ENV_GCP_PROJECT: ${self:provider.project}
       ENV_SERVICE_NAME: ${self:service}
     events:
       - event:
           eventType: google.storage.object.finalize
-          resource: projects/wowarenalogs/buckets/${self:provider.project}-log-files-${opt:stage}
+          resource: projects/wowarenalogs/buckets/${self:provider.project}-log-files-prod
 
   refreshSpellIcons:
     memorySize: 1024

--- a/packages/cloud/src/operations/generateMapImage.ts
+++ b/packages/cloud/src/operations/generateMapImage.ts
@@ -11,7 +11,8 @@ import { parseFromStringArrayAsync } from '../utils';
 
 const firestore = new Firestore({
   ignoreUndefinedProperties: true,
-  projectId: 'wowarenalogs',
+  // always read production credentials because this tool is designed to work on production data
+  credentials: JSON.parse(fs.readFileSync(path.join(__dirname, '../../wowarenalogs.json'), 'utf8')),
 });
 const zoneIdField = new FieldPath('startInfo', 'zoneId');
 

--- a/packages/cloud/src/writeAnonLogHandler.ts
+++ b/packages/cloud/src/writeAnonLogHandler.ts
@@ -1,7 +1,9 @@
 import { Firestore } from '@google-cloud/firestore';
 import { Storage as GoogleCloudStorage } from '@google-cloud/storage';
 import { instanceToPlain } from 'class-transformer';
+import fs from 'fs';
 import fetch from 'node-fetch';
+import path from 'path';
 import { Readable } from 'stream';
 
 import { WowVersion } from '../../parser/dist/index';
@@ -10,15 +12,20 @@ import { createStubDTOFromArenaMatch } from './createMatchStub';
 import { parseFromStringArrayAsync } from './utils';
 
 const anonFilesBucket = process.env.ENV_LOG_FILES_BUCKET || 'wowarenalogs-anon-log-files-prod';
-const projectId = process.env.ENV_GCP_PROJECT;
 const matchStubsFirestore = process.env.ENV_MATCH_STUBS_FIRESTORE;
+
+const gcpCredentials =
+  process.env.NODE_ENV === 'development'
+    ? JSON.parse(fs.readFileSync(path.join(__dirname, '../../wowarenalogs-public-dev.json'), 'utf8'))
+    : undefined;
 
 const firestore = new Firestore({
   ignoreUndefinedProperties: true,
+  credentials: gcpCredentials,
 });
 
 const storage = new GoogleCloudStorage({
-  projectId,
+  credentials: gcpCredentials,
 });
 
 const DF_S1_LAUNCH_DATE = 1670734800000;

--- a/packages/cloud/src/writeMatchStubHandler.ts
+++ b/packages/cloud/src/writeMatchStubHandler.ts
@@ -1,6 +1,8 @@
 import { Firestore } from '@google-cloud/firestore';
 import { instanceToPlain } from 'class-transformer';
+import fs from 'fs';
 import fetch from 'node-fetch';
+import path from 'path';
 
 import { WowVersion } from '../../parser/dist/index';
 import { createStubDTOFromArenaMatch, createStubDTOFromShuffleMatch } from './createMatchStub';
@@ -8,8 +10,14 @@ import { parseFromStringArrayAsync } from './utils';
 
 const matchStubsFirestore = process.env.ENV_MATCH_STUBS_FIRESTORE;
 
+const gcpCredentials =
+  process.env.NODE_ENV === 'development'
+    ? JSON.parse(fs.readFileSync(path.join(__dirname, '../../wowarenalogs-public-dev.json'), 'utf8'))
+    : undefined;
+
 const firestore = new Firestore({
   ignoreUndefinedProperties: true,
+  credentials: gcpCredentials,
 });
 
 // In the Google code they actually type file as `data:{}`

--- a/packages/cloud/test/test_file_upload.ts
+++ b/packages/cloud/test/test_file_upload.ts
@@ -1,8 +1,6 @@
 import fs from 'fs';
 import fetch from 'node-fetch';
 
-const STAGE = 'dev';
-
 const functionURL = 'us-central1-wowarenalogs.cloudfunctions.net';
 
 /*
@@ -11,7 +9,7 @@ const functionURL = 'us-central1-wowarenalogs.cloudfunctions.net';
 async function uploadFile(fullFilePath: string, hashedName: string) {
   console.log('Uploading file', fullFilePath, hashedName);
   const s3_preflight = await fetch(
-    `https://${functionURL}/gcp-wowarenalogs-${STAGE}-getUploadSignature?name=${hashedName}`,
+    `https://${functionURL}/gcp-wowarenalogs-prod-getUploadSignature?name=${hashedName}`,
     {
       method: 'OPTIONS',
       headers: {
@@ -23,7 +21,7 @@ async function uploadFile(fullFilePath: string, hashedName: string) {
   console.log(s3_preflight.headers);
 
   const s3_signed_response = await fetch(
-    `https://${functionURL}/gcp-wowarenalogs-${STAGE}-getUploadSignature?name=${hashedName}`,
+    `https://${functionURL}/gcp-wowarenalogs-prod-getUploadSignature?name=${hashedName}`,
     {
       headers: {
         'content-type': 'text/plain;charset=UTF-8',

--- a/packages/cloud/test/test_indexes.ts
+++ b/packages/cloud/test/test_indexes.ts
@@ -1,10 +1,19 @@
 import { Firestore } from '@google-cloud/firestore';
+import fs from 'fs';
+import path from 'path';
 
 const MAX_RESULTS_PER_QUERY = 1;
 
-const matchAnonStubsCollection = 'match-anon-stubs-dev';
+const matchAnonStubsCollection = 'match-anon-stubs-prod';
 
-const firestore = new Firestore();
+const gcpCredentials =
+  process.env.NODE_ENV === 'development'
+    ? JSON.parse(fs.readFileSync(path.join(__dirname, '../../wowarenalogs-public-dev.json'), 'utf8'))
+    : undefined;
+
+const firestore = new Firestore({
+  credentials: gcpCredentials,
+});
 
 const collectionReference = firestore.collection(matchAnonStubsCollection);
 const docsQuery = collectionReference.orderBy('startTime', 'desc').limit(MAX_RESULTS_PER_QUERY);

--- a/packages/desktop/pages/api/auth/[...nextauth].ts
+++ b/packages/desktop/pages/api/auth/[...nextauth].ts
@@ -1,9 +1,15 @@
 import { Firestore } from '@google-cloud/firestore';
 import { FirestoreNextAuthAdapter } from '@wowarenalogs/shared';
+import fs from 'fs';
 import NextAuth from 'next-auth';
+import path from 'path';
 
 const firestore = new Firestore({
   ignoreUndefinedProperties: true,
+  credentials:
+    process.env.NODE_ENV === 'development'
+      ? JSON.parse(fs.readFileSync(path.join(process.cwd(), '../cloud/wowarenalogs-public-dev.json'), 'utf8'))
+      : undefined,
 });
 
 export default NextAuth({

--- a/packages/shared/src/api/combatUploadSignatureHandler.ts
+++ b/packages/shared/src/api/combatUploadSignatureHandler.ts
@@ -1,19 +1,19 @@
 import { GetSignedUrlConfig, Storage } from '@google-cloud/storage';
+import fs from 'fs';
 import _ from 'lodash';
 import type { NextApiRequest, NextApiResponse } from 'next';
+import path from 'path';
 
 const isDev = process.env.NODE_ENV === 'development';
 
-const logFilesBucket = isDev ? 'wowarenalogs-public-dev-log-files-dev' : 'wowarenalogs-log-files-prod';
+const logFilesBucket = isDev ? 'wowarenalogs-public-dev-log-files-prod' : 'wowarenalogs-log-files-prod';
 
-const storage = new Storage(
-  isDev
-    ? {
-        // encode your GCP service account key json into a base64 string and put in .env.local as GCP_KEY_JSON_BASE64
-        credentials: JSON.parse(Buffer.from(process.env.GCP_KEY_JSON_BASE64 || '', 'base64').toString('ascii')),
-      }
-    : {},
-);
+const storage = new Storage({
+  credentials:
+    process.env.NODE_ENV === 'development'
+      ? JSON.parse(fs.readFileSync(path.join(process.cwd(), '../cloud/wowarenalogs-public-dev.json'), 'utf8'))
+      : undefined,
+});
 
 const bucket = storage.bucket(logFilesBucket);
 

--- a/packages/shared/src/components/common/ErrorPage.tsx
+++ b/packages/shared/src/components/common/ErrorPage.tsx
@@ -16,8 +16,8 @@ export function ErrorPage({ message }: { message: string }) {
       </div>
       <div className="w-4/12 px-2 mt-4 space-y-4">
         Report this error at{' '}
-        <a href="https://discord.gg/jXrH5ZEan3" target="_blank" rel="noreferrer">
-          https://discord.gg/jXrH5ZEan3
+        <a href="https://discord.gg/NFTPK9tmJK" target="_blank" rel="noreferrer">
+          https://discord.gg/NFTPK9tmJK
         </a>
         <div
           className="btn"

--- a/packages/shared/src/graphql-server/resolvers/matches.ts
+++ b/packages/shared/src/graphql-server/resolvers/matches.ts
@@ -1,16 +1,22 @@
 import { Firestore } from '@google-cloud/firestore';
 import { WowVersion } from '@wowarenalogs/parser';
+import fs from 'fs';
 import moment from 'moment';
+import path from 'path';
 
 import { ApolloContext, CombatQueryResult, ICombatDataStub, UserSubscriptionTier } from '../types';
 import { Constants } from '../utils/constants';
 import { getUserProfileAsync } from '../utils/getUserProfileAsync';
 
-const matchStubsCollection = process.env.NODE_ENV === 'development' ? 'match-stubs-dev' : 'match-stubs-prod';
-const matchAnonStubsCollection =
-  process.env.NODE_ENV === 'development' ? 'match-anon-stubs-dev' : 'match-anon-stubs-prod';
+const matchStubsCollection = 'match-stubs-prod';
+const matchAnonStubsCollection = 'match-anon-stubs-prod';
 
-const firestore = new Firestore();
+const firestore = new Firestore({
+  credentials:
+    process.env.NODE_ENV === 'development'
+      ? JSON.parse(fs.readFileSync(path.join(process.cwd(), '../cloud/wowarenalogs-public-dev.json'), 'utf8'))
+      : undefined,
+});
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function firestoreDocToMatchStub(stub: ICombatDataStub): ICombatDataStub {

--- a/packages/shared/src/graphql-server/utils/getUserProfileAsync.ts
+++ b/packages/shared/src/graphql-server/utils/getUserProfileAsync.ts
@@ -1,10 +1,17 @@
 import { Firestore } from '@google-cloud/firestore';
+import fs from 'fs';
+import path from 'path';
 
 import { ApolloContext, User, UserSubscriptionTier } from '../types';
 
 const userProfileCollection = process.env.NODE_ENV === 'development' ? 'user-profile-dev' : 'user-profile-prod';
 
-const firestore = new Firestore();
+const firestore = new Firestore({
+  credentials:
+    process.env.NODE_ENV === 'development'
+      ? JSON.parse(fs.readFileSync(path.join(process.cwd(), '../cloud/wowarenalogs-public-dev.json'), 'utf8'))
+      : undefined,
+});
 
 export async function getUserProfileAsync(context: ApolloContext): Promise<User | null> {
   if (context.user == null) {

--- a/packages/shared/src/graphql-server/utils/setUserReferrerAsync.ts
+++ b/packages/shared/src/graphql-server/utils/setUserReferrerAsync.ts
@@ -1,11 +1,18 @@
 import { Firestore } from '@google-cloud/firestore';
+import fs from 'fs';
+import path from 'path';
 
 import { ApolloContext, User } from '../types';
 import { getUserProfileAsync } from './getUserProfileAsync';
 
 const userProfileCollection = process.env.NODE_ENV === 'development' ? 'user-profile-dev' : 'user-profile-prod';
 
-const firestore = new Firestore();
+const firestore = new Firestore({
+  credentials:
+    process.env.NODE_ENV === 'development'
+      ? JSON.parse(fs.readFileSync(path.join(process.cwd(), '../cloud/wowarenalogs-public-dev.json'), 'utf8'))
+      : undefined,
+});
 
 export async function setUserReferrerAsync(context: ApolloContext, referrer: string | null): Promise<User | null> {
   if (context.user == null) {


### PR DESCRIPTION
doing a few things in this PR -
* we now consistently use a json file as GCP credential. one json file to rule them all.
* got rid of the different table/bucket names between dev vs prod, since we are separate them at GCP project level
* added instructions in README to help contributors get started