### PR TITLE
log match stats to google analytics

### DIFF
--- a/packages/desktop/components/DesktopLayout/index.tsx
+++ b/packages/desktop/components/DesktopLayout/index.tsx
@@ -80,9 +80,15 @@ export const DesktopLayout = !window.wowarenalogs
               window.wowarenalogs.links?.openExternalURL(url);
             }}
             showLoginModal={(authUrl, callback) => {
-              window.wowarenalogs.bnet?.login(getAbsoluteAuthUrl(authUrl), 'Login').then(() => {
-                callback();
-              });
+              window.wowarenalogs.bnet
+                ?.login(getAbsoluteAuthUrl(authUrl), 'Login')
+                .then(() => {
+                  callback();
+                })
+                .catch(() => {
+                  // catching this promise rejection is necessary to not crash the app.
+                  // but there's nothing we need to do here.
+                });
             }}
             saveWindowPosition={async () => {
               const pos = await window.wowarenalogs.win?.getWindowPosition();

--- a/packages/desktop/components/FirstTimeSetup/index.tsx
+++ b/packages/desktop/components/FirstTimeSetup/index.tsx
@@ -1,6 +1,6 @@
-import { LoadingScreen, useClientContext } from '@wowarenalogs/shared';
+import { LoadingScreen, logAnalyticsEvent, useClientContext } from '@wowarenalogs/shared';
 import { useRouter } from 'next/router';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { useAppConfig } from '../../hooks/AppConfigContext';
 
@@ -11,6 +11,12 @@ export const FirstTimeSetup = () => {
   const [acceptTos, setAcceptTos] = useState(true);
   const [launchAtStartup, setLaunchAtStartup] = useState(true);
   const router = useRouter();
+
+  useEffect(() => {
+    if (step === 0) {
+      logAnalyticsEvent('tutorial_begin');
+    }
+  }, [step]);
 
   if (isLoading) {
     return <LoadingScreen />;
@@ -102,6 +108,7 @@ export const FirstTimeSetup = () => {
                       tosAccepted: acceptTos,
                     };
                   });
+                  logAnalyticsEvent('tutorial_complete');
                   router.push('/latest');
                 }}
               >

