### PR TITLE
Fix check pvp link, rare bug with spell keys

### DIFF
--- a/packages/shared/src/components/CombatReport/CombatPlayers/CheckPvPLink.tsx
+++ b/packages/shared/src/components/CombatReport/CombatPlayers/CheckPvPLink.tsx
@@ -48,7 +48,7 @@ export function CheckPvPLink({ player }: IProps) {
         width={22}
         alt="check-pvp.fr Link"
         title="check-pvp.fr Link"
-        src={'https://check-tbc.fr/assets/images/logo-pvp.png'}
+        src={'https://check-pvp.fr/favicon.png'}
       />
       Check PvP
     </button>

--- a/packages/shared/src/components/CombatReport/CombatPlayers/CombatPlayer.tsx
+++ b/packages/shared/src/components/CombatReport/CombatPlayers/CombatPlayer.tsx
@@ -362,7 +362,7 @@ export function CombatPlayer(props: IProps) {
           </thead>
           <tbody>
             {damageDoneBySpells.map((d) => (
-              <tr key={d.id}>
+              <tr key={d.id + d.name}>
                 <td className="bg-base-200 flex flex-row items-center">
                   <SpellIcon spellId={d.id} size={24} />
                   <div className="ml-1">{d.name}</div>
@@ -384,7 +384,7 @@ export function CombatPlayer(props: IProps) {
               </th>
             </tr>
             {damageDoneByDest.map((d) => (
-              <tr key={d.id}>
+              <tr key={d.id + d.name}>
                 <td className="bg-base-200">
                   <CombatUnitName unit={combat.units[d.id]} navigateToPlayerView />
                 </td>
@@ -405,7 +405,7 @@ export function CombatPlayer(props: IProps) {
               </th>
             </tr>
             {healsDoneBySpells.map((d) => (
-              <tr key={d.id}>
+              <tr key={d.id + d.name}>
                 <td className="bg-base-200 flex flex-row items-center">
                   <SpellIcon spellId={d.id} size={24} />
                   <div className="ml-1">{d.name}</div>
@@ -427,7 +427,7 @@ export function CombatPlayer(props: IProps) {
               </th>
             </tr>
             {healsDoneByDest.map((d) => (
-              <tr key={d.id}>
+              <tr key={d.id + d.name}>
                 <td className="bg-base-200">
                   <CombatUnitName unit={combat.units[d.id]} navigateToPlayerView />
                 </td>


### PR DESCRIPTION
In rare cases pets could use abilities that had the same spell id which would cause a dupe-key warning from React
