### PR TITLE
quick and dirty impl to get hidden feature flags

### DIFF
--- a/packages/desktop/components/DesktopLayout/index.tsx
+++ b/packages/desktop/components/DesktopLayout/index.tsx
@@ -33,7 +33,7 @@ export const DesktopLayout = !window.wowarenalogs
       return null;
     }
   : ({ Component, pageProps }: AppProps) => {
-      const { isLoading } = useAppConfig();
+      const { isLoading, appConfig } = useAppConfig();
 
       useEffect(() => {
         initAnalyticsAsync('G-Z6E8QS4ENW', '650475e4b06ebfb536489356d27b60f8').then(() => {
@@ -106,6 +106,7 @@ export const DesktopLayout = !window.wowarenalogs
                   // but there's nothing we need to do here.
                 });
             }}
+            localFlags={appConfig.flags || []}
           >
             <AuthProvider>
               <VideoRecordingContextProvider>

--- a/packages/desktop/components/LatestMatchMonitor/index.tsx
+++ b/packages/desktop/components/LatestMatchMonitor/index.tsx
@@ -1,4 +1,4 @@
-import { CombatReport } from '@wowarenalogs/shared';
+import { canUseFeature, CombatReport, features } from '@wowarenalogs/shared';
 import Link from 'next/link';
 
 import { useAppConfig } from '../../hooks/AppConfigContext';
@@ -22,6 +22,11 @@ export const LatestMatchMonitor = () => {
         <div className="hero-content text-center flex flex-col pb-16">
           <h1 className="text-5xl font-bold">Ready for battle</h1>
           <p className="py-6">Please keep WoW Arena Logs running. Your latest match will be reported here.</p>
+          {canUseFeature(features.skipUploads, undefined, appConfig.flags) && (
+            <div className="text-2xl font-bold text-red-400 badge badge-lg badge-error p-5">
+              Logs are NOT being automatically uploaded to WoW Arena Logs!
+            </div>
+          )}
           <button
             className="btn glass btn-wide"
             onClick={() => {
@@ -46,6 +51,7 @@ export const LatestMatchMonitor = () => {
           )}
         </div>
       </div>
+
       <input type="checkbox" id="toggle-troubleshooter" className="modal-toggle" />
       <label htmlFor="toggle-troubleshooter" className="modal">
         <label className="modal-box prose relative" htmlFor="">

--- a/packages/desktop/hooks/AppConfigContext/index.tsx
+++ b/packages/desktop/hooks/AppConfigContext/index.tsx
@@ -12,6 +12,7 @@ export interface IAppConfig {
   lastWindowHeight?: number;
   launchAtStartup?: boolean;
   enableVideoRecording?: boolean;
+  flags?: string[];
 }
 
 interface IAppConfigContextData {

--- a/packages/desktop/pages/settings.tsx
+++ b/packages/desktop/pages/settings.tsx
@@ -11,26 +11,23 @@ const Page = () => {
   const [appVersion, setAppVersion] = useState('');
   const [featureCode, setFeatureCode] = useState('');
 
-  const parseCode = useCallback(
-    (featureCode: string) => {
-      if (featureCode.startsWith('add:')) {
-        updateAppConfig((prev) => {
-          return {
-            ...prev,
-            flags: [featureCode.slice(4), ...(appConfig.flags || [])],
-          };
-        });
-      } else if (featureCode.startsWith('drop:')) {
-        updateAppConfig((prev) => {
-          return {
-            ...prev,
-            flags: (appConfig.flags || []).filter((a) => a !== featureCode.slice(5)),
-          };
-        });
-      }
-    },
-    [appConfig.flags, updateAppConfig],
-  );
+  const parseCode = useCallback(() => {
+    if (featureCode.startsWith('add:')) {
+      updateAppConfig((prev) => {
+        return {
+          ...prev,
+          flags: [featureCode.slice(4), ...(appConfig.flags || [])],
+        };
+      });
+    } else if (featureCode.startsWith('drop:')) {
+      updateAppConfig((prev) => {
+        return {
+          ...prev,
+          flags: (appConfig.flags || []).filter((a) => a !== featureCode.slice(5)),
+        };
+      });
+    }
+  }, [appConfig.flags, featureCode, updateAppConfig]);
 
   // Intentionally leaving console log here so I can debug some in prod
   // eslint-disable-next-line no-console

--- a/packages/desktop/pages/settings.tsx
+++ b/packages/desktop/pages/settings.tsx
@@ -137,7 +137,7 @@ const Page = () => {
         <button
           className="btn btn-sm gap-2"
           onClick={() => {
-            parseCode(featureCode);
+            parseCode();
           }}
         >
           Use feature code

--- a/packages/desktop/pages/settings.tsx
+++ b/packages/desktop/pages/settings.tsx
@@ -1,5 +1,5 @@
 import { LoadingScreen, useClientContext } from '@wowarenalogs/shared';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { FaDiscord, FaPatreon } from 'react-icons/fa';
 
 import RecordingSettings from '../components/Settings/RecordingSettings';
@@ -9,6 +9,32 @@ const Page = () => {
   const { isLoading, appConfig, updateAppConfig } = useAppConfig();
   const clientContext = useClientContext();
   const [appVersion, setAppVersion] = useState('');
+  const [featureCode, setFeatureCode] = useState('');
+
+  const parseCode = useCallback(
+    (featureCode: string) => {
+      if (featureCode.startsWith('add:')) {
+        updateAppConfig((prev) => {
+          return {
+            ...prev,
+            flags: [featureCode.slice(4), ...(appConfig.flags || [])],
+          };
+        });
+      } else if (featureCode.startsWith('drop:')) {
+        updateAppConfig((prev) => {
+          return {
+            ...prev,
+            flags: (appConfig.flags || []).filter((a) => a !== featureCode.slice(5)),
+          };
+        });
+      }
+    },
+    [appConfig.flags, updateAppConfig],
+  );
+
+  // Intentionally leaving console log here so I can debug some in prod
+  // eslint-disable-next-line no-console
+  console.log(appConfig.flags);
 
   useEffect(() => {
     if (window.wowarenalogs.app?.getVersion) {
@@ -102,6 +128,23 @@ const Page = () => {
             Set WoW Path
           </button>
         </div>
+      </div>
+      <div className="flex flex-row-reverse gap-2">
+        <input
+          type="text"
+          placeholder={`enter feature code here`}
+          className={`input input-sm input-bordered flex-1`}
+          value={featureCode}
+          onChange={(e) => setFeatureCode(e.target.value)}
+        />
+        <button
+          className="btn btn-sm gap-2"
+          onClick={() => {
+            parseCode(featureCode);
+          }}
+        >
+          Use feature code
+        </button>
       </div>
       <div className="divider" />
       {window.wowarenalogs.platform === 'win32' && window.wowarenalogs.obs && <RecordingSettings />}

--- a/packages/shared/src/components/CombatReport/index.tsx
+++ b/packages/shared/src/components/CombatReport/index.tsx
@@ -9,6 +9,7 @@ import { zoneMetadata } from '../../data/zoneMetadata';
 import { useGetProfileQuery } from '../../graphql/__generated__/graphql';
 import { useClientContext } from '../../hooks/ClientContext';
 import { logAnalyticsEvent } from '../../utils/analytics';
+import { canUseFeature } from '../../utils/featureFlags';
 import { DownloadPromotion } from '../common/DownloadPromotion';
 import { CombatCC } from './CombatCC';
 import { CombatCurves } from './CombatCurves';
@@ -156,7 +157,7 @@ export const CombatReportInternal = ({ matchId, roundId }: { matchId: string; ro
             Video
           </a>
         )}
-        {user?.me?.tags?.includes('rawlogs') && (
+        {canUseFeature('rawlogs', user, clientContext.localFlags) && (
           <a
             className={`tab ${activeTab === 'logview' ? 'tab-active' : ''}`}
             onClick={() => {

--- a/packages/shared/src/hooks/ClientContext/index.tsx
+++ b/packages/shared/src/hooks/ClientContext/index.tsx
@@ -4,6 +4,7 @@ interface IClientContextData {
   isDesktop: boolean;
   openExternalURL: (url: string) => void;
   showLoginModal: (authUrl: string, callback: () => void) => void;
+  localFlags: string[];
 }
 
 const ClientContext = React.createContext<IClientContextData>({
@@ -12,6 +13,7 @@ const ClientContext = React.createContext<IClientContextData>({
   showLoginModal: (_authUrl: string, callback: () => void) => {
     callback();
   },
+  localFlags: [],
 });
 
 interface IProps {
@@ -19,6 +21,7 @@ interface IProps {
   openExternalURL: (url: string) => void;
   showLoginModal: (authUrl: string, callback: () => void) => void;
   children: React.ReactNode | React.ReactNode[];
+  localFlags: string[];
 }
 
 export const ClientContextProvider = (props: IProps) => {
@@ -28,6 +31,7 @@ export const ClientContextProvider = (props: IProps) => {
         openExternalURL: props.openExternalURL,
         isDesktop: props.isDesktop,
         showLoginModal: props.showLoginModal,
+        localFlags: props.localFlags,
       }}
     >
       {props.children}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -5,6 +5,7 @@ export { ClientContextProvider, useClientContext } from './hooks/ClientContext';
 export { AuthProvider } from './hooks/AuthContext';
 export { useAuth } from './hooks/AuthContext';
 export { uploadCombatAsync } from './utils/upload';
+export { canUseFeature, features } from './utils/featureFlags';
 export {
   initAnalyticsAsync,
   logAnalyticsEvent,

--- a/packages/shared/src/utils/featureFlags.ts
+++ b/packages/shared/src/utils/featureFlags.ts
@@ -1,0 +1,15 @@
+import { GetProfileQuery } from '../graphql/__generated__/graphql';
+
+export const features = {
+  skipUploads: 'skip-log-uploads',
+};
+
+export const canUseFeature = (flag: string, user?: GetProfileQuery | undefined, localFlags?: string[]) => {
+  if (user && user?.me?.tags?.includes(flag)) {
+    return true;
+  }
+  if (localFlags && localFlags.includes(flag)) {
+    return true;
+  }
+  return false;
+};

--- a/packages/web/components/WebLayout/index.tsx
+++ b/packages/web/components/WebLayout/index.tsx
@@ -26,6 +26,7 @@ const Page = (props: { children: ReactNode | ReactNode[] }) => {
         showLoginModal={() => {
           signIn('battlenet');
         }}
+        localFlags={[]} // No local flags in web context
       >
         <MainLayout>
           <Head>


### PR DESCRIPTION
Flags exposed through clientContext which inherits locally-defined flags from appConfig; for web these are empty for now but in theory we could use cookies/localstorage to carry flags if needed

Simple cli-like utility to add/drop feature flags
Some consolidation of logic to use the remote flags on the user model in firebase as well

![image](https://github.com/wowarenalogs/wowarenalogs/assets/15525519/15d4e37d-de41-4586-a658-74a01cec15fa)
![image](https://github.com/wowarenalogs/wowarenalogs/assets/15525519/387c1acb-711c-44c9-9af2-799acfac947a)

