### PR TITLE
Update awc auras to track duration and add a just-casted state

### DIFF
--- a/packages/shared/src/components/CombatReport/CombatReplay/ReplayUnitFrames/UnitSpellTracker.tsx
+++ b/packages/shared/src/components/CombatReport/CombatReplay/ReplayUnitFrames/UnitSpellTracker.tsx
@@ -105,7 +105,6 @@ export const UnitSpellTracker = (props: IUnitFrameRenderData) => {
         const cooldownInfo = cdrInfo.cooldown;
         const spellMaxCharges = props.spellData[spellId]?.charges?.charges || 0;
         const shouldShowCharges = spellMaxCharges > 1;
-
         if (props.currentTimeOffset - (cdrInfo.lastCastTimestampOffset || -5000) < 500) {
           return (
             <SpellIcon
@@ -118,17 +117,6 @@ export const UnitSpellTracker = (props: IUnitFrameRenderData) => {
           );
         }
         if (activeAura) {
-          if (props.currentTimeOffset - activeAura.startTimeOffset < 500) {
-            return (
-              <SpellIcon
-                key={spellId}
-                charges={shouldShowCharges ? cooldownInfo.charges : undefined}
-                className={styles['unit-frame-auraicon-casting']}
-                size={24}
-                spellId={spellId}
-              />
-            );
-          }
           return (
             <SpellIcon
               key={spellId}

--- a/packages/shared/src/components/CombatReport/SpellIcon.tsx
+++ b/packages/shared/src/components/CombatReport/SpellIcon.tsx
@@ -56,7 +56,7 @@ export function SpellIcon(props: IProps) {
             style={{
               height: props.size,
               width: props.size,
-              top: props.cooldownPercent * props.size,
+              top: props.cooldownPercent * props.size - 8,
             }}
           />
         )}


### PR DESCRIPTION
Allow AWC icons to track full aura duration
Show icon as 'active' for 500ms after casting to let instant auras like medallion work well

Cooldown tracking overall is still not perfect, procs of stuff like Avatar can trick it