### PR TITLE
Disk warn

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wowarenalogs",
-  "version": "4.6.5",
+  "version": "4.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wowarenalogs",
-      "version": "4.6.5",
+      "version": "4.7.0",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
@@ -9908,6 +9908,14 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/check-disk-space": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/check-disk-space/-/check-disk-space-3.4.0.tgz",
+      "integrity": "sha512-drVkSqfwA+TvuEhFipiR1OC9boEGZL5RrWvVsOthdcvQNXyCCuKkEiTOTXZ7qxSf/GLwq4GvzfrQD/Wz325hgw==",
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/child-process-ext": {
@@ -27140,6 +27148,7 @@
         "@wowarenalogs/parser": "^5.2.0",
         "@wowarenalogs/recorder": "^1.0.0",
         "@wowarenalogs/shared": "^1.0.0",
+        "check-disk-space": "^3.4.0",
         "chokidar": "^3.5.3",
         "electron": "^27.0.2",
         "electron-devtools-installer": "^3.2.0",
@@ -33431,6 +33440,7 @@
         "@wowarenalogs/recorder": "^1.0.0",
         "@wowarenalogs/shared": "^1.0.0",
         "babel-loader": "^8.2.5",
+        "check-disk-space": "*",
         "chokidar": "^3.5.3",
         "electron": "^27.0.2",
         "electron-devtools-installer": "^3.2.0",
@@ -34082,7 +34092,7 @@
     "@wowarenalogs/shared": {
       "version": "file:packages/shared",
       "requires": {
-        "@amplitude/analytics-browser": "*",
+        "@amplitude/analytics-browser": "^2.3.3",
         "@apollo/client": "^3.6.9",
         "@google-cloud/firestore": "^5.0.2",
         "@google-cloud/storage": "^6.7.0",
@@ -35825,6 +35835,11 @@
     },
     "charenc": {
       "version": "0.0.2"
+    },
+    "check-disk-space": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/check-disk-space/-/check-disk-space-3.4.0.tgz",
+      "integrity": "sha512-drVkSqfwA+TvuEhFipiR1OC9boEGZL5RrWvVsOthdcvQNXyCCuKkEiTOTXZ7qxSf/GLwq4GvzfrQD/Wz325hgw=="
     },
     "child-process-ext": {
       "version": "2.1.1",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -29,6 +29,7 @@
     "@wowarenalogs/parser": "^5.2.0",
     "@wowarenalogs/recorder": "^1.0.0",
     "@wowarenalogs/shared": "^1.0.0",
+    "check-disk-space": "^3.4.0",
     "chokidar": "^3.5.3",
     "electron": "^27.0.2",
     "electron-devtools-installer": "^3.2.0",

--- a/packages/app/src/preloadApi.ts
+++ b/packages/app/src/preloadApi.ts
@@ -93,5 +93,9 @@ export const modulesApi = {
     videoRecorded: (callback: (event: IpcRendererEvent, ...args: any[]) => void) =>
       ipcRenderer.on('wowarenalogs:obs:videoRecorded', callback),
     removeAll_videoRecorded_listeners: () => ipcRenderer.removeAllListeners('wowarenalogs:obs:videoRecorded'),
+    diskSpaceBecameCritical: (callback: (event: IpcRendererEvent, ...args: any[]) => void) =>
+      ipcRenderer.on('wowarenalogs:obs:diskSpaceBecameCritical', callback),
+    removeAll_diskSpaceBecameCritical_listeners: () =>
+      ipcRenderer.removeAllListeners('wowarenalogs:obs:diskSpaceBecameCritical'),
   },
 };

--- a/packages/app/src/windowApi.d.ts
+++ b/packages/app/src/windowApi.d.ts
@@ -88,5 +88,7 @@ export type NativeApi = {
     removeAll_configUpdated_listeners?: () => void;
     videoRecorded?: (callback: AsEventFunction<ObsModule['videoRecorded']>) => void;
     removeAll_videoRecorded_listeners?: () => void;
+    diskSpaceBecameCritical?: (callback: AsEventFunction<ObsModule['diskSpaceBecameCritical']>) => void;
+    removeAll_diskSpaceBecameCritical_listeners?: () => void;
   };
 };

--- a/packages/desktop/components/LatestMatchMonitor/index.tsx
+++ b/packages/desktop/components/LatestMatchMonitor/index.tsx
@@ -37,7 +37,10 @@ export const LatestMatchMonitor = () => {
           {diskSpaceRemaining > -1 && (
             <div className="text-2xl font-bold text-red-400 badge badge-lg badge-error p-5">
               You have only {(diskSpaceRemaining / 1e6).toFixed(1)} Mbytes disk space remaining. Vods may fail to
-              record!
+              record!{' '}
+              <button className="button pl-2" onClick={() => setDiskSpaceRemaining(-1)}>
+                dismiss
+              </button>
             </div>
           )}
           <button


### PR DESCRIPTION
Simple check at the end of each vod to see if there is room to record more. My solo shuffle vods are almost 2gb so I chose that as a threshold, probably could be a bit more aggressive (8/16gb).

![diskwarn](https://github.com/wowarenalogs/wowarenalogs/assets/15525519/fd79c7c2-84ed-4c9c-853b-e2763d652a42)

Need to find a better spot to position this warning