### PR TITLE
Fix issue where local shuffle rounds caused an error

### DIFF
--- a/packages/shared/src/components/CombatStubList/rows.tsx
+++ b/packages/shared/src/components/CombatStubList/rows.tsx
@@ -83,7 +83,7 @@ export function ShuffleRoundRow({
   viewerIsOwner?: boolean;
   source: CombatStubListSource;
 }) {
-  const maybeShuffleId = !combat.isLocal ? combat.match?.shuffleMatchId : undefined;
+  const maybeShuffleId = combat.isLocal ? combat.match.id : combat.match?.shuffleMatchId;
   const round = combat.match;
   const roundTitle = `Round ${round.sequenceNumber + 1} ${round.result === CombatResult.Win ? 'win' : 'loss'}`;
 


### PR DESCRIPTION
Shuffle rounds that were still local ended up without ids which caused the match loader to fail

ref: https://discord.com/channels/797758027875876865/797759589591678987/1161649022122078228

