### PR TITLE
Simple encoding settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "wowarenalogs",
   "productName": "WoW Arena Logs",
   "license": "MIT",
-  "version": "4.6.6",
+  "version": "4.7.0",
   "description": "WoW Arena Logs",
   "author": "WoW Arena Logs",
   "homepage": ".",

--- a/packages/app/src/nativeBridge/modules/obsModule.ts
+++ b/packages/app/src/nativeBridge/modules/obsModule.ts
@@ -114,6 +114,11 @@ export class ObsModule extends NativeBridgeModule {
     return;
   }
 
+  @moduleFunction()
+  public async getEncoders(_mainWindow: BrowserWindow) {
+    return this.manager?.getAvailableEncoders();
+  }
+
   /**
    * A very hacky way to find if a match of a given id has a video file
    */

--- a/packages/app/src/preloadApi.ts
+++ b/packages/app/src/preloadApi.ts
@@ -81,6 +81,7 @@ export const modulesApi = {
     setConfig: (...args: any[]) => ipcRenderer.invoke('wowarenalogs:obs:setConfig', ...args),
     getAudioDevices: (...args: any[]) => ipcRenderer.invoke('wowarenalogs:obs:getAudioDevices', ...args),
     getRecorderStatus: (...args: any[]) => ipcRenderer.invoke('wowarenalogs:obs:getRecorderStatus', ...args),
+    getEncoders: (...args: any[]) => ipcRenderer.invoke('wowarenalogs:obs:getEncoders', ...args),
     findVideoForMatch: (...args: any[]) => ipcRenderer.invoke('wowarenalogs:obs:findVideoForMatch', ...args),
     recorderStatusUpdated: (callback: (event: IpcRendererEvent, ...args: any[]) => void) =>
       ipcRenderer.on('wowarenalogs:obs:recorderStatusUpdated', callback),

--- a/packages/app/src/windowApi.d.ts
+++ b/packages/app/src/windowApi.d.ts
@@ -80,6 +80,7 @@ export type NativeApi = {
     setConfig?: OmitFirstArg<ObsModule['setConfig']>;
     getAudioDevices?: OmitFirstArg<ObsModule['getAudioDevices']>;
     getRecorderStatus?: OmitFirstArg<ObsModule['getRecorderStatus']>;
+    getEncoders?: OmitFirstArg<ObsModule['getEncoders']>;
     findVideoForMatch?: OmitFirstArg<ObsModule['findVideoForMatch']>;
     recorderStatusUpdated?: (callback: AsEventFunction<ObsModule['recorderStatusUpdated']>) => void;
     removeAll_recorderStatusUpdated_listeners?: () => void;

--- a/packages/desktop/components/Settings/RecordingSettings.tsx
+++ b/packages/desktop/components/Settings/RecordingSettings.tsx
@@ -117,7 +117,7 @@ function PreviewVideoWindow() {
 const RecordingSettings = () => {
   const clientContext = useClientContext();
   const { appConfig, updateAppConfig } = useAppConfig();
-  const { recordingConfig, recordingStatus, recordingStatusError } = useVideoRecordingContext();
+  const { recordingConfig, recordingStatus, recordingStatusError, encoderOptions } = useVideoRecordingContext();
   const [outputAudioOptions, setOutputAudioOptions] = useState<IOBSDevice[]>([]);
 
   async function checkAudioDevices() {
@@ -288,6 +288,20 @@ const RecordingSettings = () => {
                     <span className="label-text">Capture cursor</span>
                   </label>
                 </div>
+                {window.wowarenalogs.obs?.getEncoders && (
+                  <Dropdown
+                    menuItems={encoderOptions.map((k) => ({
+                      onClick: () => {
+                        window.wowarenalogs.obs?.setConfig?.('obsRecEncoder', k);
+                      },
+                      key: k,
+                      label: k,
+                    }))}
+                  >
+                    <div>{recordingConfig?.obsRecEncoder ?? 'Select encoding method'}</div>
+                    <TbCaretDown size={20} />
+                  </Dropdown>
+                )}
               </div>
               <div className="flex flex-row-reverse gap-2">
                 <input

--- a/packages/parser/test/soloshuffle.test.ts
+++ b/packages/parser/test/soloshuffle.test.ts
@@ -30,9 +30,9 @@ describe('solo shuffle tests', () => {
       const firstRound = results.shuffleRounds[0];
       const lastRound = results.shuffleRounds[5];
 
-      expect(shuffle.startTime).toBe(1670981589259);
+      expect(shuffle.startTime).toBe(1702517589259);
       expect(shuffle.startTime).toBe(firstRound.startTime);
-      expect(shuffle.endTime).toBe(1670981983080);
+      expect(shuffle.endTime).toBe(1702517983080);
       expect(shuffle.endTime).toBe(lastRound.endTime);
       expect(shuffle.timezone).toBe('America/New_York');
 
@@ -77,8 +77,8 @@ describe('solo shuffle tests', () => {
       expect(round.killedUnitId).toBe('Player-3684-0DF0B4B2');
 
       expect(round.timezone).toBe('America/New_York');
-      expect(round.startTime).toBe(1670981589259);
-      expect(round.endTime).toBe(1670981624027);
+      expect(round.startTime).toBe(1702517589259);
+      expect(round.endTime).toBe(1702517624027);
       expect(round.hasAdvancedLogging).toBe(true);
       expect(round.playerTeamId).toBe('0');
       expect(round.playerTeamRating).toBe(0);


### PR DESCRIPTION
Allow users to edit encoding settings for OBS

Uses the lib obs query to get encoder options and then intersects that with the list of explicitly supported encoders to limit the user choices fairly conservatively. On my machine lib-obs exposes 9 options but some of them have lots of weird errors.