### PR TITLE
Change hashing to be lighter

### DIFF
--- a/packages/parser/src/utils.ts
+++ b/packages/parser/src/utils.ts
@@ -26,7 +26,7 @@ export const parseQuotedName = (quotedName: string): string => {
 };
 
 export function computeCanonicalHash(buffer: string[]): string {
-  return md5(buffer.join('\n').slice(1024));
+  return md5(buffer.join('\n').slice(0, 16348));
 }
 
 export function getUnitType(flag: number): CombatUnitType {

--- a/packages/parser/test/3v3.test.ts
+++ b/packages/parser/test/3v3.test.ts
@@ -30,7 +30,7 @@ describe('3v3 match parsing', () => {
 
     it('should compute the correct hash id', () => {
       const combat = results.combats[0];
-      expect(combat.id).toEqual('02e4b6d60277b6834648ff0414eae219');
+      expect(combat.id).toEqual('69cf0aa254959c0f569c55d3a73d91a9');
       expect(combat.dataType).toBe('ArenaMatch');
       expect(combat.timezone).toBe('America/New_York');
     });

--- a/packages/parser/test/bgblitz.test.ts
+++ b/packages/parser/test/bgblitz.test.ts
@@ -43,7 +43,7 @@ describe('BG Blitz parsing', () => {
       expect(players).toHaveLength(16);
       expect(bg?.zoneInEvent.instanceId).toBe(998);
       expect(bg?.zoneOutEvent.instanceId).toBe(2444);
-      expect(bg?.id).toBe('8b1f03c30499464e6341d465b781183c');
+      expect(bg?.id).toBe('4e3ff617d1b17cb4dcfb01dd6839fccd');
     });
   });
 });

--- a/packages/parser/test/soloshuffle.test.ts
+++ b/packages/parser/test/soloshuffle.test.ts
@@ -70,7 +70,7 @@ describe('solo shuffle tests', () => {
       team1Ids.forEach((id) => expect(round.units[id].info?.teamId).toBe('1'));
       team0Ids.forEach((id) => expect(round.units[id].info?.teamId).toBe('0'));
 
-      expect(round.id).toBe('aff33d7cf26bf37ff07850b8e9f2eff7');
+      expect(round.id).toBe('9ce503a8d5ebd79b8043b34cc23bf313');
       expect(round.dataType).toBe('ShuffleRound');
       expect(round.sequenceNumber).toBe(0);
       expect(round.winningTeamId).toBe('1');


### PR DESCRIPTION
This function was responsible for insane memory allocations -- I think originally I had thought String.slice(n) would pull the first n chars but it actually pulls char n to the last to char. This means the md5 hash was receiving almost the entire log file as input for hashing which in addition to being unintentional was massive overkill.

Profiling an execution where I parsed 4 of our test logs I went from ~170mb total heap down to 80mb total heap (per `{ memoryUsage } from 'node:process'`) results)

This will cause some duplication to be possible during the transition, it's not something I think is critical to address though.