### PR TITLE
hide insignificant auras on replay

### DIFF
--- a/packages/shared/src/data/spellTags.ts
+++ b/packages/shared/src/data/spellTags.ts
@@ -14,6 +14,8 @@ interface ISpellMetadata {
     | 'interrupts';
   duration?: number;
   priority?: boolean;
+  nounitFrames?: boolean;
+  nonameplates?: boolean;
 }
 
 const PRIORITY_MAP = {
@@ -36,5 +38,8 @@ export const ccSpellIds = new Set<string>(Object.keys(spells).filter((spellId) =
 export const trinketSpellIds = ['336126']; // TODO: Add adaptation spell id here
 
 export const spellIdToPriority = new Map<string, number>(
-  Object.keys(spells).map((spellId) => [spellId, PRIORITY_MAP[spells[spellId].type]]),
+  Object.keys(spells)
+    // exclude spells marked as "nounitFrames" or "nonameplates" which are basically insignificant
+    .filter((spellId) => !spells[spellId].nounitFrames && !spells[spellId].nonameplates)
+    .map((spellId) => [spellId, PRIORITY_MAP[spells[spellId].type]]),
 );


### PR DESCRIPTION
lots of insignificant buffs/debuffs are shown on the replay map view. bigdebuff provided a flag for us to exclude them so making use of it.