### PR TITLE
Experimental gcds only mode for replay events

### DIFF
--- a/packages/shared/src/components/CombatReport/CombatReplay/ReplayEvents/ReplayEventDisplay.tsx
+++ b/packages/shared/src/components/CombatReport/CombatReplay/ReplayEvents/ReplayEventDisplay.tsx
@@ -41,6 +41,8 @@ export const ReplayEventDisplay = React.memo(function ReplayEventDisplay(props: 
         return <ReplayUnitDiedEvent event={e} expanded={props.expanded} />;
       case LogEvent.SPELL_AURA_APPLIED:
         return <ReplayAuraAppliedEvent event={e} expanded={props.expanded} />;
+      case LogEvent.SPELL_CAST_SUCCESS:
+        return <ReplayAuraAppliedEvent event={e} expanded={props.expanded} />;
       case LogEvent.SPELL_AURA_REMOVED:
         return <ReplayAuraRemovedEvent event={e} expanded={props.expanded} />;
       case LogEvent.SPELL_AURA_APPLIED_DOSE:

--- a/packages/shared/src/components/CombatReport/CombatReplay/ReplayEvents/ReplayEventFilterDropdown.tsx
+++ b/packages/shared/src/components/CombatReport/CombatReplay/ReplayEvents/ReplayEventFilterDropdown.tsx
@@ -6,6 +6,7 @@ import { Dropdown } from '../../../common/Dropdown';
 export interface ReplayEventFilters {
   significantDamageHealOnly: boolean;
   significantAurasOnly: boolean;
+  gcdsOnly: boolean;
 }
 
 interface IProps {
@@ -59,6 +60,30 @@ export const ReplayEventFilterDropdown = React.memo(function ReplayEventFilterDr
                     props.setFilters({
                       ...props.filters,
                       significantAurasOnly: e.target.checked,
+                    });
+                  }}
+                />
+              </label>
+            </div>
+          ),
+          onClick: () => {
+            return;
+          },
+        },
+        {
+          key: 'gcdsOnly',
+          label: (
+            <div className="form-control">
+              <label className="label cursor-pointer">
+                <span className="label-text min-w-[150px]">GCDs Mode</span>
+                <input
+                  className="checkbox checkbox-sm"
+                  type="checkbox"
+                  checked={props.filters.gcdsOnly}
+                  onChange={(e) => {
+                    props.setFilters({
+                      ...props.filters,
+                      gcdsOnly: e.target.checked,
                     });
                   }}
                 />


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/15525519/210195845-d73e24f4-d97d-45f1-8b26-c884624c2421.png)

Option:
![image](https://user-images.githubusercontent.com/15525519/210195852-6b99bdfd-0a8a-45cb-aa82-1434f8c319f8.png)

After:
![image](https://user-images.githubusercontent.com/15525519/210195864-3cffb6dd-537f-44cc-a5ca-ac97cec025ee.png)

This mode changes the events log to only show casted spells -- effectively making it a display of how the caster used their GCDs. The standard log is fairly confusing due to the high number of procs/double effects like overload that pollute the list. It can be challenging to tell how a player is actually setting up their burst