### PR TITLE
feat: add PvpTalent DB2 table as spell resolution source

### DIFF
--- a/packages/shared/src/data/spellClassMap.json
+++ b/packages/shared/src/data/spellClassMap.json
@@ -1,10 +1,11 @@
 {
-  "generatedAt": "2026-04-15T05:59:10.362Z",
+  "generatedAt": "2026-04-15T06:27:38.227Z",
   "wagoBuild": "12.0.1.66838",
   "sources": {
     "chrSpecializationCsv": "https://wago.tools/db2/ChrSpecialization/csv?build=12.0.1.66838",
     "specializationSpellsCsv": "https://wago.tools/db2/SpecializationSpells/csv?build=12.0.1.66838",
     "skillLineAbilityCsv": "https://wago.tools/db2/SkillLineAbility/csv?build=12.0.1.66838",
+    "pvpTalentCsv": "https://wago.tools/db2/PvpTalent/csv?build=12.0.1.66838",
     "spellNameCsv": "https://wago.tools/db2/SpellName/csv?build=12.0.1.66838",
     "spellCategoriesCsv": "https://wago.tools/db2/SpellCategories/csv?build=12.0.1.66838",
     "spellEffectCsv": "https://wago.tools/db2/SpellEffect/csv?build=12.0.1.66838",
@@ -398,7 +399,9 @@
       "spellId": "204018",
       "name": "Blessing of Spellwarding",
       "specIds": [
-        "66"
+        "65",
+        "66",
+        "70"
       ],
       "source": "TalentTree"
     },
@@ -958,7 +961,9 @@
       "spellId": "204018",
       "name": "Blessing of Spellwarding",
       "specIds": [
-        "66"
+        "65",
+        "66",
+        "70"
       ],
       "source": "TalentTree"
     },
@@ -981,8 +986,12 @@
     {
       "spellId": "212295",
       "name": "Nether Ward",
-      "specIds": [],
-      "source": "unresolved"
+      "specIds": [
+        "265",
+        "266",
+        "267"
+      ],
+      "source": "PvpTalent"
     },
     {
       "spellId": "212800",
@@ -1261,8 +1270,12 @@
     {
       "spellId": "378441",
       "name": "Time Stop",
-      "specIds": [],
-      "source": "unresolved"
+      "specIds": [
+        "1467",
+        "1468",
+        "1473"
+      ],
+      "source": "PvpTalent"
     },
     {
       "spellId": "378464",
@@ -2287,6 +2300,22 @@
           "104",
           "105"
         ]
+      },
+      {
+        "spellId": "212638",
+        "name": "Tracker's Net",
+        "specIds": [
+          "255"
+        ]
+      },
+      {
+        "spellId": "236077",
+        "name": "Disarm",
+        "specIds": [
+          "71",
+          "72",
+          "73"
+        ]
       }
     ],
     "taunt": [
@@ -2468,6 +2497,14 @@
       {
         "spellId": "179057",
         "name": "Chaos Nova",
+        "specIds": [
+          "577",
+          "581"
+        ]
+      },
+      {
+        "spellId": "205630",
+        "name": "Illidan's Grasp",
         "specIds": [
           "577",
           "581"
@@ -3052,7 +3089,40 @@
         ]
       }
     ],
