### PR TITLE
feat(cloud): add per-round shuffle data to webhook payload

### DIFF
--- a/packages/cloud/WEBHOOKS.md
+++ b/packages/cloud/WEBHOOKS.md
@@ -44,7 +44,7 @@ delivery is logged as a warning on our side.
 
 ```jsonc
 {
-  "version": 1,                       // payload schema version; branch on this
+  "version": 2,                       // payload schema version; branch on this
   "dataType": "ArenaMatch",           // "ArenaMatch" | "ShuffleMatch"
   "id": "string",                     // match id (also the idempotency key)
   "wowVersion": "retail",             // "retail" | "classic"
@@ -102,14 +102,45 @@ delivery is logged as a warning on our side.
       "equipment": [{ "id": "string", "ilvl": 0 }]
     }
   ],
-  "roundResults": [3, 2, 3, 2, 3, 2]  // shuffle only — per-round result codes
+  "roundResults": [3, 2, 3, 2, 3, 2], // shuffle only — per-round result codes
+
+  // --- shuffle only, added in version 2 ---
+  "rounds": [                         // 6 entries, sequenceNumber 0..5
+    {
+      "id": "string",                 // round content hash (rounds[5].id === top-level id)
+      "sequenceNumber": 0,            // 0..5
+      "startTimestamp": 0,            // epoch ms (NOTE: not "startTime")
+      "endTimestamp": 0,              // epoch ms (NOTE: not "endTime")
+      "durationInSeconds": 0,
+      "winningTeamId": "string",
+      "killedUnitId": "string",       // GUID of the unit whose death ended the round; null if empty
+      "result": 3,                    // CombatResult, uploader perspective
+      "combatants": [                 // 6 LIGHT per-round combatants (no stats/talents/equipment)
+        {
+          "id": "string",
+          "name": "string",
+          "specId": "string",
+          "teamId": "string",         // THIS round's team (re-drawn each round)
+          "dps": 0,
+          "hps": 0,
+          "deaths": 0
+        }
+      ]
+    }
+  ],
+  "scoreboard": [                     // shuffle only — 6 entries, per-player LOBBY-TOTAL wins (0..6)
+    { "unitId": "string", "wins": 0 }
+  ]
 }
 ```
 
-Note: for **shuffle**, `combatants` (and each `combatants[].teamId`, `dps`, `hps`,
-`deaths`, `hasAdvancedLogging`, `playerTeamRating`) is taken from **round 1** only —
-teams are re-drawn each round, so `teamId` is not stable across the match. For
-per-round detail across the whole shuffle, query the GraphQL API by match `id`.
+Note: for **shuffle**, the top-level `combatants` (and each `combatants[].teamId`, `dps`,
+`hps`, `deaths`, `hasAdvancedLogging`, `playerTeamRating`) is still taken from **round 1**
+only — teams are re-drawn each round, so the top-level `teamId` is not stable across the
+match. As of **version 2**, full per-round detail ships in `rounds[]` (with light per-round
+`combatants` carrying this round's `teamId`) and per-player lobby totals in `scoreboard[]`;
+the per-round combatants are intentionally light (no stats/talents/equipment). Arena payloads
+do not include `rounds`/`scoreboard`.
 
 ## Verifying the signature
 

--- a/packages/cloud/package.json
+++ b/packages/cloud/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "lint": "eslint . --max-warnings 0",
     "lint:fix": "eslint . --fix",
+    "test": "tsc --noEmit -p tsconfig.json && npm run test:webhooks",
     "build:cloud": "shx rm -rf dist && cd ../.. && npm run build:parser && npm run build:sql && cd packages/cloud && tsc && tsup && shx cp -r ./deploy/* ./dist && shx cp wowarenalogs*.json ./dist && shx cp .env ./dist && shx cp ../sql/prisma/schema.prisma ./dist",
     "deploy:dev": "npm run build:cloud && bash ./deploy/deploy_dev.sh",
     "deploy:prod": "npm run build:cloud && bash ./deploy/deploy_prod.sh",

--- a/packages/cloud/src/webhooks.ts
+++ b/packages/cloud/src/webhooks.ts
@@ -11,11 +11,12 @@ import {
   IArenaMatch,
   ICombatUnit,
   IShuffleMatch,
+  IShuffleRound,
   WowVersion,
 } from '../../parser/dist/index';
 import { realmIdToRegion } from '../../shared/src/utils/realms';
 
-const WEBHOOK_PAYLOAD_VERSION = 1;
+const WEBHOOK_PAYLOAD_VERSION = 2;
 const WEBHOOK_DEFAULT_TIMEOUT_MS = 10000;
 
 export type WebhookCombatantStats = {
@@ -61,6 +62,32 @@ export type WebhookCombatant = {
   equipment: { id: string; ilvl: number }[] | undefined;
 };
 
+export type WebhookScoreboardEntry = { unitId: string; wins: number };
+
+// Light per-round combatant — intentionally a strict subset of WebhookCombatant (no
+// realmId/classId/stats/talents/equipment). Keeps the per-round payload ~+6 KB, not ~+160 KB.
+export type WebhookRoundCombatant = {
+  id: string;
+  name: string;
+  specId: string | undefined;
+  teamId: string | undefined; // per-round team (re-drawn each round)
+  dps: number;
+  hps: number;
+  deaths: number;
+};
+
+export type WebhookRound = {
+  id: string;
+  sequenceNumber: number;
+  startTimestamp: number; // round.startTime (ms) — renamed on the way out
+  endTimestamp: number; // round.endTime (ms) — renamed on the way out
+  durationInSeconds: number;
+  winningTeamId: string;
+  killedUnitId: string | null;
+  result: CombatResult;
+  combatants: WebhookRoundCombatant[];
+};
+
 export type WebhookStub = {
   version: number;
   dataType: 'ArenaMatch' | 'ShuffleMatch';
@@ -92,6 +119,8 @@ export type WebhookStub = {
 
   // Shuffle only
   roundResults?: number[] | undefined;
+  rounds?: WebhookRound[] | undefined;
+  scoreboard?: WebhookScoreboardEntry[] | undefined;
 };
 
 type WebhookStubBase = Pick<
@@ -194,6 +223,23 @@ const mapCombatants = (units: Record<string, ICombatUnit>, effectiveDuration: nu
     }));
 };
 