--- a/packages/desktop/hooks/LocalCombatsContext/index.tsx
+++ b/packages/desktop/hooks/LocalCombatsContext/index.tsx
@@ -113,7 +113,7 @@ const logCombatAnalyticsAsync = async (combat: AtomicArenaCombat) => {
       ...commonProperties,
       name: p.name,
       rating: p.info?.personalRating ?? 0,
-      highestRating: p.info?.highestPvpTier ?? 0,
+      highestPvpTier: p.info?.highestPvpTier ?? 0,
       spec: p.spec,
       teamId: p.info?.teamId ?? '',
       result: p.info?.teamId === combat.winningTeamId ? 'win' : 'lose',

--- a/packages/desktop/hooks/LocalCombatsContext/index.tsx
+++ b/packages/desktop/hooks/LocalCombatsContext/index.tsx
@@ -70,6 +70,7 @@ const logCombatAnalyticsAsync = async (combat: AtomicArenaCombat) => {
     zoneId: combat.startInfo.zoneId,
     durationInSeconds: combat.durationInSeconds,
     averageMMR,
+    playerResult: combat.result,
     playerId: combat.playerId,
     playerTeamId: combat.playerTeamId,
     winningTeamId: combat.winningTeamId,
@@ -104,7 +105,7 @@ const logCombatAnalyticsAsync = async (combat: AtomicArenaCombat) => {
   logAnalyticsEvent('event_NewCompRecord', {
     ...commonProperties,
     specs: combat.winningTeamId === '1' ? team0specs : team1specs,
-    teamId: combat.winningTeamId === '0' ? '0' : '1',
+    teamId: combat.winningTeamId === '1' ? '0' : '1',
     result: 'lose',
   });
 

--- a/packages/desktop/hooks/LocalCombatsContext/index.tsx
+++ b/packages/desktop/hooks/LocalCombatsContext/index.tsx
@@ -134,8 +134,11 @@ export const LocalCombatsContextProvider = (props: IProps) => {
 
       window.wowarenalogs.logs?.handleNewCombat((_event, combat) => {
         if (wowVersion === combat.wowVersion) {
-          uploadCombatAsync(combat, auth.battlenetId);
-          logCombatAnalyticsAsync(combat);
+          uploadCombatAsync(combat, auth.battlenetId).then((r) => {
+            if (!r.matchExists) {
+              logCombatAnalyticsAsync(combat);
+            }
+          });
 
           setCombats((prev) => {
             return prev.concat([combat]);
@@ -145,7 +148,6 @@ export const LocalCombatsContextProvider = (props: IProps) => {
 
       window.wowarenalogs.logs?.handleSoloShuffleRoundEnded((_event, combat) => {
         if (wowVersion === combat.wowVersion) {
-          logCombatAnalyticsAsync(combat);
           setCombats((prev) => {
             return prev.concat([combat]);
           });
@@ -154,7 +156,13 @@ export const LocalCombatsContextProvider = (props: IProps) => {
 
       window.wowarenalogs.logs?.handleSoloShuffleEnded((_event, combat) => {
         if (wowVersion === combat.wowVersion) {
-          uploadCombatAsync(combat, auth.battlenetId);
+          uploadCombatAsync(combat, auth.battlenetId).then((r) => {
+            if (!r.matchExists) {
+              combat.rounds.forEach((round) => {
+                logCombatAnalyticsAsync(round);
+              });
+            }
+          });
         }
       });
 

--- a/packages/desktop/hooks/LocalCombatsContext/index.tsx
+++ b/packages/desktop/hooks/LocalCombatsContext/index.tsx
@@ -1,14 +1,14 @@
-import { IArenaMatch, IShuffleRound } from '@wowarenalogs/parser';
+import { AtomicArenaCombat, buildQueryHelpers, CombatUnitSpec, CombatUnitType } from '@wowarenalogs/parser';
 import { logAnalyticsEvent, uploadCombatAsync, useAuth } from '@wowarenalogs/shared';
+import _ from 'lodash';
+import moment from 'moment';
 import React, { useContext, useEffect, useState } from 'react';
 
 import { useAppConfig } from '../AppConfigContext';
 
-type ParserCombatData = IArenaMatch | IShuffleRound;
-
 interface ILocalCombatsContextData {
-  localCombats: ParserCombatData[];
-  appendCombat: (combat: ParserCombatData) => void;
+  localCombats: AtomicArenaCombat[];
+  appendCombat: (combat: AtomicArenaCombat) => void;
 }
 
 const LocalCombatsContext = React.createContext<ILocalCombatsContextData>({
@@ -22,8 +22,85 @@ interface IProps {
   children: React.ReactNode | React.ReactNode[];
 }
 
+const logCombatAnalyticsAsync = async (combat: AtomicArenaCombat) => {
+  // const isPackaged = await window.wowarenalogs.app?.getIsPackaged();
+  // if (!isPackaged) {
+  //   return;
+  // }
+
+  const averageMMR =
+    combat.dataType === 'ArenaMatch'
+      ? ((combat.endInfo?.team0MMR || 0) + (combat.endInfo?.team1MMR || 0)) / 2
+      : ((combat.shuffleMatchEndInfo?.team0MMR || 0) + (combat.shuffleMatchEndInfo?.team1MMR || 0)) / 2;
+  const unitsList = _.values(combat.units).map((c) => ({
+    id: c.id,
+    name: c.name,
+    info: c.info,
+    type: c.type,
+    class: c.class,
+    spec: c.spec,
+    reaction: c.reaction,
+  }));
+  const players = unitsList.filter((u) => u.type === CombatUnitType.Player);
+  const team0specs = players
+    .filter((u) => u.info?.teamId === '0')
+    .map((u) => (u.spec === CombatUnitSpec.None ? `c${u.class}` : u.spec))
+    .sort()
+    .join('_');
+  const team1specs = players
+    .filter((u) => u.info?.teamId === '1')
+    .map((u) => (u.spec === CombatUnitSpec.None ? `c${u.class}` : u.spec))
+    .sort()
+    .join('_');
+  const indices = buildQueryHelpers(combat, true);
+
+  const commonProperties = {
+    wowVersion: combat.wowVersion,
+    combatId: combat.id,
+    date: moment(combat.startTime).format('YYYY-MM-DD'),
+    bracket: combat.startInfo.bracket,
+    zoneId: combat.startInfo.zoneId,
+    durationInSeconds: combat.durationInSeconds,
+    averageMMR,
+  };
+
+  // google analytics limitations:
+  // - event names can be up to 40 characters long
+  // - property names must be 40 characters or less
+  // - property values must be 100 characters or less
+  // - less than 25 properties
+  logAnalyticsEvent('event_NewMatchProcessed', {
+    ...commonProperties,
+    winningTeamSpecs: combat.winningTeamId === '0' ? team0specs : team1specs,
+    losingTeamSpecs: combat.winningTeamId === '1' ? team0specs : team1specs,
+    singleSidedSpecIndices: `|${indices.singleSidedSpecs.join('|')}|`,
+  });
+
+  logAnalyticsEvent('event_NewCompRecord', {
+    ...commonProperties,
+    specs: combat.winningTeamId === '0' ? team0specs : team1specs,
+    result: 'win',
+  });
+  logAnalyticsEvent('event_NewCompRecord', {
+    ...commonProperties,
+    specs: combat.winningTeamId === '1' ? team0specs : team1specs,
+    result: 'lose',
+  });
+
+  players.forEach((p) => {
+    logAnalyticsEvent('event_NewPlayerRecord', {
+      ...commonProperties,
+      name: p.name,
+      rating: p.info?.personalRating ?? 0,
+      highestRating: p.info?.highestPvpTier ?? 0,
+      spec: p.spec,
+      result: p.info?.teamId === combat.winningTeamId ? 'win' : 'lose',
+    });
+  });
+};
+
 export const LocalCombatsContextProvider = (props: IProps) => {
-  const [combats, setCombats] = useState<ParserCombatData[]>([]);
+  const [combats, setCombats] = useState<AtomicArenaCombat[]>([]);
   const auth = useAuth();
   const { wowInstallations } = useAppConfig();
 
@@ -33,25 +110,19 @@ export const LocalCombatsContextProvider = (props: IProps) => {
       window.wowarenalogs.logs?.startLogWatcher(wowDirectory, wowVersion);
 
       window.wowarenalogs.logs?.handleNewCombat((_event, combat) => {
-        if (
-          window.wowarenalogs.app?.getIsPackaged().then((isPackaged) => {
-            if (isPackaged) {
-              logAnalyticsEvent('event_NewMatchProcessed', {
-                wowVersion: combat.wowVersion,
-              });
-            }
-          })
-        )
-          if (wowVersion === combat.wowVersion) {
-            uploadCombatAsync(combat, auth.battlenetId);
-            setCombats((prev) => {
-              return prev.concat([combat]);
-            });
-          }
+        if (wowVersion === combat.wowVersion) {
+          uploadCombatAsync(combat, auth.battlenetId);
+          logCombatAnalyticsAsync(combat);
+
+          setCombats((prev) => {
+            return prev.concat([combat]);
+          });
+        }
       });
 
       window.wowarenalogs.logs?.handleSoloShuffleRoundEnded((_event, combat) => {
         if (wowVersion === combat.wowVersion) {
+          logCombatAnalyticsAsync(combat);
           setCombats((prev) => {
             return prev.concat([combat]);
           });

--- a/packages/desktop/pages/search.tsx
+++ b/packages/desktop/pages/search.tsx
@@ -1,11 +1,11 @@
 import { CombatUnitSpec } from '@wowarenalogs/parser';
-import { BracketSelector, CombatStubList, RatingSelector, SpecSelector } from '@wowarenalogs/shared';
+import { BracketSelector, CombatStubList, logAnalyticsEvent, RatingSelector, SpecSelector } from '@wowarenalogs/shared';
 import { LocalRemoteHybridCombat } from '@wowarenalogs/shared/src/components/CombatStubList/rows';
 import { QuerryError } from '@wowarenalogs/shared/src/components/common/QueryError';
 import { useGetPublicMatchesQuery } from '@wowarenalogs/shared/src/graphql/__generated__/graphql';
 import _ from 'lodash';
 import { useRouter } from 'next/router';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { TbArrowBigUpLines, TbLoader, TbRocketOff } from 'react-icons/tb';
 
 const PAGE_SIZE = 50;
@@ -39,6 +39,15 @@ const Page = () => {
     team1SpecIds: [],
     team2SpecIds: [],
   });
+
+  useEffect(() => {
+    // following predefined schema by google analytics convention.
+    // see https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtag#search
+    logAnalyticsEvent('search', {
+      search_term: filters.bracket,
+    });
+  }, [filters]);
+
   const compQueryString = computeCompQueryString(filters.team1SpecIds, filters.team2SpecIds);
   // const compQueryString = computeCompQueryString(filters.team1SpecIds, filters.team2SpecIds);
 

--- a/packages/parser/src/utils.ts
+++ b/packages/parser/src/utils.ts
@@ -1,10 +1,13 @@
+import _ from 'lodash';
 import md5 from 'md5';
 
+import { IArenaMatch, IShuffleRound } from './CombatData';
 import {
   CombatUnitAffiliation,
   CombatUnitClass,
   CombatUnitPowerType,
   CombatUnitReaction,
+  CombatUnitSpec,
   CombatUnitType,
 } from './types';
 
@@ -144,3 +147,137 @@ export const getPowerColor = (powerType: CombatUnitPowerType) => {
       return 'transparent';
   }
 };
+
+export interface SpecIndexFields {
+  singleSidedSpecs: string[];
+  doubleSidedSpecs: string[];
+  singleSidedSpecsWinners: string[];
+  doubleSidedSpecsWLHS: string[];
+}
+
+export interface MMRIndexFields {
+  matchAverageMMR: number;
+  gte1400: boolean;
+  gte1800: boolean;
+  gte2100: boolean;
+  gte2400: boolean;
+}
+
+function kCombinations<T>(set: T[], k: number): T[][] {
+  // https://gist.github.com/axelpale/3118596
+  let i, j, combs, head, tailcombs;
+  if (k > set.length || k <= 0) {
+    return [];
+  }
+  if (k === set.length) {
+    return [set];
+  }
+  if (k === 1) {
+    combs = [];
+    for (i = 0; i < set.length; i++) {
+      combs.push([set[i]]);
+    }
+    return combs;
+  }
+  combs = [];
+  for (i = 0; i < set.length - k + 1; i++) {
+    head = set.slice(i, i + 1);
+    tailcombs = kCombinations(set.slice(i + 1), k - 1);
+    for (j = 0; j < tailcombs.length; j++) {
+      combs.push(head.concat(tailcombs[j]));
+    }
+  }
+  return combs;
+}
+
+function allCombinations<T>(set: T[]): T[][] {
+  let combs: T[][] = [];
+  for (let i = 0; i < set.length; i++) {
+    combs = combs.concat(kCombinations(set, i + 1));
+  }
+  return combs;
+}
+
+export function buildMMRHelpers(com: IArenaMatch | IShuffleRound): MMRIndexFields {
+  const averageMMR =
+    com.dataType === 'ArenaMatch'
+      ? ((com.endInfo?.team0MMR || 0) + (com.endInfo?.team1MMR || 0)) / 2
+      : ((com.shuffleMatchEndInfo?.team0MMR || 0) + (com.shuffleMatchEndInfo?.team1MMR || 0)) / 2;
+  return {
+    matchAverageMMR: averageMMR,
+    gte1400: nullthrows(averageMMR) >= 1400,
+    gte1800: nullthrows(averageMMR) >= 1800,
+    gte2100: nullthrows(averageMMR) >= 2100,
+    gte2400: nullthrows(averageMMR) >= 2400,
+  };
+}
+
+export function buildQueryHelpers(
+  com: IArenaMatch | IShuffleRound,
+  excludePartialCombinations = false,
+): SpecIndexFields {
+  const unitsList = _.values(com.units).map((c) => ({
+    id: c.id,
+    name: c.name,
+    info: c.info,
+    type: c.type,
+    class: c.class,
+    spec: c.spec,
+    reaction: c.reaction,
+  }));
+  const team0specs = unitsList
+    .filter((u) => u.type === CombatUnitType.Player)
+    .filter((u) => u.info?.teamId === '0')
+    .map((u) => (u.spec === CombatUnitSpec.None ? `c${u.class}` : u.spec))
+    .sort();
+  const team1specs = unitsList
+    .filter((u) => u.type === CombatUnitType.Player)
+    .filter((u) => u.info?.teamId === '1')
+    .map((u) => (u.spec === CombatUnitSpec.None ? `c${u.class}` : u.spec))
+    .sort();
+  const team0sss = allCombinations(team0specs)
+    .map((s: string[]) => {
+      // this logic is designed for google analytics which has a limit of 100 total characters per property.
+      // so we had to reduce the number of combinations we send in the analytics event.
+      if (excludePartialCombinations && s.length !== 1 && s.length !== team0specs.length) {
+        return '';
+      }
+      return s.join('_');
+    })
+    .filter((s) => s !== '');
+  const team1sss = allCombinations(team1specs)
+    .map((s: string[]) => {
+      // this logic is designed for google analytics which has a limit of 100 total characters per property.
+      // so we had to reduce the number of combinations we send in the analytics event.
+      if (excludePartialCombinations && s.length !== 1 && s.length !== team1specs.length) {
+        return '';
+      }
+      return s.join('_');
+    })
+    .filter((s) => s !== '');
+  let singleSidedSpecsWinners = [];
+  if (com.winningTeamId === '0') {
+    singleSidedSpecsWinners = team0sss;
+  } else {
+    singleSidedSpecsWinners = team1sss;
+  }
+  const doubleSided = new Set<string>();
+  const doubleSidedWinnersLHS = new Set<string>();
+  for (const t0 of team0sss) {
+    for (const t1 of team1sss) {
+      doubleSided.add(`${t0}x${t1}`);
+      doubleSided.add(`${t1}x${t0}`);
+      if (com.winningTeamId === '0') {
+        doubleSidedWinnersLHS.add(`${t0}x${t1}`);
+      } else {
+        doubleSidedWinnersLHS.add(`${t1}x${t0}`);
+      }
+    }
+  }
+  return {
+    singleSidedSpecs: team0sss.concat(team1sss),
+    singleSidedSpecsWinners,
+    doubleSidedSpecs: Array.from(doubleSided),
+    doubleSidedSpecsWLHS: Array.from(doubleSidedWinnersLHS),
+  };
+}

--- a/packages/shared/src/api/combatUploadSignatureHandler.ts
+++ b/packages/shared/src/api/combatUploadSignatureHandler.ts
@@ -1,3 +1,4 @@
+import { Firestore } from '@google-cloud/firestore';
 import { GetSignedUrlConfig, Storage } from '@google-cloud/storage';
 import fs from 'fs';
 import _ from 'lodash';
@@ -7,58 +8,71 @@ import path from 'path';
 const isDev = process.env.NODE_ENV === 'development';
 
 const logFilesBucket = isDev ? 'wowarenalogs-public-dev-log-files-prod' : 'wowarenalogs-log-files-prod';
-
 const storage = new Storage({
   credentials:
     process.env.NODE_ENV === 'development'
       ? JSON.parse(fs.readFileSync(path.join(process.cwd(), '../cloud/wowarenalogs-public-dev.json'), 'utf8'))
       : undefined,
 });
-
 const bucket = storage.bucket(logFilesBucket);
 
-const extensionHeaders = {
-  'x-goog-meta-ownerid': '',
-  'x-goog-meta-wow-version': '',
-  'x-goog-meta-wow-patch-rev': '',
-  'x-goog-meta-starttime-utc': '',
-  'x-goog-meta-client-timezone': '',
-  'x-goog-meta-client-year': '',
+const matchStubsCollection = 'match-stubs-prod';
+const firestore = new Firestore({
+  credentials: isDev
+    ? JSON.parse(fs.readFileSync(path.join(process.cwd(), '../cloud/wowarenalogs-public-dev.json'), 'utf8'))
+    : undefined,
+});
+
+const matchExistsAsync = async (id: string) => {
+  const collectionReference = firestore.collection(matchStubsCollection);
+  const matchDocs = await collectionReference.where('id', '==', `${id}`).limit(1).get();
+  return !matchDocs.empty;
 };
 
-const signedUrlConfig: GetSignedUrlConfig = {
-  action: 'write',
-  expires: '03-01-2500',
-  contentType: 'text/plain;charset=UTF-8',
-  extensionHeaders,
-};
-
-export const combatUploadSignatureHandler = (request: NextApiRequest, response: NextApiResponse) => {
+export const combatUploadSignatureHandler = async (request: NextApiRequest, response: NextApiResponse) => {
   const { id } = request.query;
   const file = bucket.file(id as string);
 
-  if (request.method === 'GET') {
+  if (request.method !== 'GET') {
+    response.status(400).json({ error: 'Only GET requests are allowed.' });
+    return;
+  }
+
+  if (!request.headers) {
+    response.status(400).json({ error: 'x-goog-meta-ownerid header is required.' });
+    return;
+  }
+
+  const extensionHeaders = {
+    'x-goog-meta-ownerid': '',
+    'x-goog-meta-wow-version': '',
+    'x-goog-meta-wow-patch-rev': '',
+    'x-goog-meta-starttime-utc': '',
+    'x-goog-meta-client-timezone': '',
+    'x-goog-meta-client-year': '',
+  };
+  const signedUrlConfig: GetSignedUrlConfig = {
+    action: 'write',
+    expires: '03-01-2500',
+    contentType: 'text/plain;charset=UTF-8',
+    extensionHeaders,
+  };
+  _.keys(extensionHeaders).forEach((k) => {
     if (signedUrlConfig.extensionHeaders) {
-      _.keys(extensionHeaders).forEach((k) => {
-        if (signedUrlConfig.extensionHeaders) {
-          signedUrlConfig.extensionHeaders[k] = request.headers[k];
-        }
-      });
-    } else {
-      return response.status(400).json({ error: 'x-goog-meta-ownerid header is required.' });
+      signedUrlConfig.extensionHeaders[k] = request.headers[k];
     }
-    return new Promise((resolve) => {
-      file.getSignedUrl(signedUrlConfig, function (err, url) {
-        if (err) {
-          // eslint-disable-next-line no-console
-          console.log(err);
-          resolve(response.status(500).json({ error: 'An error has occurred' }));
-        } else {
-          resolve(response.status(200).json({ url, parsedName: id }));
-        }
-      });
-    });
-  } else {
-    return response.status(400).json({ error: 'Only GET requests are allowed.' });
+  });
+
+  try {
+    const [matchExists, result] = await Promise.all([
+      matchExistsAsync(id as string),
+      file.getSignedUrl(signedUrlConfig),
+    ]);
+    const url = result[0];
+    response.status(200).json({ url, id, matchExists });
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.log(err);
+    response.status(500).json({ error: 'An error has occurred' });
   }
 };

--- a/packages/shared/src/components/CombatReport/index.tsx
+++ b/packages/shared/src/components/CombatReport/index.tsx
@@ -1,9 +1,11 @@
 import { AtomicArenaCombat } from '@wowarenalogs/parser';
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
+import { useEffect } from 'react';
 import { TbChevronLeft } from 'react-icons/tb';
 
 import { useGetProfileQuery } from '../../graphql/__generated__/graphql';
+import { logAnalyticsEvent } from '../../utils/analytics';
 import { TimestampDisplay } from '../common/TimestampDisplay';
 import { CombatCurves } from './CombatCurves';
 import { CombatDeathReports } from './CombatDeathReports';
@@ -30,6 +32,17 @@ export const CombatReportInternal = () => {
   const router = useRouter();
   const { data: user } = useGetProfileQuery();
   const { combat, activeTab, setActiveTab } = useCombatReportContext();
+
+  useEffect(() => {
+    if (combat) {
+      // following predefined schema by google analytics convention.
+      // see https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtag#select_content
+      logAnalyticsEvent('select_content', {
+        content_type: combat.startInfo.bracket,
+        item_id: combat.id,
+      });
+    }
+  }, [combat]);
 
   if (!combat) return null;
 

--- a/packages/shared/src/hooks/AuthContext/index.tsx
+++ b/packages/shared/src/hooks/AuthContext/index.tsx
@@ -2,7 +2,12 @@ import { Session, User } from 'next-auth';
 import { signOut, useSession } from 'next-auth/react';
 import React, { useCallback, useContext, useEffect } from 'react';
 
-import { getAnalyticsDeviceId, getAnalyticsSessionId, setAnalyticsUserProperties } from '../../utils/analytics';
+import {
+  getAnalyticsDeviceId,
+  getAnalyticsSessionId,
+  logAnalyticsEvent,
+  setAnalyticsUserProperties,
+} from '../../utils/analytics';
 import { useClientContext } from '../ClientContext';
 
 interface WALUser extends User {
@@ -58,7 +63,12 @@ export const useAuth = () => {
   const clientContext = useClientContext();
 
   const signIn = useCallback(() => {
+    // following predefined schema by google analytics convention.
+    // see https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtag#login
     clientContext.showLoginModal('/login', () => {
+      logAnalyticsEvent('login', {
+        method: 'bnet',
+      });
       window.location.reload();
     });
   }, [clientContext]);

--- a/packages/shared/src/utils/upload.ts
+++ b/packages/shared/src/utils/upload.ts
@@ -27,12 +27,14 @@ export async function uploadCombatAsync(
   }
 
   const storageSignerResponse = await fetch(`/api/getCombatUploadSignature/${combat.id}`, { headers });
-  const jsonResponse = await storageSignerResponse.json();
+  const jsonResponse = (await storageSignerResponse.json()) as { id: string; url: string; matchExists: boolean };
   const signedUploadUrl = jsonResponse.url;
 
-  return fetch(signedUploadUrl, {
+  await fetch(signedUploadUrl, {
     method: 'PUT',
     body: buffer,
     headers,
   });
+
+  return jsonResponse;
 }


### PR DESCRIPTION
I think we can implement most of our stats features through google analytics reporting API once these events are in.

google analytics automatically batches events which is nice - 

en=event_NewMatchProcessed&_ee=1&ep.wowVersion=retail&ep.combatId=806f6f59e89c33c8a221f56e9d2175c4&ep.date=2022-12-22&ep.bracket=Rated%20Solo%20Shuffle&ep.zoneId=2547&epn.durationInSeconds=42.296&epn.averageMMR=0&ep.winningTeamSpecs=256_70_71&ep.losingTeamSpecs=1468_267_72&ep.singleSidedSpecIndices=%7C256%7C70%7C71%7C256_70_71%7C1468%7C267%7C72%7C1468_267_72%7C
en=event_NewCompRecord&_ee=1&ep.wowVersion=retail&ep.combatId=806f6f59e89c33c8a221f56e9d2175c4&ep.date=2022-12-22&ep.bracket=Rated%20Solo%20Shuffle&ep.zoneId=2547&epn.durationInSeconds=42.296&epn.averageMMR=0&ep.specs=256_70_71&ep.result=win
en=event_NewCompRecord&_ee=1&ep.wowVersion=retail&ep.combatId=806f6f59e89c33c8a221f56e9d2175c4&ep.date=2022-12-22&ep.bracket=Rated%20Solo%20Shuffle&ep.zoneId=2547&epn.durationInSeconds=42.296&epn.averageMMR=0&ep.specs=1468_267_72&ep.result=lose
en=event_NewPlayerRecord&_ee=1&ep.wowVersion=retail&ep.combatId=806f6f59e89c33c8a221f56e9d2175c4&ep.date=2022-12-22&ep.bracket=Rated%20Solo%20Shuffle&ep.zoneId=2547&epn.durationInSeconds=42.296&epn.averageMMR=0&ep.name=Enthaylia-Tichondrius&epn.rating=1090&epn.highestRating=311&ep.spec=267&ep.result=lose
en=event_NewPlayerRecord&_ee=1&ep.wowVersion=retail&ep.combatId=806f6f59e89c33c8a221f56e9d2175c4&ep.date=2022-12-22&ep.bracket=Rated%20Solo%20Shuffle&ep.zoneId=2547&epn.durationInSeconds=42.296&epn.averageMMR=0&ep.name=Rumtaz-Stormrage&epn.rating=1078&epn.highestRating=311&ep.spec=72&ep.result=lose
en=event_NewPlayerRecord&_ee=1&ep.wowVersion=retail&ep.combatId=806f6f59e89c33c8a221f56e9d2175c4&ep.date=2022-12-22&ep.bracket=Rated%20Solo%20Shuffle&ep.zoneId=2547&epn.durationInSeconds=42.296&epn.averageMMR=0&ep.name=Sherka-Quel'Thalas&epn.rating=1149&epn.highestRating=311&ep.spec=1468&ep.result=lose
en=event_NewPlayerRecord&_ee=1&ep.wowVersion=retail&ep.combatId=806f6f59e89c33c8a221f56e9d2175c4&ep.date=2022-12-22&ep.bracket=Rated%20Solo%20Shuffle&ep.zoneId=2547&epn.durationInSeconds=42.296&epn.averageMMR=0&ep.name=Tatsuu-Tichondrius&epn.rating=848&epn.highestRating=312&ep.spec=71&ep.result=win
en=event_NewPlayerRecord&_ee=1&ep.wowVersion=retail&ep.combatId=806f6f59e89c33c8a221f56e9d2175c4&ep.date=2022-12-22&ep.bracket=Rated%20Solo%20Shuffle&ep.zoneId=2547&epn.durationInSeconds=42.296&epn.averageMMR=0&ep.name=Slayrod-Vek'nilash&epn.rating=1100&epn.highestRating=311&ep.spec=70&ep.result=win
en=event_NewPlayerRecord&_ee=1&ep.wowVersion=retail&ep.combatId=806f6f59e89c33c8a221f56e9d2175c4&ep.date=2022-12-22&ep.bracket=Rated%20Solo%20Shuffle&ep.zoneId=2547&epn.durationInSeconds=42.296&epn.averageMMR=0&ep.name=Lodra-Illidan&epn.rating=1119&epn.highestRating=311&ep.spec=256&ep.result=win