### PR TITLE
fix average stats

### DIFF
--- a/packages/cloud/src/refreshCompetitiveStatsHandler.ts
+++ b/packages/cloud/src/refreshCompetitiveStatsHandler.ts
@@ -44,7 +44,7 @@ async function generateSpecStatsAsync() {
     property: 'properties/259314484',
     dateRanges: [
       {
-        startDate: `${(LOOKBACK_DAYS + 1).toFixed()}daysAgo`,
+        startDate: `${LOOKBACK_DAYS.toFixed()}daysAgo`,
         endDate: 'yesterday',
       },
     ],
@@ -64,10 +64,10 @@ async function generateSpecStatsAsync() {
         name: 'eventCount',
       },
       {
-        name: 'averageCustomEvent:effectiveDps',
+        name: 'customEvent:effectiveDps',
       },
       {
-        name: 'averageCustomEvent:effectiveHps',
+        name: 'customEvent:effectiveHps',
       },
       {
         name: 'customEvent:isKillTarget',
@@ -76,7 +76,7 @@ async function generateSpecStatsAsync() {
         name: 'countCustomEvent:isKillTarget',
       },
       {
-        name: 'averageCustomEvent:burstDps',
+        name: 'customEvent:burstDps',
       },
     ],
     dimensionFilter: {
@@ -133,15 +133,25 @@ async function generateSpecStatsAsync() {
     const killTargetCount = parseFloat(row.metricValues[4].value as string);
     const isKillTargetAvg = (killTargetSum ? killTargetSum : 0) / (killTargetCount ? killTargetCount : 1);
 
+    const effectiveDps =
+      Math.abs(parseFloat(row.metricValues[1].value as string) ?? 0) /
+      (parseInt(row.metricValues[0].value as string) ?? 1);
+    const effectiveHps =
+      Math.abs(parseFloat(row.metricValues[2].value as string) ?? 0) /
+      (parseInt(row.metricValues[0].value as string) ?? 1);
+    const burstDps =
+      Math.abs(parseFloat(row.metricValues[5].value as string) ?? 0) /
+      (parseInt(row.metricValues[0].value as string) ?? 1);
+
     const newEntry = {
       [bracket]: {
         [spec]: {
           [result]: {
             matches: parseInt(row.metricValues[0].value as string) ?? 0,
-            effectiveDps: Math.abs(parseFloat(row.metricValues[1].value as string) ?? 0),
-            effectiveHps: Math.abs(parseFloat(row.metricValues[2].value as string) ?? 0),
+            effectiveDps,
+            effectiveHps,
             isKillTarget: isKillTargetAvg,
-            burstDps: Math.abs(parseFloat(row.metricValues[5].value as string) ?? 0),
+            burstDps,
           },
         },
       },
@@ -183,7 +193,7 @@ async function generateCompStatsAsync() {
     property: 'properties/259314484',
     dateRanges: [
       {
-        startDate: `${(LOOKBACK_DAYS + 1).toFixed()}daysAgo`,
+        startDate: `${LOOKBACK_DAYS.toFixed()}daysAgo`,
         endDate: 'yesterday',
       },
     ],
@@ -203,13 +213,13 @@ async function generateCompStatsAsync() {
         name: 'eventCount',
       },
       {
-        name: 'averageCustomEvent:effectiveDps',
+        name: 'customEvent:effectiveDps',
       },
       {
-        name: 'averageCustomEvent:effectiveHps',
+        name: 'customEvent:effectiveHps',
       },
       {
-        name: 'averageCustomEvent:burstDps',
+        name: 'customEvent:burstDps',
       },
     ],
     dimensionFilter: {
@@ -265,14 +275,24 @@ async function generateCompStatsAsync() {
       return;
     }
 
+    const effectiveDps =
+      Math.abs(parseFloat(row.metricValues[1].value as string) ?? 0) /
+      (parseInt(row.metricValues[0].value as string) ?? 1);
+    const effectiveHps =
+      Math.abs(parseFloat(row.metricValues[2].value as string) ?? 0) /
+      (parseInt(row.metricValues[0].value as string) ?? 1);
+    const burstDps =
+      Math.abs(parseFloat(row.metricValues[3].value as string) ?? 0) /
+      (parseInt(row.metricValues[0].value as string) ?? 1);
+
     const newEntry = {
       [bracket]: {
         [specs]: {
           [result]: {
             matches: parseInt(row.metricValues[0].value as string) ?? 0,
-            effectiveDps: Math.abs(parseFloat(row.metricValues[1].value as string) ?? 0),
-            effectiveHps: Math.abs(parseFloat(row.metricValues[2].value as string) ?? 0),
-            burstDps: Math.abs(parseFloat(row.metricValues[3].value as string) ?? 0),
+            effectiveDps,
+            effectiveHps,
+            burstDps,
           },
         },
       },
@@ -284,7 +304,7 @@ async function generateCompStatsAsync() {
     property: 'properties/259314484',
     dateRanges: [
       {
-        startDate: `${(LOOKBACK_DAYS + 1).toFixed()}daysAgo`,
+        startDate: `${LOOKBACK_DAYS.toFixed()}daysAgo`,
         endDate: 'yesterday',
       },
     ],


### PR DESCRIPTION
apparently, calculating average value through GA is very unreliable. calculating sum of the numerator and denominator separately is giving much more consistent results. 

pick ret paladin stats in 2s as example:

using average - 2023-01-25
```json
{
      "lose": {
        "matches": 1089,
        "effectiveDps": 20988.103974068003,
        "effectiveHps": 8823.23409059669,
        "isKillTarget": 0.6042240587695134,
        "burstDps": 133829.25570331683
      },
      "win": {
        "matches": 870,
        "effectiveDps": 33265.368247626626,
        "effectiveHps": 8894.698457811162,
        "isKillTarget": 0.01954022988505747,
        "burstDps": 164578.80550756268
      }
    }
```

using average - 2023-02-01
```json
{
      "lose": {
        "matches": 662,
        "effectiveDps": 10658.13090955438,
        "effectiveHps": 4675.602709016615,
        "isKillTarget": 0.6148036253776435,
        "burstDps": 60860.62034241388
      },
      "win": {
        "matches": 576,
        "effectiveDps": 16659.782304331595,
        "effectiveHps": 4935.54340874479,
        "isKillTarget": 0.010416666666666666,
        "burstDps": 75321.22858797222
      }
    }
```

using sum - 2023-01-25
```json
{
      "lose": {
        "matches": 947,
        "effectiveDps": 10712.106916379089,
        "effectiveHps": 4509.656059531151,
        "isKillTarget": 0.5997888067581837,
        "burstDps": 65501.56423795142
      },
      "win": {
        "matches": 771,
        "effectiveDps": 16962.356367565502,
        "effectiveHps": 4639.042919632943,
        "isKillTarget": 0.019455252918287938,
        "burstDps": 81677.72200605187
      }
    }
```

using sum - 2023-02-01
```json
{
      "lose": {
        "matches": 643,
        "effectiveDps": 10485.08839804821,
        "effectiveHps": 4718.096039917574,
        "isKillTarget": 0.6220839813374806,
        "burstDps": 59714.981855886464
      },
      "win": {
        "matches": 583,
        "effectiveDps": 16219.926325771872,
        "effectiveHps": 4979.973542924528,
        "isKillTarget": 0.010291595197255575,
        "burstDps": 73809.85991995882
      }
    }
```