### PR TITLE
chore: clean up console.log usage in web and shared packages

### DIFF
--- a/packages/shared/src/api/combatUploadSignatureHandler.ts
+++ b/packages/shared/src/api/combatUploadSignatureHandler.ts
@@ -74,7 +74,7 @@ export const combatUploadSignatureHandler = async (request: NextApiRequest, resp
     response.status(200).json({ url, id, matchExists });
   } catch (err) {
     // eslint-disable-next-line no-console
-    console.log(err);
+    console.error(err);
     response.status(500).json({ error: 'An error has occurred' });
   }
 };

--- a/packages/shared/src/components/CombatReport/CombatLogView/index.tsx
+++ b/packages/shared/src/components/CombatReport/CombatLogView/index.tsx
@@ -18,7 +18,7 @@ export const CombatLogView = () => {
 
   // Intentionally logging to JS console here for debugging
   // eslint-disable-next-line no-console
-  console.log({ combat });
+  console.debug({ combat });
 
   const lines = combat.rawLines.filter((e) => lowerIncludes(e, textFilter));
   const debouncedUpdate = _.debounce(setTextFilter, 300);

--- a/packages/shared/src/components/pages/AWCPage.tsx
+++ b/packages/shared/src/components/pages/AWCPage.tsx
@@ -279,8 +279,8 @@ export const AWCPage = () => {
           );
 
           if (closestMatches.length > 1) {
-            console.log('N>1:', gameDate);
-            console.log({
+            // eslint-disable-next-line no-console
+            console.debug('N>1:', gameDate, {
               game,
               gameRoster1: game.firstTeamRoster?.map((p) => p.name),
               gameRoster2: game.secondTeamRoster?.map((p) => p.name),

--- a/packages/shared/src/utils/upload.ts
+++ b/packages/shared/src/utils/upload.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import { IArenaMatch, IShuffleMatch } from '@wowarenalogs/parser';
 import moment from 'moment-timezone';
 
@@ -9,12 +8,14 @@ export async function uploadCombatAsync(
     patchRevision?: string;
   },
 ) {
-  console.log('Starting compressed upload...');
+  // eslint-disable-next-line no-console
+  console.debug('Starting compressed upload...');
 
   // Create iterator for all lines
   const allLines = combat.dataType === 'ArenaMatch' ? combat.rawLines : combat.rounds.flatMap((c) => c.rawLines);
 
-  console.log(`Streaming ${combat.dataType} with ${allLines.length} lines directly to compression`);
+  // eslint-disable-next-line no-console
+  console.debug(`Streaming ${combat.dataType} with ${allLines.length} lines directly to compression`);
 
   // Stream lines directly without buffering the full text
   const textEncoder = new TextEncoder();
@@ -37,7 +38,8 @@ export async function uploadCombatAsync(
   });
 
   const compressedReadableStream = readBufferStream.pipeThrough(new CompressionStream('gzip'));
-  console.log('Created compressed stream, ready to upload directly');
+  // eslint-disable-next-line no-console
+  console.debug('Created compressed stream, ready to upload directly');
 
   const headers: Record<string, string> = {
     'content-type': 'text/plain;charset=UTF-8',
@@ -57,7 +59,8 @@ export async function uploadCombatAsync(
   const jsonResponse = (await storageSignerResponse.json()) as { id: string; url: string; matchExists: boolean };
   const signedUploadUrl = jsonResponse.url;
 
-  console.log('Starting streaming upload...');
+  // eslint-disable-next-line no-console
+  console.debug('Starting streaming upload...');
   await fetch(signedUploadUrl, {
     duplex: 'half',
     method: 'PUT',
@@ -66,7 +69,8 @@ export async function uploadCombatAsync(
   } as {
     duplex: string; // jank polyfill for the weird typings here. param is required for stream requests.
   } & RequestInit);
-  console.log('Upload complete!');
+  // eslint-disable-next-line no-console
+  console.debug('Upload complete!');
 
   return jsonResponse;
 }

--- a/packages/web/hooks/LocalCombatsContext/index.tsx
+++ b/packages/web/hooks/LocalCombatsContext/index.tsx
@@ -327,9 +327,7 @@ export const LocalCombatsContextProvider = (props: IProps) => {
               });
           }
           // eslint-disable-next-line no-console
-          console.log('Malformed combat');
-          // eslint-disable-next-line no-console
-          console.log(combat);
+          console.warn('Malformed combat', combat);
         }
       });
 


### PR DESCRIPTION
## Summary

Reviews and cleans up `console.log` usage across the `web` and `shared` packages:

- **upload.ts**: Downgraded 5 verbose progress logs (`Starting compressed upload...`, `Streaming...`, `Created compressed stream...`, etc.) from `console.log` to `console.debug` so they don't clutter the browser console in production. Removed the file-level eslint-disable.
- **combatUploadSignatureHandler.ts**: Changed `console.log(err)` to `console.error(err)` in the catch block — errors should use the appropriate log level.
- **AWCPage.tsx**: Consolidated two `console.log` calls into one `console.debug` for the `N>1` closest-match debugging path.
- **CombatLogView/index.tsx**: Downgraded the render-time `console.log({ combat })` to `console.debug` — still available for debugging but hidden by default.
- **LocalCombatsContext/index.tsx**: Changed malformed combat logging from `console.log` to `console.warn` and consolidated into a single call — this is a warning condition, not informational.

### Left as-is (intentional/acceptable):
- `settings/page.tsx:44` — explicit comment says intentional for prod debugging
- `analytics.ts:39` — already guarded by `NODE_ENV === 'development'`
- `CombatLogView:44` — part of debug tool UI interaction
- `AWCPage:259` — behind `enableEditor` flag
- `LocalCombatsContext:195,210` — event handler logging with eslint-disable comments
- `talentStrings.ts` — already commented out

## Test plan

- [ ] Verify `npm run build` succeeds for both `web` and `shared` packages
- [ ] Check browser console during an upload — should see debug-level messages only (hidden by default in most browsers)
- [ ] Verify malformed combat detection now shows as a warning in browser console
- [ ] Confirm error in combatUploadSignatureHandler appears as console.error

Munr-Job-ID: 05660549544b48b680b581ddf25f9e92
Munr-Session-ID: d5de63e7-cleanup-console-logs