### PR TITLE
Look up owner of action to determine true color of damage tick

### DIFF
--- a/packages/shared/src/components/CombatReport/CombatUnitTimelineView/CombatUnitHpUpdate.tsx
+++ b/packages/shared/src/components/CombatReport/CombatUnitTimelineView/CombatUnitHpUpdate.tsx
@@ -28,7 +28,12 @@ interface IProps {
 export const CombatUnitHpUpdate = (props: IProps) => {
   const colorSourceUnitId =
     props.actionGroup.destUnitId === props.unit.id ? props.actionGroup.srcUnitId : props.actionGroup.destUnitId;
-  const colorSourceUnit = props.combat.units[colorSourceUnitId];
+
+  let colorSourceUnit = props.combat.units[colorSourceUnitId];
+  if (colorSourceUnit.ownerId !== '0') {
+    colorSourceUnit = props.combat.units[colorSourceUnit.ownerId];
+  }
+
   const colorSourceUnitClass = colorSourceUnit ? colorSourceUnit.class : CombatUnitClass.None;
   const totalEffectiveAmount = useMemo(
     () => _.sum(props.actionGroup.actions.map((a) => a.effectiveAmount)),


### PR DESCRIPTION
![before_c](https://github.com/wowarenalogs/wowarenalogs/assets/15525519/98612f8b-a148-424c-893e-357e192517f2)

after:
![after_c](https://github.com/wowarenalogs/wowarenalogs/assets/15525519/d1ecf009-8b89-46f0-b247-686fc2f49cd2)
