### PR TITLE
Video UX v1

### DIFF
--- a/packages/shared/src/components/CombatReport/CombatVideo/index.module.css
+++ b/packages/shared/src/components/CombatReport/CombatVideo/index.module.css
@@ -1,0 +1,3 @@
+video.vodPlayer::-webkit-media-controls-panel {
+  background-image: linear-gradient(180deg, transparent, rgba(0, 0, 0, 0.1));
+}

--- a/packages/shared/src/components/CombatReport/CombatVideo/index.tsx
+++ b/packages/shared/src/components/CombatReport/CombatVideo/index.tsx
@@ -2,6 +2,7 @@ import { MouseEvent, useCallback, useEffect, useRef, useState } from 'react';
 
 import { ArenaMatchMetadata, INativeBridge, ShuffleMatchMetadata } from '../../..';
 import { useCombatReportContext } from '../CombatReportContext';
+import styles from './index.module.css';
 
 declare global {
   interface Window {
@@ -175,6 +176,7 @@ export const CombatVideo = () => {
         </div>
         <video
           controls
+          className={styles['vodPlayer']}
           id="video"
           ref={vidRef}
           // domain here looks weird but chrome will canonicalize the item in the string it thinks is the domain

--- a/packages/shared/src/components/CombatReport/CombatVideo/index.tsx
+++ b/packages/shared/src/components/CombatReport/CombatVideo/index.tsx
@@ -174,7 +174,7 @@ export const CombatVideo = () => {
           // which will lead to the b64 string losing its casing :(
           src={`vod://wowarenalogs/${btoa(videoInformation.videoPath)}`}
           style={{
-            maxHeight: 'calc(100vh - 240px)', // TODO: MIGHTFIX figure out how to contain video without allowing scrollbars here
+            maxHeight: 'calc(100vh - 200px)', // TODO: MIGHTFIX figure out how to contain video without allowing scrollbars here
           }}
         />
       </div>

--- a/packages/shared/src/components/CombatReport/CombatVideo/index.tsx
+++ b/packages/shared/src/components/CombatReport/CombatVideo/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { MouseEvent, useCallback, useEffect, useRef, useState } from 'react';
 
 import { ArenaMatchMetadata, INativeBridge, ShuffleMatchMetadata } from '../../..';
 import { useCombatReportContext } from '../CombatReportContext';
@@ -9,28 +9,28 @@ declare global {
   }
 }
 
-// TODO: What does this value represent? Where should we store it?
-// Downgraded this from MUSTFIX to just a todo. This will need more exploration.
-const MATCH_START_CORRECTION = 0;
-// I have observed correct values for this between 1 - 2.75s
-// it appears to be some discrepency between the combat log timestamps and system clock?
-
-function getMatchTimeoffsetSeconds(matchId: string, metadata: ArenaMatchMetadata | ShuffleMatchMetadata) {
+function getMatchTimeoffsetSeconds(
+  matchId: string,
+  metadata: ArenaMatchMetadata | ShuffleMatchMetadata,
+  compensationTimeSeconds: number,
+) {
   if (metadata.dataType == 'ShuffleMatchMetadata') {
     const roundOne = metadata.roundStarts.find((r) => r.sequenceNumber === 0);
     const roundInfo = metadata.roundStarts.find((r) => r.id === matchId);
-    if (!roundOne || !roundInfo) return;
+    if (!roundOne || !roundInfo) return 0;
     const roundTimeOffset = (roundInfo.startInfo.timestamp - roundOne.startInfo.timestamp) / 1000;
-    return roundTimeOffset + MATCH_START_CORRECTION;
+    return roundTimeOffset + compensationTimeSeconds;
   } else {
-    return MATCH_START_CORRECTION;
+    return compensationTimeSeconds;
   }
 }
 
 export const CombatVideo = () => {
+  const progressBar = useRef<HTMLProgressElement>(null);
   const { combat } = useCombatReportContext();
-  const [foundVodRef, setFoundVodRef] = useState<
-    { videoPath: string; metadata: ArenaMatchMetadata | ShuffleMatchMetadata } | undefined
+  const [videoInformation, setVideoInformation] = useState<
+    | { compensationTimeSeconds: number; videoPath: string; metadata: ArenaMatchMetadata | ShuffleMatchMetadata }
+    | undefined
   >();
   const [vodNotFound, setVodNotFound] = useState(false);
 
@@ -42,7 +42,7 @@ export const CombatVideo = () => {
           if (f.metadata?.dataType) {
             // Since we are casting the metadata into a type from decoded JSON, we are a little more careful
             // about checking a field to make sure it looks like it's the right type
-            setFoundVodRef(f);
+            setVideoInformation(f);
           } else {
             setVodNotFound(true);
           }
@@ -56,46 +56,140 @@ export const CombatVideo = () => {
 
   const vidRef = useRef<HTMLVideoElement>(null);
 
+  const videoMathReady =
+    combat?.id && videoInformation?.metadata && videoInformation.compensationTimeSeconds !== undefined;
+
+  const matchStartTime = videoMathReady
+    ? getMatchTimeoffsetSeconds(combat.id, videoInformation?.metadata, videoInformation?.compensationTimeSeconds || 0)
+    : 0;
+
+  // Set video playhead to start of round when it loads
   useEffect(() => {
     if (!combat) return;
-    if (!foundVodRef?.metadata) return;
+    if (!videoInformation?.metadata) return;
     if (!vidRef.current) return;
-    vidRef.current.currentTime = getMatchTimeoffsetSeconds(combat.id, foundVodRef.metadata) || MATCH_START_CORRECTION;
-  }, [combat, foundVodRef]);
+    vidRef.current.currentTime =
+      getMatchTimeoffsetSeconds(combat.id, videoInformation.metadata, videoInformation.compensationTimeSeconds || 0) ||
+      0;
+  }, [combat, videoInformation]);
+
+  const progressBarClick = useCallback(
+    (e: MouseEvent<HTMLProgressElement>) => {
+      if (!vidRef.current) return;
+      if (!progressBar.current) return;
+
+      const rect = progressBar.current.getBoundingClientRect();
+      const pos = (e.pageX - rect.left) / progressBar.current.clientWidth;
+      vidRef.current.currentTime = (combat?.durationInSeconds || 0) * pos + matchStartTime;
+    },
+    [combat?.durationInSeconds, matchStartTime],
+  );
+
+  const progressBarDrag = useCallback(
+    (e: MouseEvent<HTMLProgressElement>) => {
+      if (!vidRef.current) return;
+      if (!progressBar.current) return;
+      if (!(e.buttons === 1)) return;
+      const rect = progressBar.current.getBoundingClientRect();
+      const pos = (e.pageX - rect.left) / progressBar.current.clientWidth;
+      vidRef.current.currentTime = (combat?.durationInSeconds || 0) * pos + matchStartTime;
+    },
+    [combat?.durationInSeconds, matchStartTime],
+  );
+
+  useEffect(() => {
+    const controller = new AbortController();
+    const signal = controller.signal;
+    if (vidRef.current && progressBar.current) {
+      vidRef.current.addEventListener(
+        'timeupdate',
+        () => {
+          if (!progressBar.current) return;
+          if (!vidRef.current) return;
+          progressBar.current.setAttribute('max', `${combat?.durationInSeconds}` || '100');
+          progressBar.current.value = vidRef.current.currentTime - matchStartTime;
+        },
+        {
+          signal,
+        },
+      );
+    }
+
+    return () => {
+      controller.abort();
+    };
+  }, [combat?.durationInSeconds, matchStartTime, videoInformation]);
 
   if (vodNotFound) {
     return <div className="animate-fadein flex flex-col gap-2">No video found for this match!</div>;
   }
-  if (!combat || !foundVodRef) {
+  if (!combat || !videoInformation) {
     return null;
   }
 
   return (
     <div className="animate-fadein flex flex-col gap-2 flex-1 h-full">
-      <button
-        className="btn"
-        onClick={() => {
-          if (!vidRef.current) return;
-          if (!foundVodRef.metadata) return;
+      <div className="flex flex-row gap-2">
+        <div className="flex flex-col gap-2">
+          <button
+            className="btn"
+            onClick={() => {
+              if (!vidRef.current) return;
+              if (!videoInformation.metadata) return;
 
-          const offset = getMatchTimeoffsetSeconds(combat.id, foundVodRef.metadata);
-          vidRef.current.currentTime = offset || MATCH_START_CORRECTION;
-          vidRef.current.play();
-        }}
-      >
-        Play from start of round
-      </button>
-      <video
-        controls
-        id="video"
-        ref={vidRef}
-        // domain here looks weird but chrome will canonicalize the item in the string it thinks is the domain
-        // which will lead to the b64 string losing its casing :(
-        src={`vod://wowarenalogs/${btoa(foundVodRef.videoPath)}`}
-        style={{
-          maxHeight: 'calc(100vh - 200px)', // TODO: MIGHTFIX figure out how to contain video without allowing scrollbars here
-        }}
-      />
+              const offset = getMatchTimeoffsetSeconds(
+                combat.id,
+                videoInformation.metadata,
+                videoInformation.compensationTimeSeconds || 0,
+              );
+              vidRef.current.currentTime = offset || 0;
+              vidRef.current.play();
+            }}
+          >
+            Start
+          </button>
+          <button
+            className="btn"
+            onClick={() => {
+              if (!vidRef.current) return;
+              if (!videoInformation.metadata) return;
+
+              const offset = getMatchTimeoffsetSeconds(
+                combat.id,
+                videoInformation.metadata,
+                videoInformation.compensationTimeSeconds || 0,
+              );
+              vidRef.current.currentTime = combat.durationInSeconds + offset - 5 || 0;
+              vidRef.current.play();
+            }}
+          >
+            Final 5s
+          </button>
+        </div>
+        <video
+          controls
+          id="video"
+          ref={vidRef}
+          // domain here looks weird but chrome will canonicalize the item in the string it thinks is the domain
+          // which will lead to the b64 string losing its casing :(
+          src={`vod://wowarenalogs/${btoa(videoInformation.videoPath)}`}
+          style={{
+            maxHeight: 'calc(100vh - 240px)', // TODO: MIGHTFIX figure out how to contain video without allowing scrollbars here
+          }}
+        />
+      </div>
+      <div className="flex flex-row gap-2 items-center">
+        <progress
+          ref={progressBar}
+          onClick={progressBarClick}
+          onMouseMove={progressBarDrag}
+          className="w-full"
+          id="progress"
+          value="0"
+        >
+          <span id="progress-bar"></span>
+        </progress>
+      </div>
     </div>
   );
 };

--- a/packages/shared/src/components/CombatReport/CombatVideo/index.tsx
+++ b/packages/shared/src/components/CombatReport/CombatVideo/index.tsx
@@ -9,6 +9,16 @@ declare global {
   }
 }
 
+// TODO: Fix this typing.
+// Forgot to add a few extra fields that are always present in the native side to the response type.
+type FindVideoReturnShim =
+  | {
+      compensationTimeSeconds: number;
+      videoPath: string;
+      metadata: ArenaMatchMetadata | ShuffleMatchMetadata;
+    }
+  | undefined;
+
 function getMatchTimeoffsetSeconds(
   matchId: string,
   metadata: ArenaMatchMetadata | ShuffleMatchMetadata,
@@ -37,7 +47,10 @@ export const CombatVideo = () => {
   useEffect(() => {
     async function find() {
       if (window.wowarenalogs.obs?.findVideoForMatch && combat?.id) {
-        const f = await window.wowarenalogs.obs?.findVideoForMatch('D:\\Video', combat.id);
+        const f = (await window.wowarenalogs.obs?.findVideoForMatch(
+          'D:\\Video',
+          combat.id,
+        )) as unknown as FindVideoReturnShim;
         if (f) {
           if (f.metadata?.dataType) {
             // Since we are casting the metadata into a type from decoded JSON, we are a little more careful

--- a/packages/shared/src/components/CombatReport/index.tsx
+++ b/packages/shared/src/components/CombatReport/index.tsx
@@ -39,7 +39,7 @@ export const CombatReportInternal = ({ matchId, roundId }: { matchId: string; ro
   const clientContext = useClientContext();
   const router = useRouter();
   const { data: user } = useGetProfileQuery();
-  const { combat, activeTab, setActiveTab, activePlayerId } = useCombatReportContext();
+  const { combat, activeTab, setActiveTab, activePlayerId, viewerIsOwner } = useCombatReportContext();
 
   const [urlCopied, setUrlCopied] = useState(false);
   const reportUrl = useMemo(() => {
@@ -146,7 +146,7 @@ export const CombatReportInternal = ({ matchId, roundId }: { matchId: string; ro
             Scoreboard
           </a>
         )}
-        {clientContext.isDesktop && (
+        {clientContext.isDesktop && viewerIsOwner && (
           <a
             className={`tab ${activeTab === 'video' ? 'tab-active' : ''}`}
             onClick={() => {


### PR DESCRIPTION

![image](https://github.com/wowarenalogs/wowarenalogs/assets/15525519/76dd3035-660f-4d6d-8ddd-b940876cc6fd)


timestamp sync implemented from native side

buttons to restart round and skip to last 5 seconds

crude progress bar to show round overall time

controls still present in video to provide easier viewing if you already know all the hotkeys
