### PR TITLE
Show active feature flag badges on settings page

### DIFF
--- a/packages/web/app/(main)/settings/page.tsx
+++ b/packages/web/app/(main)/settings/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { getAnalyticsDeviceId, LoadingScreen, useClientContext } from '@wowarenalogs/shared';
-import { useCallback, useEffect, useState } from 'react';
+import { features, getAnalyticsDeviceId, LoadingScreen, useClientContext } from '@wowarenalogs/shared';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { FaDiscord, FaPatreon } from 'react-icons/fa';
 
 import RecordingSettings from '../../../components/Settings/RecordingSettings';
@@ -13,6 +13,13 @@ export default function SettingsPage() {
   const [appVersion, setAppVersion] = useState('');
   const [featureCode, setFeatureCode] = useState('');
   const [sentryId, setSentryId] = useState('');
+
+  const validFlags = useMemo(() => new Set(Object.values(features)), []);
+
+  const activeFlags = useMemo(
+    () => (appConfig.flags || []).filter((f) => validFlags.has(f)),
+    [appConfig.flags, validFlags],
+  );
 
   const parseCode = useCallback(() => {
     if (featureCode.startsWith('add:')) {
@@ -141,22 +148,44 @@ export default function SettingsPage() {
           </button>
         </div>
       </div>
-      <div className="flex flex-row-reverse gap-2">
-        <input
-          type="text"
-          placeholder={`enter feature code here`}
-          className={`input input-sm input-bordered flex-1`}
-          value={featureCode}
-          onChange={(e) => setFeatureCode(e.target.value)}
-        />
-        <button
-          className="btn btn-sm gap-2"
-          onClick={() => {
-            parseCode();
-          }}
-        >
-          Use feature code
-        </button>
+      <div className="flex flex-col gap-2">
+        <div className="flex flex-row-reverse gap-2">
+          <input
+            type="text"
+            placeholder={`enter feature code here`}
+            className={`input input-sm input-bordered flex-1`}
+            value={featureCode}
+            onChange={(e) => setFeatureCode(e.target.value)}
+          />
+          <button
+            className="btn btn-sm gap-2"
+            onClick={() => {
+              parseCode();
+            }}
+          >
+            Use feature code
+          </button>
+        </div>
+        {activeFlags.length > 0 && (
+          <div className="flex flex-wrap gap-2">
+            {activeFlags.map((flag) => (
+              <span key={flag} className="badge badge-outline gap-1">
+                {flag}
+                <button
+                  className="text-xs opacity-60 hover:opacity-100"
+                  onClick={() => {
+                    updateAppConfig((prev) => ({
+                      ...prev,
+                      flags: (prev.flags || []).filter((f) => f !== flag),
+                    }));
+                  }}
+                >
+                  ✕
+                </button>
+              </span>
+            ))}
+          </div>
+        )}
       </div>
       <div className="divider" />
       {window.wowarenalogs.platform === 'win32' && window.wowarenalogs.obs && <RecordingSettings />}


### PR DESCRIPTION
## Summary
- Display active feature codes as outlined badges below the feature code input on the Settings page
- Each badge has an inline remove button (no need to type `drop:flag-name`)
- Only valid flags (defined in `features` object) are shown; stale or mistyped flags are hidden

## Test plan
- [ ] Go to Settings, enter `add:skip-log-uploads`, click "Use feature code"
- [ ] Verify a `skip-log-uploads` badge appears below the input
- [ ] Click the ✕ on the badge, verify it's removed
- [ ] Enter an invalid code like `add:nonsense`, verify no badge appears

Made with [Cursor](https://cursor.com)