### PR TITLE
Add toggle to disable floating combat text on combat replay

### DIFF
--- a/packages/shared/src/components/CombatReport/CombatReplay/CombatReplayClient.tsx
+++ b/packages/shared/src/components/CombatReport/CombatReplay/CombatReplayClient.tsx
@@ -66,6 +66,7 @@ export function CombatReplayClient() {
   const [speed, setSpeed] = useState(1);
   const [currentTimeOffset, setCurrentTimeOffset] = useState(0);
   const [filterEventsByPlayerId, setFilterEventsByPlayerId] = useState<string | null>(null);
+  const [showFloatingCombatText, setShowFloatingCombatText] = useState(true);
   const [sliderPos, setSliderPos] = useState(0);
   const [pixiApp, setPixiApp] = useState<PixiApplication | null>(null);
 
@@ -225,6 +226,19 @@ export function CombatReplayClient() {
             </button>
           </div>
         </div>
+        <div className="mr-2">
+          <div className="tooltip" data-tip="Toggle floating combat text over players">
+            <label className="label cursor-pointer gap-2 py-0">
+              <input
+                type="checkbox"
+                className="checkbox checkbox-sm"
+                checked={showFloatingCombatText}
+                onChange={(e) => setShowFloatingCombatText(e.target.checked)}
+              />
+              <span className="label-text whitespace-nowrap">Floating text</span>
+            </label>
+          </div>
+        </div>
         <div className="flex-1 flex flex-col justify-center">
           <input
             type="range"
@@ -293,6 +307,7 @@ export function CombatReplayClient() {
                         key={p.id}
                         unit={p}
                         currentTimeOffset={currentTimeOffset}
+                        showFloatingCombatText={showFloatingCombatText}
                         gamePositionToRenderPosition={(gameX, gameY) => ({
                           x: -gameX - worldMinX + VIEWPORT_PADDING + VIEWPORT_X_OFFSET,
                           y: gameY - worldMinY + VIEWPORT_PADDING,

--- a/packages/shared/src/components/CombatReport/CombatReplay/ReplayCharacter.tsx
+++ b/packages/shared/src/components/CombatReport/CombatReplay/ReplayCharacter.tsx
@@ -13,6 +13,7 @@ interface IProps {
   combat: AtomicArenaCombat;
   unit: ICombatUnit;
   currentTimeOffset: number;
+  showFloatingCombatText: boolean;
   gamePositionToRenderPosition: (gameX: number, gameY: number) => { x: number; y: number };
 }
 
@@ -210,7 +211,9 @@ export function ReplayCharacter(props: IProps) {
           y={-3.0}
         />
       ) : null}
-      <ReplayHpNumbers unit={props.unit} currentTimeOffset={props.currentTimeOffset} />
+      {props.showFloatingCombatText ? (
+        <ReplayHpNumbers unit={props.unit} currentTimeOffset={props.currentTimeOffset} />
+      ) : null}
       <ReplayHealthBar current={hp.current} max={hp.max} reaction={props.unit.reaction} />
       <ReplayCastBar unit={props.unit} currentTimeOffset={props.currentTimeOffset} />
     </pixiContainer>


### PR DESCRIPTION
## Summary

Adds a **"Floating text"** checkbox to the combat replay toolbar that lets users disable the floating combat text (damage/healing numbers) that animate over player avatars.

The toggle defaults to **on**, preserving the current behavior. When unchecked, the `ReplayHpNumbers` floats are no longer rendered over any character.

## Changes

- `CombatReplayClient.tsx`
  - New `showFloatingCombatText` state (default `true`)
  - Checkbox added to the playback toolbar (next to the speed / first-blood controls) with a tooltip
  - State passed down to each `ReplayCharacter`
- `ReplayCharacter.tsx`
  - New required `showFloatingCombatText` prop
  - `ReplayHpNumbers` rendered only when the toggle is enabled

## Testing

- `eslint` passes on the changed files (`--max-warnings 0`)
- Single call site of `ReplayCharacter`, updated to pass the new prop

🤖 Generated with [Claude Code](https://claude.com/claude-code)