### PR TITLE
fix neutral unit showing as a player

### DIFF
--- a/packages/shared/src/components/CombatReport/CombatReportContext.tsx
+++ b/packages/shared/src/components/CombatReport/CombatReportContext.tsx
@@ -63,7 +63,11 @@ export const CombatReportContextProvider = (props: IProps) => {
     playerInterrupts,
   ] = useMemo(() => {
     const mPlayers = _.orderBy(
-      _.values(props.combat.units).filter((u) => u.type === CombatUnitType.Player),
+      _.values(props.combat.units).filter(
+        (u) =>
+          u.type === CombatUnitType.Player &&
+          (u.reaction === CombatUnitReaction.Friendly || u.reaction === CombatUnitReaction.Hostile),
+      ),
       ['reaction', 'name'],
       ['desc', 'asc'],
     );


### PR DESCRIPTION
there's a bug sometimes a neutral unit would show up as a player. 
![image](https://user-images.githubusercontent.com/3233006/210319212-46befac7-fb15-4f65-886a-29bd6f8832ae.png)

a deeper fix might need to happen in the parser but this would solve most of the visible problems