### PR TITLE
A simple system for looking up history by charname and realm

### DIFF
--- a/packages/shared/graphql.schema.json
+++ b/packages/shared/graphql.schema.json
@@ -934,6 +934,87 @@
         "description": null,
         "fields": [
           {
+            "name": "characterMatches",
+            "description": null,
+            "args": [
+              {
+                "name": "characterName",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "count",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": "50",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": "0",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "realm",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "CombatQueryResult",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "latestMatches",
             "description": null,
             "args": [

--- a/packages/shared/src/graphql-server/resolvers/index.ts
+++ b/packages/shared/src/graphql-server/resolvers/index.ts
@@ -1,4 +1,4 @@
-import { latestMatches, matchById, matchesWithCombatant, myMatches, userMatches } from './matches';
+import { characterMatches, latestMatches, matchById, matchesWithCombatant, myMatches, userMatches } from './matches';
 import { me, setUserReferrer } from './profile';
 
 export const resolvers = {
@@ -19,6 +19,7 @@ export const resolvers = {
     latestMatches,
     myMatches,
     userMatches,
+    characterMatches,
     matchesWithCombatant,
     matchById,
   },

--- a/packages/shared/src/graphql-server/resolvers/matches.ts
+++ b/packages/shared/src/graphql-server/resolvers/matches.ts
@@ -168,6 +168,25 @@ export async function userMatches(
   };
 }
 
+export async function characterMatches(
+  _parent: unknown,
+  args: { realm: string; characterName: string; offset: number; count: number },
+): Promise<CombatQueryResult> {
+  const collectionReference = firestore.collection(matchStubsCollection);
+  const matchDocs = await collectionReference
+    .where('combatantNames', 'array-contains', `${args.characterName}-${args.realm}`)
+    .orderBy('startTime', 'desc')
+    .offset(args.offset)
+    .limit(Math.min(args.count, Constants.MAX_RESULTS_PER_QUERY))
+    .get();
+  const matches = matchDocs.docs.map((d) => firestoreDocToMatchStub(d.data() as ICombatDataStub));
+
+  return {
+    combats: matches,
+    queryLimitReached: false,
+  };
+}
+
 export async function matchById(_parent: unknown, args: { matchId: string }) {
   const collection = matchStubsCollection;
   const collectionReference = firestore.collection(collection);

--- a/packages/shared/src/graphql-server/types/gql.ts
+++ b/packages/shared/src/graphql-server/types/gql.ts
@@ -112,6 +112,7 @@ export const typeDefs = gql`
     ): CombatQueryResult!
     myMatches(anonymousUserId: String = null, offset: Int! = 0, count: Int! = 50): CombatQueryResult!
     userMatches(userId: String!, offset: Int! = 0, count: Int! = 50): CombatQueryResult!
+    characterMatches(realm: String!, characterName: String!, offset: Int! = 0, count: Int! = 50): CombatQueryResult!
     matchesWithCombatant(playerName: String!): [CombatDataStub!]!
     matchById(matchId: String!, anon: Boolean!): CombatDataStub!
   }

--- a/packages/shared/src/graphql/__generated__/graphql.ts
+++ b/packages/shared/src/graphql/__generated__/graphql.ts
@@ -106,12 +106,21 @@ export type MutationSetUserReferrerArgs = {
 
 export type Query = {
   __typename?: 'Query';
+  characterMatches: CombatQueryResult;
   latestMatches: CombatQueryResult;
   matchById: CombatDataStub;
   matchesWithCombatant: Array<CombatDataStub>;
   me?: Maybe<IUser>;
   myMatches: CombatQueryResult;
   userMatches: CombatQueryResult;
+};
+
+
+export type QueryCharacterMatchesArgs = {
+  characterName: Scalars['String'];
+  count?: Scalars['Int'];
+  offset?: Scalars['Int'];
+  realm: Scalars['String'];
 };
 
 
@@ -231,6 +240,16 @@ export type GetUserMatchesQueryVariables = Exact<{
 
 
 export type GetUserMatchesQuery = { __typename?: 'Query', userMatches: { __typename?: 'CombatQueryResult', queryLimitReached: boolean, combats: Array<{ __typename?: 'ArenaMatchDataStub', id: string, wowVersion?: string | null, ownerId?: string | null, result: number, logObjectUrl: string, startTime: number, endTime: number, playerId?: string | null, playerTeamId: string, playerTeamRating: number, hasAdvancedLogging: boolean, durationInSeconds?: number | null, winningTeamId?: string | null, timezone?: string | null, units: Array<{ __typename?: 'CombatUnitStub', id: string, name: string, affiliation?: number | null, type: number, spec: string, class: number, reaction: number, info?: { __typename?: 'CombatantInfo', teamId: string, specId: string, pvpTalents: Array<string>, personalRating: number, highestPvpTier?: number | null, talents: Array<{ __typename?: 'Talent', id1?: number | null, id2?: number | null, count?: number | null } | null> } | null }>, startInfo?: { __typename?: 'ArenaMatchStartInfo', timestamp: number, zoneId: string, item1: string, bracket: string, isRanked: boolean } | null, endInfo?: { __typename?: 'ArenaMatchEndInfo', timestamp: number, winningTeamId: string, matchDurationInSeconds: number, team0MMR: number, team1MMR: number } | null } | { __typename?: 'ShuffleRoundStub', id: string, wowVersion?: string | null, ownerId?: string | null, result: number, logObjectUrl: string, startTime: number, endTime: number, playerId?: string | null, playerTeamId: string, playerTeamRating: number, hasAdvancedLogging: boolean, durationInSeconds?: number | null, winningTeamId?: string | null, killedUnitId: string, sequenceNumber: number, shuffleMatchResult?: number | null, shuffleMatchId?: string | null, timezone?: string | null, units: Array<{ __typename?: 'CombatUnitStub', id: string, name: string, affiliation?: number | null, type: number, spec: string, class: number, reaction: number, info?: { __typename?: 'CombatantInfo', teamId: string, specId: string, pvpTalents: Array<string>, personalRating: number, highestPvpTier?: number | null, talents: Array<{ __typename?: 'Talent', id1?: number | null, id2?: number | null, count?: number | null } | null> } | null }>, startInfo?: { __typename?: 'ArenaMatchStartInfo', timestamp: number, zoneId: string, item1: string, bracket: string, isRanked: boolean } | null, scoreboard?: Array<{ __typename?: 'ScoreboardEntry', unitId: string, wins: number } | null> | null, shuffleMatchEndInfo?: { __typename?: 'ArenaMatchEndInfo', timestamp: number, winningTeamId: string, matchDurationInSeconds: number, team0MMR: number, team1MMR: number } | null }> } };
+
+export type GetCharacterMatchesQueryVariables = Exact<{
+  realm: Scalars['String'];
+  characterName: Scalars['String'];
+  offset?: InputMaybe<Scalars['Int']>;
+  count?: InputMaybe<Scalars['Int']>;
+}>;
+
+
+export type GetCharacterMatchesQuery = { __typename?: 'Query', characterMatches: { __typename?: 'CombatQueryResult', queryLimitReached: boolean, combats: Array<{ __typename?: 'ArenaMatchDataStub', id: string, wowVersion?: string | null, ownerId?: string | null, result: number, logObjectUrl: string, startTime: number, endTime: number, playerId?: string | null, playerTeamId: string, playerTeamRating: number, hasAdvancedLogging: boolean, durationInSeconds?: number | null, winningTeamId?: string | null, timezone?: string | null, units: Array<{ __typename?: 'CombatUnitStub', id: string, name: string, affiliation?: number | null, type: number, spec: string, class: number, reaction: number, info?: { __typename?: 'CombatantInfo', teamId: string, specId: string, pvpTalents: Array<string>, personalRating: number, highestPvpTier?: number | null, talents: Array<{ __typename?: 'Talent', id1?: number | null, id2?: number | null, count?: number | null } | null> } | null }>, startInfo?: { __typename?: 'ArenaMatchStartInfo', timestamp: number, zoneId: string, item1: string, bracket: string, isRanked: boolean } | null, endInfo?: { __typename?: 'ArenaMatchEndInfo', timestamp: number, winningTeamId: string, matchDurationInSeconds: number, team0MMR: number, team1MMR: number } | null } | { __typename?: 'ShuffleRoundStub', id: string, wowVersion?: string | null, ownerId?: string | null, result: number, logObjectUrl: string, startTime: number, endTime: number, playerId?: string | null, playerTeamId: string, playerTeamRating: number, hasAdvancedLogging: boolean, durationInSeconds?: number | null, winningTeamId?: string | null, killedUnitId: string, sequenceNumber: number, shuffleMatchResult?: number | null, shuffleMatchId?: string | null, timezone?: string | null, units: Array<{ __typename?: 'CombatUnitStub', id: string, name: string, affiliation?: number | null, type: number, spec: string, class: number, reaction: number, info?: { __typename?: 'CombatantInfo', teamId: string, specId: string, pvpTalents: Array<string>, personalRating: number, highestPvpTier?: number | null, talents: Array<{ __typename?: 'Talent', id1?: number | null, id2?: number | null, count?: number | null } | null> } | null }>, startInfo?: { __typename?: 'ArenaMatchStartInfo', timestamp: number, zoneId: string, item1: string, bracket: string, isRanked: boolean } | null, scoreboard?: Array<{ __typename?: 'ScoreboardEntry', unitId: string, wins: number } | null> | null, shuffleMatchEndInfo?: { __typename?: 'ArenaMatchEndInfo', timestamp: number, winningTeamId: string, matchDurationInSeconds: number, team0MMR: number, team1MMR: number } | null }> } };
 
 export type GetMatchesWithCombatantQueryVariables = Exact<{
   playerName: Scalars['String'];
@@ -509,6 +528,54 @@ export function useGetUserMatchesLazyQuery(baseOptions?: Apollo.LazyQueryHookOpt
 export type GetUserMatchesQueryHookResult = ReturnType<typeof useGetUserMatchesQuery>;
 export type GetUserMatchesLazyQueryHookResult = ReturnType<typeof useGetUserMatchesLazyQuery>;
 export type GetUserMatchesQueryResult = Apollo.QueryResult<GetUserMatchesQuery, GetUserMatchesQueryVariables>;
+export const GetCharacterMatchesDocument = gql`
+    query GetCharacterMatches($realm: String!, $characterName: String!, $offset: Int = 0, $count: Int = 50) {
+  characterMatches(
+    realm: $realm
+    characterName: $characterName
+    offset: $offset
+    count: $count
+  ) {
+    combats {
+      ...arenaInfos
+      ...shuffleInfos
+    }
+    queryLimitReached
+  }
+}
+    ${ArenaInfosFragmentDoc}
+${ShuffleInfosFragmentDoc}`;
+
+/**
+ * __useGetCharacterMatchesQuery__
+ *
+ * To run a query within a React component, call `useGetCharacterMatchesQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetCharacterMatchesQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetCharacterMatchesQuery({
+ *   variables: {
+ *      realm: // value for 'realm'
+ *      characterName: // value for 'characterName'
+ *      offset: // value for 'offset'
+ *      count: // value for 'count'
+ *   },
+ * });
+ */
+export function useGetCharacterMatchesQuery(baseOptions: Apollo.QueryHookOptions<GetCharacterMatchesQuery, GetCharacterMatchesQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<GetCharacterMatchesQuery, GetCharacterMatchesQueryVariables>(GetCharacterMatchesDocument, options);
+      }
+export function useGetCharacterMatchesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetCharacterMatchesQuery, GetCharacterMatchesQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<GetCharacterMatchesQuery, GetCharacterMatchesQueryVariables>(GetCharacterMatchesDocument, options);
+        }
+export type GetCharacterMatchesQueryHookResult = ReturnType<typeof useGetCharacterMatchesQuery>;
+export type GetCharacterMatchesLazyQueryHookResult = ReturnType<typeof useGetCharacterMatchesLazyQuery>;
+export type GetCharacterMatchesQueryResult = Apollo.QueryResult<GetCharacterMatchesQuery, GetCharacterMatchesQueryVariables>;
 export const GetMatchesWithCombatantDocument = gql`
     query GetMatchesWithCombatant($playerName: String!) {
   matchesWithCombatant(playerName: $playerName) {

--- a/packages/shared/src/graphql/queries.graphql
+++ b/packages/shared/src/graphql/queries.graphql
@@ -142,6 +142,16 @@ query GetUserMatches($userId: String!, $offset: Int = 0, $count: Int = 50) {
   }
 }
 
+query GetCharacterMatches($realm: String!, $characterName: String!, $offset: Int = 0, $count: Int = 50) {
+  characterMatches(realm: $realm, characterName: $characterName, offset: $offset, count: $count) {
+    combats {
+      ...arenaInfos
+      ...shuffleInfos
+    }
+    queryLimitReached
+  }
+}
+
 query GetMatchesWithCombatant($playerName: String!) {
   matchesWithCombatant(playerName: $playerName) {
     ...arenaInfos

--- a/packages/web/pages/matches/character/[characterName].tsx
+++ b/packages/web/pages/matches/character/[characterName].tsx
@@ -1,0 +1,75 @@
+import { CombatStubList } from '@wowarenalogs/shared';
+import { LocalRemoteHybridCombat } from '@wowarenalogs/shared/src/components/CombatStubList/rows';
+import { LoadingPage } from '@wowarenalogs/shared/src/components/common/LoadingPage';
+import { QuerryError } from '@wowarenalogs/shared/src/components/common/QueryError';
+import { useGetCharacterMatchesLazyQuery } from '@wowarenalogs/shared/src/graphql/__generated__/graphql';
+import _ from 'lodash';
+import { useRouter } from 'next/router';
+import { useEffect } from 'react';
+import { TbLoader, TbRocketOff } from 'react-icons/tb';
+
+const Page = () => {
+  const router = useRouter();
+  const { realm, characterName } = router.query;
+
+  const [exec, matchesQuery] = useGetCharacterMatchesLazyQuery({
+    variables: {
+      realm: '',
+      characterName: '',
+    },
+  });
+
+  useEffect(() => {
+    if (characterName && typeof characterName === 'string') {
+      if (realm && typeof realm === 'string') {
+        exec({
+          variables: {
+            realm,
+            characterName,
+          },
+        });
+      }
+    }
+  }, [realm, characterName, exec]);
+
+  const isLoading = matchesQuery.loading || !router.isReady;
+
+  if (isLoading) {
+    return <LoadingPage />;
+  }
+
+  const remoteCombats = (matchesQuery.data?.characterMatches.combats || []).map((c) => ({
+    isLocal: false,
+    isShuffle: c.__typename === 'ShuffleRoundStub',
+    match: c,
+  })) as LocalRemoteHybridCombat[];
+
+  return (
+    <div className="transition-all p-2 overflow-y-auto">
+      <h2 className="text-2xl font-bold">
+        <span>
+          Match history for {characterName}-{realm}
+        </span>
+      </h2>
+      <div className="animate-fadein mt-2">
+        <CombatStubList viewerIsOwner={true} combats={remoteCombats} source="history" />
+      </div>
+      {matchesQuery.loading && (
+        <div className="flex flex-row items-center justify-center animate-loader h-[300px]">
+          <TbLoader color="gray" size={60} className="animate-spin-slow" />
+        </div>
+      )}
+      {matchesQuery.data?.characterMatches.combats.length === 0 && (
+        <div className="alert shadow-lg">
+          <div>
+            <TbRocketOff size={24} />
+            <span>No matches to display!</span>
+          </div>
+        </div>
+      )}
+      <QuerryError query={matchesQuery} />
+    </div>
+  );
+};
+
+export default Page;


### PR DESCRIPTION
-May contain same-name-same-realm-name entries for characters that exist in EU/US/etc realms. Factoring them out isn't simple right now because the region isn't recorded on the stub and the base data isn't in the log. We'd have to add a header to stitch it into metadata similar to timezone. Seems like a big lift for very little reward - the number of exact name/realm matches should be very very low

<img width="1396" alt="Screenshot 2023-01-15 at 2 32 28 PM" src="https://user-images.githubusercontent.com/15525519/212562963-62283b01-015e-481c-94fe-9f4fa1ac1b69.png">