+// Light sibling of mapCombatants for shuffle per-round detail. Duration is computed once for
+// the round and reused for every player (mirrors mapCombatants, which is handed a duration).
+const mapRoundCombatants = (round: IShuffleRound): WebhookRoundCombatant[] => {
+  const safeDuration = Math.max(getEffectiveCombatDuration(round), 1);
+  return Object.values(round.units)
+    .filter((u) => u.type === CombatUnitType.Player)
+    .map((c) => ({
+      id: c.id,
+      name: c.name,
+      specId: c.info?.specId,
+      teamId: c.info?.teamId,
+      dps: Math.round(getEffectiveDps([c], safeDuration)),
+      hps: Math.round(getEffectiveHps([c], safeDuration)),
+      deaths: c.deathRecords.length,
+    }));
+};
+
 // `atomic` is the IArenaCombat to source per-round flags from: the match itself for
 // arena, rounds[0] for shuffle.
 const buildStubBase = (match: IArenaMatch | IShuffleMatch, atomic: AtomicArenaCombat): WebhookStubBase => ({
@@ -247,6 +293,18 @@ export const createWebhookStubFromShuffleMatch = (match: IShuffleMatch): Webhook
         `https://wowarenalogs.com/match?id=${match.id}&viewerIsOwner=false&source=webhook&roundId=${idx + 1}`,
     ),
     roundResults: match.rounds.map((r) => r.result),
+    rounds: match.rounds.map((round) => ({
+      id: round.id,
+      sequenceNumber: round.sequenceNumber,
+      startTimestamp: round.startTime,
+      endTimestamp: round.endTime,
+      durationInSeconds: round.durationInSeconds,
+      winningTeamId: round.winningTeamId,
+      killedUnitId: round.killedUnitId || null, // parser types it string; "" → null
+      result: round.result,
+      combatants: mapRoundCombatants(round),
+    })),
+    scoreboard: match.rounds[match.rounds.length - 1].scoreboard, // last round = lobby totals
     combatants: mapCombatants(round0.units, effectiveDuration),
   };
 };

--- a/packages/cloud/test/test_webhooks.ts
+++ b/packages/cloud/test/test_webhooks.ts
@@ -1,17 +1,25 @@
 import crypto from 'crypto';
 import http from 'http';
 
