### PR TITLE
style: improve settings page layout and visual consistency

### DIFF
--- a/packages/web/app/(main)/settings/page.tsx
+++ b/packages/web/app/(main)/settings/page.tsx
@@ -57,138 +57,148 @@ export default function SettingsPage() {
   }
 
   return (
-    <div className="flex flex-col m-2 gap-4">
-      <div className="flex gap-2 items-center fixed bottom-4 right-4">
-        <button
-          className="btn btn-sm btn-info gap-2"
-          onClick={() => {
-            clientContext.openExternalURL('https://discord.gg/NFTPK9tmJK');
-          }}
-        >
-          <FaDiscord />
-          Join our Discord
-        </button>
-        <button
-          className="btn btn-sm btn-success gap-2"
-          onClick={() => {
-            clientContext.openExternalURL('https://www.patreon.com/armsperson');
-          }}
-        >
-          <FaPatreon />
-          Support us on Patreon
-        </button>
-        {appVersion ? (
-          <table className="rounded-box table table-compact">
-            <thead>
-              <tr>
-                <th className="bg-base-300">Version</th>
-                <td className="bg-base-200">{appVersion}</td>
-                <td>{sentryId}</td>
-              </tr>
-            </thead>
-          </table>
-        ) : null}
-        {sentryId ? (
-          <table className="rounded-box table table-compact">
-            <thead>
-              <tr>
-                <th className="bg-base-300">Session</th>
-                <td className="bg-base-200">{sentryId}</td>
-              </tr>
-            </thead>
-          </table>
-        ) : null}
-      </div>
-      <div className="flex flex-col gap-2">
-        <div className="text-2xl font-bold">Basics</div>
-        <div className="flex flex-row form-control">
-          <label className="label">
-            <input
-              type="checkbox"
-              className="checkbox mr-2"
-              checked={appConfig.launchAtStartup}
-              onChange={(e) => {
-                updateAppConfig((prev) => {
-                  return {
-                    ...prev,
-                    launchAtStartup: e.target.checked,
-                  };
-                });
-              }}
-            />
-            <span className="label-text">Launch WoW Arena Logs when computer starts.</span>
-          </label>
-        </div>
-        <div className="flex flex-row-reverse gap-2">
-          <input
-            type="text"
-            placeholder={`Please locate your ${
-              window.wowarenalogs.platform === 'win32' ? 'WoW.exe' : 'World of Warcraft.app'
-            }`}
-            readOnly
-            className={`input input-sm input-bordered flex-1 ${appConfig.wowDirectory ? '' : 'input-error'}`}
-            value={appConfig.wowDirectory}
-          />
-          <button
-            className="btn btn-sm gap-2"
-            onClick={() => {
-              window.wowarenalogs.fs
-                ?.selectFolder()
-                .then((folder) => {
-                  updateAppConfig((prev) => {
-                    return { ...prev, wowDirectory: folder };
-                  });
-                })
-                .catch(() => {
-                  return;
-                });
-            }}
-          >
-            Set WoW Path
-          </button>
-        </div>
-      </div>
-      <div className="flex flex-col gap-2">
-        <div className="flex flex-row-reverse gap-2">
-          <input
-            type="text"
-            placeholder={`enter feature code here`}
-            className={`input input-sm input-bordered flex-1`}
-            value={featureCode}
-            onChange={(e) => setFeatureCode(e.target.value)}
-          />
-          <button
-            className="btn btn-sm gap-2"
-            onClick={() => {
-              parseCode();
-            }}
-          >
-            Use feature code
-          </button>
-        </div>
-        {activeFlags.length > 0 && (
-          <div className="flex flex-wrap gap-2">
-            {activeFlags.map((flag) => (
-              <span key={flag} className="badge badge-outline gap-1">
-                {flag}
+    <div className="mt-2 overflow-visible overflow-y-auto px-2 pb-20 sm:mt-4 sm:px-4">
+      <div className="flex flex-col gap-4">
+        <div className="rounded-lg bg-base-300 p-4">
+          <div className="text-2xl font-bold mb-3">Basics</div>
+          <div className="flex flex-col gap-3">
+            <div className="form-control">
+              <label className="label gap-2 justify-start items-center cursor-pointer">
+                <input
+                  type="checkbox"
+                  className="checkbox"
+                  checked={appConfig.launchAtStartup}
+                  onChange={(e) => {
+                    updateAppConfig((prev) => {
+                      return {
+                        ...prev,
+                        launchAtStartup: e.target.checked,
+                      };
+                    });
+                  }}
+                />
+                <span className="label-text">Launch WoW Arena Logs when computer starts</span>
+              </label>
+            </div>
+            <div>
+              <div className="text-sm font-semibold mb-1 opacity-70">WoW Installation Path</div>
+              <div className="flex flex-row gap-2">
+                <input
+                  type="text"
+                  placeholder={`Please locate your ${
+                    window.wowarenalogs.platform === 'win32' ? 'WoW.exe' : 'World of Warcraft.app'
+                  }`}
+                  readOnly
+                  className={`input input-sm input-bordered flex-1 ${appConfig.wowDirectory ? '' : 'input-error'}`}
+                  value={appConfig.wowDirectory}
+                />
                 <button
-                  className="text-xs opacity-60 hover:opacity-100"
+                  className="btn btn-sm btn-primary"
                   onClick={() => {
-                    updateAppConfig((prev) => ({
-                      ...prev,
-                      flags: (prev.flags || []).filter((f) => f !== flag),
-                    }));
+                    window.wowarenalogs.fs
+                      ?.selectFolder()
+                      .then((folder) => {
+                        updateAppConfig((prev) => {
+                          return { ...prev, wowDirectory: folder };
+                        });
+                      })
+                      .catch(() => {
+                        return;
+                      });
                   }}
                 >
-                  ✕
+                  Browse
                 </button>
-              </span>
-            ))}
+              </div>
+            </div>
           </div>
-        )}
+        </div>
+
+        <div className="rounded-lg bg-base-300 p-4">
+          <div className="text-2xl font-bold mb-3">Feature Codes</div>
+          <div className="flex flex-col gap-3">
+            <div className="flex flex-row gap-2">
+              <input
+                type="text"
+                placeholder="Enter feature code here"
+                className="input input-sm input-bordered flex-1"
+                value={featureCode}
+                onChange={(e) => setFeatureCode(e.target.value)}
+              />
+              <button
+                className="btn btn-sm btn-primary"
+                onClick={() => {
+                  parseCode();
+                }}
+              >
+                Apply
+              </button>
+            </div>
+            {activeFlags.length > 0 && (
+              <div className="flex flex-wrap gap-2">
+                {activeFlags.map((flag) => (
+                  <span key={flag} className="badge badge-outline gap-1">
+                    {flag}
+                    <button
+                      className="text-xs opacity-60 hover:opacity-100"
+                      onClick={() => {
+                        updateAppConfig((prev) => ({
+                          ...prev,
+                          flags: (prev.flags || []).filter((f) => f !== flag),
+                        }));
+                      }}
+                    >
+                      ✕
+                    </button>
+                  </span>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+
+        {window.wowarenalogs.platform === 'win32' && window.wowarenalogs.obs && <RecordingSettings />}
+
+        <div className="rounded-lg bg-base-300 p-4">
+          <div className="text-2xl font-bold mb-3">About</div>
+          <div className="flex flex-col gap-3">
+            <div className="flex flex-row gap-4 flex-wrap">
+              <button
+                className="btn btn-sm btn-info gap-2"
+                onClick={() => {
+                  clientContext.openExternalURL('https://discord.gg/NFTPK9tmJK');
+                }}
+              >
+                <FaDiscord />
+                Join our Discord
+              </button>
+              <button
+                className="btn btn-sm btn-success gap-2"
+                onClick={() => {
+                  clientContext.openExternalURL('https://www.patreon.com/armsperson');
+                }}
+              >
+                <FaPatreon />
+                Support us on Patreon
+              </button>
+            </div>
+            {(appVersion || sentryId) && (
+              <div className="flex flex-col gap-1 text-sm opacity-70">
+                {appVersion && (
+                  <div>
+                    <span className="font-semibold">Version:</span> {appVersion}
+                  </div>
+                )}
+                {sentryId && (
+                  <div>
+                    <span className="font-semibold">Session:</span> {sentryId}
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+        </div>
       </div>
-      <div className="divider" />
-      {window.wowarenalogs.platform === 'win32' && window.wowarenalogs.obs && <RecordingSettings />}
     </div>
   );
 }

--- a/packages/web/components/Settings/RecordingSettings.tsx
+++ b/packages/web/components/Settings/RecordingSettings.tsx
@@ -216,8 +216,8 @@ const RecordingSettings = () => {
   const showDebugInfo = process.env.NODE_ENV === 'development' && clientContext.isDesktop;
 
   return (
-    <div className="flex flex-col gap-2">
-      <div className="text-2xl font-bold mb-1">Video Recording</div>
+    <div className="rounded-lg bg-base-300 p-4 flex flex-col gap-3">
+      <div className="text-2xl font-bold">Video Recording</div>
       <div className="alert">
         <svg
           xmlns="http://www.w3.org/2000/svg"
@@ -363,29 +363,32 @@ const RecordingSettings = () => {
                   </label>
                 </div>
               </div>
-              <div className="flex flex-row-reverse gap-2">
-                <input
-                  type="text"
-                  placeholder=""
-                  readOnly
-                  className="input input-sm input-bordered flex-1"
-                  value={recordingConfig?.storagePath ?? ''}
-                />
-                <button
-                  className="btn btn-sm gap-2"
-                  onClick={async () => {
-                    if (window.wowarenalogs.obs?.selectFolder) {
-                      const folderChoice = await window.wowarenalogs.obs.selectFolder(
-                        'Select folder to store videos to',
-                      );
-                      if (folderChoice.length > 0) {
-                        window.wowarenalogs.obs?.setConfig?.('storagePath', folderChoice[0]);
+              <div>
+                <div className="text-sm font-semibold mb-1 opacity-70">VOD Storage Directory</div>
+                <div className="flex flex-row gap-2">
+                  <input
+                    type="text"
+                    placeholder=""
+                    readOnly
+                    className="input input-sm input-bordered flex-1"
+                    value={recordingConfig?.storagePath ?? ''}
+                  />
+                  <button
+                    className="btn btn-sm btn-primary"
+                    onClick={async () => {
+                      if (window.wowarenalogs.obs?.selectFolder) {
+                        const folderChoice = await window.wowarenalogs.obs.selectFolder(
+                          'Select folder to store videos to',
+                        );
+                        if (folderChoice.length > 0) {
+                          window.wowarenalogs.obs?.setConfig?.('storagePath', folderChoice[0]);
+                        }
                       }
-                    }
-                  }}
-                >
-                  Set VOD Directory
-                </button>
+                    }}
+                  >
+                    Browse
+                  </button>
+                </div>
               </div>
               <div>
                 <div className="flex flex-row gap-4">


### PR DESCRIPTION
## Summary
- Wrap each settings section (Basics, Feature Codes, Video Recording, About) in rounded `bg-base-300` cards to match the styling patterns used across the rest of the app
- Move version/session info and social links from a fixed floating footer bar into a proper "About" card at the bottom of the page
- Standardize input+button row layouts (left-to-right instead of reversed flex) and add descriptive labels for path inputs
- Use `btn-primary` for action buttons (Browse, Apply) to improve visual hierarchy

## Test plan
- [ ] Open the Settings page in the Electron app and verify all sections render inside rounded card containers
- [ ] Verify the "Launch at startup" checkbox toggles correctly
- [ ] Verify the WoW path Browse button opens a folder picker and displays the selected path
- [ ] Enter a feature code and confirm the Apply button works; verify active flags display as badges with dismiss buttons
- [ ] On Windows, confirm the Video Recording section appears inside its own card with all controls functional
- [ ] Verify the About section shows Discord/Patreon buttons and version/session info
- [ ] Resize the window to confirm responsive layout behaves well at different widths
- [ ] Confirm no regressions in the rest of the app navigation

Munr-Job-ID: 8714e226573441f49c4cae961bfef51d
Munr-Session-ID: session-improve-settings-page