### PR TITLE
reduce size of gear icons in player tab

### DIFF
--- a/packages/shared/src/components/CombatReport/CombatPlayers/CombatPlayer.tsx
+++ b/packages/shared/src/components/CombatReport/CombatPlayers/CombatPlayer.tsx
@@ -322,12 +322,12 @@ export function CombatPlayer(props: IProps) {
         <div className="flex flex-row mt-2">
           <div className="flex flex-col mr-4">
             {orderedEquipment.slice(0, orderedEquipmentHalfwayPoint).map((d) => (
-              <EquipmentInfo key={d.slot} item={d.item} />
+              <EquipmentInfo key={d.slot} item={d.item} size="medium" />
             ))}
           </div>
           <div className="flex flex-col">
             {orderedEquipment.slice(orderedEquipmentHalfwayPoint, 18).map((d) => (
-              <EquipmentInfo key={d.slot} item={d.item} />
+              <EquipmentInfo key={d.slot} item={d.item} size="medium" />
             ))}
           </div>
         </div>


### PR DESCRIPTION
the player tab is getting increasingly crowded. doing this to mitigate vertical space and medium size looks pretty good. at some point we might need tabbing there.

![image](https://user-images.githubusercontent.com/3233006/210213447-122cde40-0d46-446c-a537-6a217fc65f22.png)