-    "disarm": []
+    "disarm": [
+      {
+        "spellId": "207777",
+        "name": "Dismantle",
+        "specIds": [
+          "259",
+          "260",
+          "261"
+        ]
+      },
+      {
+        "spellId": "209749",
+        "name": "Faerie Swarm",
+        "specIds": [
+          "102"
+        ]
+      },
+      {
+        "spellId": "233759",
+        "name": "Grapple Weapon",
+        "specIds": [
+          "269"
+        ]
+      },
+      {
+        "spellId": "236077",
+        "name": "Disarm",
+        "specIds": [
+          "71",
+          "72",
+          "73"
+        ]
+      }
+    ]
   },
   "interrupts": [
     {

--- a/packages/tools/src/generateSpellClassMap.ts
+++ b/packages/tools/src/generateSpellClassMap.ts
@@ -11,6 +11,7 @@ const SOURCE_TABLES = {
   chrSpecialization: withBuild('ChrSpecialization'),
   specializationSpells: withBuild('SpecializationSpells'),
   skillLineAbility: withBuild('SkillLineAbility'),
+  pvpTalent: withBuild('PvpTalent'),
   spellName: withBuild('SpellName'),
   spellCategories: withBuild('SpellCategories'),
   spellEffect: withBuild('SpellEffect'),
@@ -133,7 +134,7 @@ interface SpellClassEntry {
   spellId: string;
   name: string;
   specIds: string[];
-  source: 'SpecializationSpells' | 'SkillLineAbility' | 'TalentTree' | 'unresolved';
+  source: 'SpecializationSpells' | 'PvpTalent' | 'SkillLineAbility' | 'TalentTree' | 'unresolved';
 }
 
 /** Spells flagged by DB2 attributes that share a name with a talent but couldn't be ID-resolved. */
@@ -165,6 +166,7 @@ interface IGeneratedSpellClassMap {
     chrSpecializationCsv: string;
     specializationSpellsCsv: string;
     skillLineAbilityCsv: string;
+    pvpTalentCsv: string;
     spellNameCsv: string;
     spellCategoriesCsv: string;
     spellEffectCsv: string;
@@ -189,11 +191,12 @@ interface IGeneratedSpellClassMap {
 async function main() {
   console.log(`Downloading DB2 CSVs from wago.tools (build=${WAGO_BUILD})\n`);
 
-  const [chrSpecRows, specSpellRows, skillLineRows, spellNameRows, spellCategoryRows, spellEffectRows] =
+  const [chrSpecRows, specSpellRows, skillLineRows, pvpTalentRows, spellNameRows, spellCategoryRows, spellEffectRows] =
     await Promise.all([
       loadCsv(SOURCE_TABLES.chrSpecialization),
       loadCsv(SOURCE_TABLES.specializationSpells),
       loadCsv(SOURCE_TABLES.skillLineAbility),
+      loadCsv(SOURCE_TABLES.pvpTalent),
       loadCsv(SOURCE_TABLES.spellName),
       loadCsv(SOURCE_TABLES.spellCategories),
       loadCsv(SOURCE_TABLES.spellEffect),
@@ -238,6 +241,34 @@ async function main() {
   }
 
   console.log(`Built SpecializationSpells index: ${specSpellMap.size} unique spells`);
+
+  // ── 2b. Build spell → specIds from PvpTalent ──────────────────
+  // Columns: Description_lang, ID, SpecID, SpellID, OverridesSpellID, Flags, ActionBarSpellID, ...
+  const pvpTalentMap = new Map<string, Set<string>>();
+
+  for (const row of pvpTalentRows) {
+    const specId = toInt(row.SpecID);
+    const spellId = row.SpellID;
+    if (!spellId || spellId === '0' || specId === 0) continue;
+
+    const spec = specInfoById.get(specId);
+    if (!spec) continue;
+
+    const existing = pvpTalentMap.get(spellId) ?? new Set<string>();
+    existing.add(String(specId));
+    pvpTalentMap.set(spellId, existing);
+
+    // Also index the ActionBarSpellID if present (the castable spell that
+    // appears on the action bar when this PvP talent is selected).
+    const actionBarId = row.ActionBarSpellID;
+    if (actionBarId && actionBarId !== '0' && actionBarId !== spellId) {
+      const abExisting = pvpTalentMap.get(actionBarId) ?? new Set<string>();
+      abExisting.add(String(specId));
+      pvpTalentMap.set(actionBarId, abExisting);
+    }
+  }
+
+  console.log(`Built PvpTalent index: ${pvpTalentMap.size} unique spells`);
 
   // ── 3. Build spell → classId from SkillLineAbility ──────────────
   // Columns: ..., SkillLine, Spell, ..., AcquireMethod, ...
@@ -478,8 +509,33 @@ async function main() {
       };
     }
 
+    // Priority 4: PvpTalent (spec-specific PvP talents)
+    const fromPvpTalent = pvpTalentMap.get(spellId);
+    if (fromPvpTalent && fromPvpTalent.size > 0) {
+      return {
+        spellId,
+        name,
+        specIds: Array.from(fromPvpTalent).sort((a, b) => Number(a) - Number(b)),
+        source: 'PvpTalent',
+      };
+    }
+
     // Not found in any source
     return { spellId, name, specIds: [], source: 'unresolved' };
+  }
+
+  /**
+   * Merge PvP talent spec assignments into an already-resolved entry.
+   * A spell may be in the regular talent tree for some specs and a PvP
+   * talent for others (e.g. Blessing of Spellwarding: Prot via talent
+   * tree, Holy/Ret via PvP talent).
+   */
+  function mergePvpTalentSpecs(entry: SpellClassEntry): void {
+    const pvpSpecs = pvpTalentMap.get(entry.spellId);
+    if (!pvpSpecs || pvpSpecs.size === 0) return;
+    const merged = new Set(entry.specIds);
+    pvpSpecs.forEach((specId) => merged.add(specId));
+    entry.specIds = Array.from(merged).sort((a, b) => Number(a) - Number(b));
   }
 
   function resolveCategory(spellIds: string[]): SpellClassEntry[] {
@@ -489,6 +545,14 @@ async function main() {
   const bigDefensive = resolveCategory(spellIdLists.bigDefensiveSpellIds);
   const externalDefensive = resolveCategory(spellIdLists.externalDefensiveSpellIds);
   const important = resolveCategory(spellIdLists.importantSpellIds);
+
+  // Merge PvP talent specs into resolved entries (a spell can be in the
+  // regular talent tree for some specs and a PvP talent for others).
+  for (const entry of [...bigDefensive, ...externalDefensive, ...important]) {
+    if (entry.specIds.length > 0) {
+      mergePvpTalentSpecs(entry);
+    }
+  }
 
   // ── 7b. Collect unresolved curated spells for bug reporting ─────
   // Spells flagged by DB2 attributes that can't be ID-resolved to a player
@@ -599,6 +663,7 @@ async function main() {
       chrSpecializationCsv: SOURCE_TABLES.chrSpecialization,
       specializationSpellsCsv: SOURCE_TABLES.specializationSpells,
       skillLineAbilityCsv: SOURCE_TABLES.skillLineAbility,
+      pvpTalentCsv: SOURCE_TABLES.pvpTalent,
       spellNameCsv: SOURCE_TABLES.spellName,
       spellCategoriesCsv: SOURCE_TABLES.spellCategories,
       spellEffectCsv: SOURCE_TABLES.spellEffect,


### PR DESCRIPTION
Download and parse the PvpTalent table from wago.tools to resolve spells that are PvP-only talents (e.g. Blessing of Spellwarding for Holy/Ret Paladin). PvP talent specs are merged into entries that already resolved via other sources, so a spell available in both the regular talent tree and as a PvP talent gets the union of all specs.

Also indexes ActionBarSpellID from PvP talents for spells where the action bar spell differs from the talent spell.