-import { sendWebhookAsync, WebhookStub } from '../src/webhooks';
+import { CombatUnitType, IArenaMatch, ICombatUnit, IShuffleMatch, IShuffleRound } from '../../parser/dist/index';
+import {
+  createWebhookStubFromArenaMatch,
+  createWebhookStubFromShuffleMatch,
+  sendWebhookAsync,
+  WebhookScoreboardEntry,
+  WebhookStub,
+} from '../src/webhooks';
 
 const TEST_SECRET = 'test-webhook-secret';
 
-// A spun-up local receiver lets us assert on what sendWebhookAsync actually sent.
+// --- Transport test: a spun-up local receiver asserts on what sendWebhookAsync sent. ---
+
 type ReceivedRequest = {
   headers: http.IncomingHttpHeaders;
   body: string;
 };
 
-async function main() {
+async function testTransport(): Promise<string[]> {
   let received: ReceivedRequest | undefined;
 
   const server = http.createServer((req, res) => {
@@ -33,7 +41,7 @@ async function main() {
   process.env.ENV_WEBHOOK_SECRET = TEST_SECRET;
 
   const sampleStub: WebhookStub = {
-    version: 1,
+    version: 2,
     dataType: 'ArenaMatch',
     id: 'test-match-1',
     wowVersion: 'retail',
@@ -80,6 +88,246 @@ async function main() {
       failures.push('received body did not match the sent stub');
     }
   }
+  return failures;
+}
+
+// --- Stub-builder tests: hermetic mocks with DISTINCT per-round data, so each risky
+// transform (last-round scoreboard, start/end rename, ""→null, per-round teamId, dps) is
+// falsifiable. The mappers read only a known handful of fields, so partial mocks cast via
+// `as unknown as` are sufficient (established repo precedent: parser/test/timezones.test.ts). ---
+
+const PLAYERS = [0, 1, 2, 3, 4, 5].map((i) => `Player-1-AAAA000${i}`);
+
+const makeUnit = (opts: {
+  id: string;
+  name: string;
+  specId: string;
+  teamId: string;
+  damageOut?: { effectiveAmount: number }[];
+}): ICombatUnit =>
+  ({
+    id: opts.id,
+    name: opts.name,
+    type: CombatUnitType.Player,
+    info: { specId: opts.specId, teamId: opts.teamId },
+    deathRecords: [],
+    damageOut: opts.damageOut ?? [],
+    healOut: [],
+    absorbsOut: [],
+  }) as unknown as ICombatUnit;
+
+// teams[i] is player i's team for this round; `damaged` (a player id) gets non-empty damageOut.
+const roundUnits = (teams: string[], damaged?: string): ICombatUnit[] =>
+  PLAYERS.map((id, i) =>
+    makeUnit({
+      id,
+      name: `Name${i}`,
+      specId: `${100 + i}`,
+      teamId: teams[i],
+      damageOut: id === damaged ? [{ effectiveAmount: 60000 }] : [],
+    }),
+  );
+
+const makeRound = (opts: {
+  seq: number;
+  units: ICombatUnit[];
+  scoreboard: WebhookScoreboardEntry[];
+  startTime: number;
+  endTime: number;
+  winningTeamId: string;
+  killedUnitId: string;
+  result: number;
+}): IShuffleRound =>
+  ({
+    id: `round-${opts.seq}`,
+    sequenceNumber: opts.seq,
+    dataType: 'ShuffleRound',
+    wowVersion: 'retail',
+    units: Object.fromEntries(opts.units.map((u) => [u.id, u])),
+    events: [],
+    startTime: opts.startTime,
+    endTime: opts.endTime,
+    durationInSeconds: (opts.endTime - opts.startTime) / 1000,
+    winningTeamId: opts.winningTeamId,
+    killedUnitId: opts.killedUnitId,
+    scoreboard: opts.scoreboard,
+    result: opts.result,
+    playerId: opts.units[0].id,
+    playerTeamId: '0',
+    hasAdvancedLogging: true,
+    playerTeamRating: 1500,
+    startInfo: { timestamp: opts.startTime, zoneId: '1552', bracket: 'Rated Solo Shuffle', isRanked: true },
+  }) as unknown as IShuffleRound;
+
+const makeShuffle = (rounds: IShuffleRound[]): IShuffleMatch =>
+  ({
+    dataType: 'ShuffleMatch',
+    id: rounds[rounds.length - 1].id,
+    wowVersion: 'retail',
+    result: 3,
+    startInfo: { timestamp: rounds[0].startTime, zoneId: '1552', bracket: 'Rated Solo Shuffle', isRanked: true },
+    endInfo: {
+      winningTeamId: '0',
+      timestamp: rounds[rounds.length - 1].endTime,
+      matchDurationInSeconds: 360,
+      team0MMR: 1500,
+      team1MMR: 1510,
+    },
+    rounds,
+  }) as unknown as IShuffleMatch;
+
+const makeArena = (units: ICombatUnit[]): IArenaMatch =>
+  ({
+    dataType: 'ArenaMatch',
+    id: 'arena-1',
+    wowVersion: 'retail',
+    result: 3,
+    units: Object.fromEntries(units.map((u) => [u.id, u])),
+    events: [],
+    startTime: 1000,
+    endTime: 1300,
+    durationInSeconds: 300,
+    playerId: units[0].id,
+    playerTeamId: '0',
+    hasAdvancedLogging: true,
+    playerTeamRating: 1600,
+    startInfo: { timestamp: 1000, zoneId: '1552', bracket: '3v3', isRanked: true },
+    endInfo: { winningTeamId: '0', timestamp: 1300, matchDurationInSeconds: 300, team0MMR: 1500, team1MMR: 1510 },
+  }) as unknown as IArenaMatch;
+
+const sb = (wins: number[]): WebhookScoreboardEntry[] => PLAYERS.map((unitId, i) => ({ unitId, wins: wins[i] }));
+
+function testBuilders(): string[] {
+  const failures: string[] = [];
+  const check = (cond: boolean | undefined, msg: string) => {
+    if (!cond) failures.push(msg);
+  };
+
+  // Six rounds with DISTINCT data so each transform is falsifiable. Index = sequenceNumber;
+  // startTime = 1000 + seq*100, endTime = start + 60. Notable rows are flagged inline.
+  type RoundSpec = {
+    teams: string[]; // teams[i] = player i's team this round (re-drawn each round)
+    scoreboard: number[]; // cumulative wins through this round
+    winningTeamId: string;
+    killedUnitId: string;
+    result: number;
+    damaged?: string; // player id given non-empty damageOut (→ dps > 0)
+  };
+  const roundSpecs: RoundSpec[] = [
+    {
+      teams: ['0', '0', '0', '1', '1', '1'],
+      scoreboard: [1, 1, 1, 0, 0, 0],
+      winningTeamId: '0',
+      killedUnitId: PLAYERS[3],
+      result: 3,
+      damaged: PLAYERS[0],
+    }, // P0 deals damage
+    {
+      teams: ['1', '0', '0', '1', '0', '1'],
+      scoreboard: [1, 2, 2, 0, 1, 0],
+      winningTeamId: '0',
+      killedUnitId: PLAYERS[0],
+      result: 2,
+    },
+    {
+      teams: ['0', '1', '0', '1', '0', '1'],
+      scoreboard: [1, 2, 3, 1, 2, 0],
+      winningTeamId: '1',
+      killedUnitId: PLAYERS[1],
+      result: 3,
+    },
+    {
+      teams: ['1', '0', '0', '0', '1', '1'],
+      scoreboard: [1, 2, 4, 2, 2, 1],
+      winningTeamId: '0',
+      killedUnitId: PLAYERS[0],
+      result: 2,
+    }, // P0 re-drawn to team '1'
+    {
+      teams: ['0', '1', '1', '0', '1', '0'],
+      scoreboard: [1, 2, 4, 3, 2, 2],
+      winningTeamId: '0',
+      killedUnitId: '',
+      result: 3,
+    }, // empty kill → null
+    {
+      teams: ['0', '0', '1', '1', '0', '1'],
+      scoreboard: [1, 2, 4, 5, 2, 4],
+      winningTeamId: '1',
+      killedUnitId: PLAYERS[2],
+      result: 3,
+    }, // last: lobby totals (sum 18), distinct from round 0
+  ];
+  const mockRounds = roundSpecs.map((s, seq) =>
+    makeRound({
+      seq,
+      units: roundUnits(s.teams, s.damaged),
+      scoreboard: sb(s.scoreboard),
+      startTime: 1000 + seq * 100,
+      endTime: 1000 + seq * 100 + 60,
+      winningTeamId: s.winningTeamId,
+      killedUnitId: s.killedUnitId,
+      result: s.result,
+    }),
+  );
+
+  const stub = createWebhookStubFromShuffleMatch(makeShuffle(mockRounds));
+
+  check(stub.version === 2, `shuffle version ${stub.version} !== 2`);
+  check(stub.rounds?.length === 6, `rounds.length ${stub.rounds?.length} !== 6`);
+  check(
+    stub.rounds?.every((r) => r.combatants.length === 6),
+    'a round did not have 6 combatants',
+  );
+
+  // Rename: startTime → startTimestamp, endTime → endTimestamp (distinct values catch a swap).
+  check(stub.rounds?.[2].startTimestamp === 1200, `round2 startTimestamp ${stub.rounds?.[2].startTimestamp} !== 1200`);
+  check(stub.rounds?.[2].endTimestamp === 1260, `round2 endTimestamp ${stub.rounds?.[2].endTimestamp} !== 1260`);
+
+  // Scoreboard must come from the LAST round, not round 0.
+  check(
+    JSON.stringify(stub.scoreboard) === JSON.stringify(mockRounds[5].scoreboard),
+    'scoreboard does not equal the last round scoreboard',
+  );
+  check(
+    JSON.stringify(stub.scoreboard) !== JSON.stringify(mockRounds[0].scoreboard),
+    'scoreboard equals round 0 (should be the last round / lobby totals)',
+  );
+  check(stub.scoreboard?.length === 6, `scoreboard.length ${stub.scoreboard?.length} !== 6`);
+  check(
+    stub.scoreboard?.some((s) => s.wins === 4),
+    'scoreboard missing the known final total of 4 wins',
+  );
+
+  // killedUnitId: "" → null; a normal round keeps its GUID.
+  check(stub.rounds?.[4].killedUnitId === null, `round4 killedUnitId ${stub.rounds?.[4].killedUnitId} !== null`);
+  check(
+    stub.rounds?.[0].killedUnitId === PLAYERS[3],
+    `round0 killedUnitId ${stub.rounds?.[0].killedUnitId} !== ${PLAYERS[3]}`,
+  );
+
+  // Per-round teamId is re-drawn each round (P0: '0' in round 0, '1' in round 3).
+  const p0r0 = stub.rounds?.[0].combatants.find((c) => c.id === PLAYERS[0]);
+  const p0r3 = stub.rounds?.[3].combatants.find((c) => c.id === PLAYERS[0]);
+  check(p0r0?.teamId === '0', `P0 round0 teamId ${p0r0?.teamId} !== '0'`);
+  check(p0r3?.teamId === '1', `P0 round3 teamId ${p0r3?.teamId} !== '1'`);
+
+  // dps: round 0 duration = (1060-1000)/1000 = 0.06s → clamped to 1 → 60000/1 = 60000.
+  check(p0r0?.dps === 60000, `P0 round0 dps ${p0r0?.dps} !== 60000 (getEffectiveDps/clamp path)`);
+  const p1r0 = stub.rounds?.[0].combatants.find((c) => c.id === PLAYERS[1]);
+  check(p1r0?.dps === 0, `P1 round0 dps ${p1r0?.dps} !== 0 (no damage)`);
+
+  // Arena must NOT carry rounds/scoreboard, but does get the version bump.
+  const arena = createWebhookStubFromArenaMatch(makeArena(roundUnits(['0', '0', '0', '1', '1', '1'])));
+  check(arena.version === 2, `arena version ${arena.version} !== 2`);
+  check(arena.rounds === undefined, 'arena stub has `rounds` (should be undefined)');
+  check(arena.scoreboard === undefined, 'arena stub has `scoreboard` (should be undefined)');
+
+  return failures;
+}
+
+async function main() {
+  const failures = [...(await testTransport()), ...testBuilders()];
 
   if (failures.length > 0) {
     console.error('FAIL test_webhooks:');


### PR DESCRIPTION
## What

Solo Shuffle webhooks currently send only round-1 combatants and a flat `roundResults` array. The parser already computes full per-round detail for all 6 rounds, then drops it at stub-build time. This copies it into the payload.

Payload bumps to **version 2**. Two new shuffle-only fields:

- `rounds[]` — per round: id, sequenceNumber, start/end timestamps, duration, winningTeamId, killedUnitId, result, and light combatants (`{id, name, specId, teamId, dps, hps, deaths}`).
- `scoreboard[]` — per-player lobby-total wins (0–6).

Additive only: no existing field changes name or meaning, and arena payloads are unchanged apart from the version field. Pure copy at build time (the full match is already in hand) — no re-parse, no extra fetch.
