### PR TITLE
promote sign in on history page for unauthenticated users

### DIFF
--- a/packages/desktop/pages/history.tsx
+++ b/packages/desktop/pages/history.tsx
@@ -1,6 +1,7 @@
-import { CombatStubList } from '@wowarenalogs/shared';
+import { CombatStubList, LoadingScreen, useAuth } from '@wowarenalogs/shared';
 import { LocalRemoteHybridCombat } from '@wowarenalogs/shared/src/components/CombatStubList/rows';
 import { QuerryError } from '@wowarenalogs/shared/src/components/common/QueryError';
+import { SignInPromotion } from '@wowarenalogs/shared/src/components/common/SignInPromotion';
 import { useGetMyMatchesQuery } from '@wowarenalogs/shared/src/graphql/__generated__/graphql';
 import _ from 'lodash';
 import { useMemo } from 'react';
@@ -9,10 +10,15 @@ import { TbLoader } from 'react-icons/tb';
 import { useLocalCombats } from '../hooks/LocalCombatsContext';
 
 const Page = () => {
+  const { isLoadingAuthData, isAuthenticated } = useAuth();
   const { localCombats } = useLocalCombats();
   const matchesQuery = useGetMyMatchesQuery();
 
   const hybridCombats = useMemo(() => {
+    if (isLoadingAuthData) {
+      return [];
+    }
+
     const remoteCombats = matchesQuery.data?.myMatches?.combats || [];
     const remoteCombatIds = new Set(remoteCombats.map((c) => c.id));
 
@@ -36,7 +42,15 @@ const Page = () => {
       (c) => c.match.startTime,
       ['desc'],
     );
-  }, [localCombats, matchesQuery.data]);
+  }, [localCombats, matchesQuery.data, isLoadingAuthData]);
+
+  if (isLoadingAuthData) {
+    return <LoadingScreen />;
+  }
+
+  if (!isAuthenticated) {
+    return <SignInPromotion />;
+  }
 
   return (
     <div className="transition-all px-2 overflow-y-auto">

--- a/packages/shared/src/components/common/SignInPromotion.tsx
+++ b/packages/shared/src/components/common/SignInPromotion.tsx
@@ -1,0 +1,23 @@
+import { useAuth } from '../../hooks/AuthContext';
+
+export const SignInPromotion = () => {
+  const { signIn } = useAuth();
+  return (
+    <div className="w-full h-full flex flex-col items-center justify-center">
+      <div className="hero">
+        <div className="hero-content text-center flex flex-col pb-16">
+          <h1 className="text-5xl font-bold">Saving your matches</h1>
+          <p className="py-6">Signing in will allow WoW Arena Logs to save your match history.</p>
+          <button
+            className="btn btn-primary btn-wide"
+            onClick={() => {
+              signIn();
+            }}
+          >
+            Sign In
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/packages/shared/src/components/pages/ProfilePage.tsx
+++ b/packages/shared/src/components/pages/ProfilePage.tsx
@@ -1,16 +1,18 @@
 import { LoadingScreen, useAuth } from '@wowarenalogs/shared';
+import { useRouter } from 'next/router';
 
 import { LogoutButton } from '../common/LogoutButton';
 
 export const ProfilePage = () => {
   const auth = useAuth();
+  const router = useRouter();
 
   if (auth.isLoadingAuthData) {
     return <LoadingScreen />;
   }
 
   if (!auth.isAuthenticated) {
-    // the profile page should only be visible to authenticated users
+    router.push('/');
     return null;
   }
 

--- a/packages/web/pages/history.tsx
+++ b/packages/web/pages/history.tsx
@@ -1,15 +1,21 @@
-import { CombatStubList } from '@wowarenalogs/shared';
+import { CombatStubList, LoadingScreen, useAuth } from '@wowarenalogs/shared';
 import { LocalRemoteHybridCombat } from '@wowarenalogs/shared/src/components/CombatStubList/rows';
 import { QuerryError } from '@wowarenalogs/shared/src/components/common/QueryError';
+import { SignInPromotion } from '@wowarenalogs/shared/src/components/common/SignInPromotion';
 import { useGetMyMatchesQuery } from '@wowarenalogs/shared/src/graphql/__generated__/graphql';
 import _ from 'lodash';
 import { useMemo } from 'react';
 import { TbLoader } from 'react-icons/tb';
 
 const Page = () => {
+  const { isLoadingAuthData, isAuthenticated } = useAuth();
   const matchesQuery = useGetMyMatchesQuery();
 
   const hybridCombats = useMemo(() => {
+    if (isLoadingAuthData) {
+      return [];
+    }
+
     const remoteCombats = matchesQuery.data?.myMatches?.combats || [];
     return _.orderBy(
       remoteCombats.map((c) => ({
@@ -20,7 +26,15 @@ const Page = () => {
       (c) => c.match.startTime,
       ['desc'],
     );
-  }, [matchesQuery.data]);
+  }, [matchesQuery.data, isLoadingAuthData]);
+
+  if (isLoadingAuthData) {
+    return <LoadingScreen />;
+  }
+
+  if (!isAuthenticated) {
+    return <SignInPromotion />;
+  }
 
   return (
     <div className="transition-all px-2 overflow-y-auto">


### PR DESCRIPTION
currently the history page is completely empty for people who have not signed in. We've heard a few users complain it's confusing. This will show a sign in prompt. 

