### PR TITLE
Fix stuck floating combat text in replay

### DIFF
--- a/packages/shared/src/components/CombatReport/CombatPerformance/index.tsx
+++ b/packages/shared/src/components/CombatReport/CombatPerformance/index.tsx
@@ -246,7 +246,7 @@ export const CombatPerformance = () => {
         : combat.startInfo.bracket
       : 'match';
     const date = combat
-      ? new Date(combat.startTime).toISOString().slice(0, 19).replace('T', '_').replaceAll(':', '-')
+      ? new Date(combat.startTime).toISOString().slice(0, 19).replace('T', '_').replace(/:/g, '-')
       : 'unknown';
     const playerName = activePlayer?.name?.split('-')[0] ?? 'player';
     a.download = `${matchType}_${date}_${playerName}_${activeMode}.csv`;

--- a/packages/shared/src/components/CombatReport/CombatReplay/ReplayHpNumbers.tsx
+++ b/packages/shared/src/components/CombatReport/CombatReplay/ReplayHpNumbers.tsx
@@ -35,7 +35,7 @@ const ReplayHpNumber = (props: { renderState: IHpNumberRenderState }) => {
       resolution={4}
       anchor={0.5}
       scale={0.2}
-      alpha={props.renderState.progress < 0.5 ? 1 : 1 - (props.renderState.progress - 0.5)}
+      alpha={props.renderState.progress < 0.5 ? 1 : 1 - (props.renderState.progress - 0.5) * 2}
       style={
         new TextStyle({
           align: 'center',
@@ -61,10 +61,16 @@ export const ReplayHpNumbers = (props: IProps) => {
     (e): e is CombatHpUpdateAction => e instanceof CombatHpUpdateAction,
   );
 
+  const seen = new Set<string>();
   const numbers = props.unit.damageIn
     .concat(props.unit.healIn)
     .concat(outgoingDamage)
     .concat(props.unit.healOut)
+    .filter((e) => {
+      if (seen.has(e.logLine.id)) return false;
+      seen.add(e.logLine.id);
+      return true;
+    })
     .filter((e) => {
       const eventTimeOffset = e.timestamp - combat.startTime;
       return (


### PR DESCRIPTION
## Summary
- Fix duplicate React keys from self-heal events appearing in both `healIn` and `healOut`, causing pixi-react to fail cleaning up `pixiText` nodes (root cause of stuck green healing numbers)
- Fix alpha fade formula to correctly reach 0 instead of stopping at 0.5

## Test plan
- [ ] Open a combat report with a healer, go to Replay tab
- [ ] Play the replay and verify floating damage (red) and healing (green) numbers appear and fade smoothly
- [ ] Pause the replay and verify visible numbers freeze in place (readable)
- [ ] Scrub the timeline slider back and forth, verify no text gets permanently stuck
- [ ] Resume playback after scrubbing, verify numbers animate normally

Made with [Cursor](https://cursor.com)