### PR TITLE
fix second-instance behavior

### DIFF
--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -7,6 +7,7 @@ import { nativeBridgeRegistry } from './nativeBridge/registry';
 
 import path = require('path');
 import { BASE_REMOTE_URL } from './constants';
+import { globalStates } from './nativeBridge/modules/common/globalStates';
 
 function createWindow() {
   const preloadScriptPath = path.join(__dirname, 'preload.bundle.js');
@@ -58,7 +59,9 @@ if (!isFirstInstance) {
 
     if (app.isPackaged) {
       autoUpdater.checkForUpdatesAndNotify().then((result) => {
-        if (result?.updateInfo.version !== app.getVersion()) {
+        if (result && result.updateInfo.version !== app.getVersion()) {
+          globalStates.isUpdateAvailable = true;
+
           dialog
             .showMessageBox(win, {
               type: 'question',

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -58,7 +58,7 @@ if (!isFirstInstance) {
 
     if (app.isPackaged) {
       autoUpdater.checkForUpdatesAndNotify().then((result) => {
-        if (result?.updateInfo.version === app.getVersion()) {
+        if (result?.updateInfo.version !== app.getVersion()) {
           dialog
             .showMessageBox(win, {
               type: 'question',

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow } from 'electron';
+import { app, BrowserWindow, dialog } from 'electron';
 import installExtension, { REACT_DEVELOPER_TOOLS } from 'electron-devtools-installer';
 import { autoUpdater } from 'electron-updater';
 import moment from 'moment';
@@ -44,16 +44,47 @@ function createWindow() {
   });
 
   nativeBridgeRegistry.startListeners(win);
+
+  return win;
 }
 
-app.on('ready', () => {
-  createWindow();
+const isFirstInstance = app.requestSingleInstanceLock();
 
-  if (app.isPackaged) {
-    autoUpdater.checkForUpdatesAndNotify();
-  }
-});
-
-app.on('window-all-closed', () => {
+if (!isFirstInstance) {
   app.quit();
-});
+} else {
+  app.on('ready', () => {
+    const win = createWindow();
+
+    if (app.isPackaged) {
+      autoUpdater.checkForUpdatesAndNotify().then((result) => {
+        if (result?.updateInfo.version === app.getVersion()) {
+          dialog
+            .showMessageBox(win, {
+              type: 'question',
+              buttons: ['Update Now', 'Skip'],
+              defaultId: 0,
+              title: 'Update Available',
+              message: 'A new version of the app is available. Would you like to update now?',
+            })
+            .then((response) => {
+              if (response.response === 0) {
+                autoUpdater.quitAndInstall();
+              }
+            });
+        }
+      });
+    }
+
+    app.on('second-instance', () => {
+      if (!win.isVisible()) {
+        win.show();
+      }
+      win.focus();
+    });
+  });
+
+  app.on('window-all-closed', () => {
+    app.quit();
+  });
+}

--- a/packages/app/src/nativeBridge/modules/applicationModule.ts
+++ b/packages/app/src/nativeBridge/modules/applicationModule.ts
@@ -1,6 +1,7 @@
 import { app, session } from 'electron';
 
 import { moduleFunction, NativeBridgeModule, nativeBridgeModule } from '../module';
+import { globalStates } from './common/globalStates';
 
 @nativeBridgeModule('app')
 export class ApplicationModule extends NativeBridgeModule {
@@ -28,6 +29,11 @@ export class ApplicationModule extends NativeBridgeModule {
   @moduleFunction()
   public async getVersion(_mainWindow: Electron.BrowserWindow) {
     return app.getVersion();
+  }
+
+  @moduleFunction()
+  public async isUpdateAvailable(_mainWindow: Electron.BrowserWindow) {
+    return globalStates.isUpdateAvailable;
   }
 
   @moduleFunction()

--- a/packages/app/src/nativeBridge/modules/common/globalStates.ts
+++ b/packages/app/src/nativeBridge/modules/common/globalStates.ts
@@ -1,3 +1,3 @@
-export const globalStates = { 
+export const globalStates = {
   isUpdateAvailable: false,
 };

--- a/packages/app/src/nativeBridge/modules/common/globalStates.ts
+++ b/packages/app/src/nativeBridge/modules/common/globalStates.ts
@@ -1,0 +1,3 @@
+export const globalStates = { 
+  isUpdateAvailable: false,
+};

--- a/packages/app/webpack.preload.config.js
+++ b/packages/app/webpack.preload.config.js
@@ -34,6 +34,7 @@ module.exports = {
     fallback: {
       assert: false,
       buffer: false,
+      child_process: false,
       console: false,
       constants: false,
       crypto: false,

--- a/packages/desktop/components/TitleBar/index.tsx
+++ b/packages/desktop/components/TitleBar/index.tsx
@@ -46,7 +46,8 @@ function TitleBar() {
           className="btn btn-ghost btn-square btn-sm"
           onClick={async () => {
             flushSync(() => {
-              if (window.wowarenalogs.win?.hideToSystemTray) {
+              // the condition below checks whether the app is on a recent enough version that supports system tray
+              if (window.wowarenalogs.win?.hideToSystemTray && window.wowarenalogs.app?.isUpdateAvailable) {
                 window.wowarenalogs.win.hideToSystemTray();
               } else {
                 window.wowarenalogs.app?.quit();

--- a/packages/shared/src/types/nativeBridge.ts
+++ b/packages/shared/src/types/nativeBridge.ts
@@ -36,6 +36,7 @@ export type INativeBridge = {
     setOpenAtLogin: (openAtLogin: boolean) => Promise<void>;
     getIsPackaged: () => Promise<boolean>;
     getVersion?: () => Promise<string>;
+    isUpdateAvailable?: () => Promise<boolean>;
     clearStorage?: () => Promise<void>;
   };
   links?: {


### PR DESCRIPTION
currently if you launch the app, minimize it to system tray, and try launching the app again, it will show a frozen window which looks broken. 

this PR makes is so that the second instance will terminate and the hidden window from the first app instance will show up.

another issue discovered here is that because of the previous minimize-to-system-tray behavior, now it's really hard to trigger app update. because people may forget to ever properly quit the app. so made another change to remind people of app update more explicitly. 

![image](https://github.com/wowarenalogs/wowarenalogs/assets/3233006/93d3bbd6-486a-444a-8534-67963d61b34d)
