### PR TITLE
use unoptimized images

### DIFF
--- a/packages/desktop/next.config.js
+++ b/packages/desktop/next.config.js
@@ -5,6 +5,7 @@ const nextConfig = {
   reactStrictMode: true,
   images: {
     domains: ['images.wowarenalogs.com'],
+    unoptimized: true,
   },
 };
 

--- a/packages/web/next.config.js
+++ b/packages/web/next.config.js
@@ -5,6 +5,7 @@ const nextConfig = {
   reactStrictMode: true,
   images: {
     domains: ['images.wowarenalogs.com'],
+    unoptimized: true,
   },
 };
 


### PR DESCRIPTION
next/image by default uses a middle tier end point to serve images which is significantly slowing down the performance. This will make it so that we hit CDN directly instead of going through the middle tier, because most of these images are just class/spec/spells which don't need much optimization (which mainly does resizing to save network bandwidth)