### PR TITLE
use data.wowarenalogs.com to query stats files

### DIFF
--- a/packages/shared/src/components/CompetitiveStats/CompStats.tsx
+++ b/packages/shared/src/components/CompetitiveStats/CompStats.tsx
@@ -39,7 +39,7 @@ export default function CompStats(props: { activeBracket: string; sortKey: strin
   const specStatsQuery = useQuery(
     ['competitive-stats', 'comp-stats'],
     async () => {
-      const result = await fetch(`https://images.wowarenalogs.com/data/comp-stats.v${STATS_SCHEMA_VERSION}.json`);
+      const result = await fetch(`https://data.wowarenalogs.com/data/comp-stats.v${STATS_SCHEMA_VERSION}.json`);
       return (await result.json()) as StatsData;
     },
     {

--- a/packages/shared/src/components/CompetitiveStats/SpecStats.tsx
+++ b/packages/shared/src/components/CompetitiveStats/SpecStats.tsx
@@ -29,7 +29,7 @@ export default function SpecStats(props: {
     ['competitive-stats', 'spec-stats', props.activeBracket, props.minRating, props.maxRating],
     async () => {
       const result = await fetch(
-        `https://images.wowarenalogs.com/data/spec-stats/${props.activeBracket}/${props.minRating}-${props.maxRating}/v${STATS_SCHEMA_VERSION}.latest.json`,
+        `https://data.wowarenalogs.com/data/spec-stats/${props.activeBracket}/${props.minRating}-${props.maxRating}/v${STATS_SCHEMA_VERSION}.latest.json`,
       );
       return (await result.json()) as SpecStatsData;
     },


### PR DESCRIPTION
data.wowarenalogs.com is done through cloudflare cdn without depending on load balancer on google cloud. next i'll swap out images.wowarenalogs.com as well, and then we can get rid of the google cloud networking cost. 