### PR TITLE
add dps, hps and kill target stats

### DIFF
--- a/packages/cloud/src/refreshCompetitiveStatsHandler.ts
+++ b/packages/cloud/src/refreshCompetitiveStatsHandler.ts
@@ -20,12 +20,23 @@ const storage = new GoogleCloudStorage({
 const bucket = storage.bucket(isDev ? 'data.public-dev.wowarenalogs.com' : 'data.wowarenalogs.com');
 
 const ALLOWED_BRACKETS = new Set<string>(['2v2', '3v3', 'Rated Solo Shuffle']);
-const STATS_SCHEMA_VERSION = 1;
+const STATS_SCHEMA_VERSION = 2;
 
 async function generateSpecStatsAsync() {
   console.log('generating spec stats...');
 
-  let resultObject: Record<string, unknown> = {};
+  let resultObject: {
+    [bracket: string]: {
+      [spec: string]: {
+        [result: string]: {
+          matches: number;
+          effectiveDps: number;
+          effectiveHps: number;
+          isKillTarget: number;
+        };
+      };
+    };
+  } = {};
 
   const [response] = await analytics.runReport({
     property: 'properties/259314484',
@@ -55,6 +66,12 @@ async function generateSpecStatsAsync() {
       },
       {
         name: 'averageCustomEvent:effectiveHps',
+      },
+      {
+        name: 'customEvent:isKillTarget',
+      },
+      {
+        name: 'countCustomEvent:isKillTarget',
       },
     ],
     dimensionFilter: {
@@ -107,6 +124,10 @@ async function generateSpecStatsAsync() {
       return;
     }
 
+    const killTargetSum = parseFloat(row.metricValues[3].value as string);
+    const killTargetCount = parseFloat(row.metricValues[4].value as string);
+    const isKillTargetAvg = (killTargetSum ? killTargetSum : 0) / (killTargetCount ? killTargetCount : 1);
+
     const newEntry = {
       [bracket]: {
         [spec]: {
@@ -114,6 +135,7 @@ async function generateSpecStatsAsync() {
             matches: parseInt(row.metricValues[0].value as string) ?? 0,
             effectiveDps: Math.abs(parseFloat(row.metricValues[1].value as string) ?? 0),
             effectiveHps: Math.abs(parseFloat(row.metricValues[2].value as string) ?? 0),
+            isKillTarget: isKillTargetAvg,
           },
         },
       },
@@ -135,9 +157,22 @@ async function generateSpecStatsAsync() {
 async function generateCompStatsAsync() {
   console.log('generating comp stats...');
 
-  let resultObject: Record<string, unknown> = {};
+  let resultObject: {
+    [bracket: string]: {
+      [specs: string]: {
+        [result: string]: {
+          matches: number;
+          effectiveDps: number;
+          effectiveHps: number;
+          killTargetSpec: {
+            [spec: string]: number;
+          };
+        };
+      };
+    };
+  } = {};
 
-  const [response] = await analytics.runReport({
+  const [baseResponse] = await analytics.runReport({
     property: 'properties/259314484',
     dateRanges: [
       {
@@ -159,6 +194,12 @@ async function generateCompStatsAsync() {
     metrics: [
       {
         name: 'eventCount',
+      },
+      {
+        name: 'averageCustomEvent:effectiveDps',
+      },
+      {
+        name: 'averageCustomEvent:effectiveHps',
       },
     ],
     dimensionFilter: {
@@ -198,7 +239,7 @@ async function generateCompStatsAsync() {
     },
   });
 
-  response.rows?.forEach((row) => {
+  baseResponse.rows?.forEach((row) => {
     if (!row.dimensionValues || !row.metricValues) {
       return;
     }
@@ -217,11 +258,123 @@ async function generateCompStatsAsync() {
     const newEntry = {
       [bracket]: {
         [specs]: {
-          [result]: parseInt(row.metricValues[0].value as string) ?? 0,
+          [result]: {
+            matches: parseInt(row.metricValues[0].value as string) ?? 0,
+            effectiveDps: Math.abs(parseFloat(row.metricValues[1].value as string) ?? 0),
+            effectiveHps: Math.abs(parseFloat(row.metricValues[2].value as string) ?? 0),
+          },
         },
       },
     };
     resultObject = _.merge(resultObject, newEntry);
+  });
+
+  const [killTargetResponse] = await analytics.runReport({
+    property: 'properties/259314484',
+    dateRanges: [
+      {
+        startDate: '8daysAgo',
+        endDate: 'yesterday',
+      },
+    ],
+    dimensions: [
+      {
+        name: 'customEvent:bracket',
+      },
+      {
+        name: 'customEvent:specs',
+      },
+      {
+        name: 'customEvent:result',
+      },
+      {
+        name: 'customEvent:killTargetSpec',
+      },
+    ],
+    metrics: [
+      {
+        name: 'eventCount',
+      },
+    ],
+    dimensionFilter: {
+      andGroup: {
+        expressions: [
+          {
+            filter: {
+              fieldName: 'eventName',
+              stringFilter: {
+                matchType: 'EXACT',
+                value: 'event_NewCompRecord',
+                caseSensitive: true,
+              },
+            },
+          },
+          {
+            filter: {
+              fieldName: 'customEvent:isPlayerTeam',
+              stringFilter: {
+                matchType: 'EXACT',
+                value: 'false',
+                caseSensitive: true,
+              },
+            },
+          },
+          {
+            filter: {
+              fieldName: 'customEvent:result',
+              stringFilter: {
+                matchType: 'EXACT',
+                value: 'lose', // only need to count the kill target spec for losses
+                caseSensitive: true,
+              },
+            },
+          },
+        ],
+      },
+    },
+  });
+
+  killTargetResponse.rows?.forEach((row) => {
+    if (!row.dimensionValues || !row.metricValues) {
+      return;
+    }
+
+    const bracket = row.dimensionValues[0].value as string;
+    const specs = row.dimensionValues[1].value as string;
+    const result = row.dimensionValues[2].value as string;
+    const killTargetSpec = row.dimensionValues[3].value as string;
+
+    if (!ALLOWED_BRACKETS.has(bracket)) {
+      return;
+    }
+    if (!specs.includes('_')) {
+      return;
+    }
+    if (!killTargetSpec || killTargetSpec === '(not set)') {
+      return;
+    }
+
+    const newEntry = {
+      [bracket]: {
+        [specs]: {
+          [result]: {
+            killTargetSpec: {
+              [killTargetSpec]: parseInt(row.metricValues[0].value as string) ?? 0,
+            },
+          },
+        },
+      },
+    };
+    resultObject = _.merge(resultObject, newEntry);
+  });
+
+  // delete specs that have less than 10 matches to optimize the size of the file
+  Object.values(resultObject).forEach((bracket) => {
+    Object.keys(bracket).forEach((specs) => {
+      if ((bracket[specs]['win']?.matches ?? 0) + (bracket[specs]['lose']?.matches ?? 0) < 10) {
+        delete bracket[specs];
+      }
+    });
   });
 
   const content = JSON.stringify(resultObject, null, 2);


### PR DESCRIPTION
for spec stats, added isKillTarget which is the likelihood of this spec being first blood

for comp stats, added effective dps, effective hps and the breakdown of kill target spec (which spec is most likely the kill target in each comp)

```json
"256_259": {
  "win": {
    "matches": 280,
    "effectiveDps": 39675.42065132331,
    "effectiveHps": 36396.11676413033
  },
  "lose": {
    "matches": 227,
    "effectiveDps": 30597.261271104755,
    "effectiveHps": 30607.103143766668,
    "killTargetSpec": {
      "256": 14,
      "259": 25
    }
  }
}
```