### PR TITLE
ci: fix Windows build (noobs native build via node-gyp)

### DIFF
--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -61,7 +61,9 @@ jobs:
         env:
           PYTHON: ${{ steps.setup-python.outputs.python-path }}
           npm_config_python: ${{ steps.setup-python.outputs.python-path }}
-        run: npm ci
+        # --foreground-scripts surfaces noobs's node-gyp output inline; without it
+        # npm hides the build error and silently rolls back the optional subtree.
+        run: npm ci --foreground-scripts
       - name: build for windows
         run: npm run build:app:windows
   build_on_mac:

--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -39,23 +39,28 @@ jobs:
         with:
           node-version: 22
       - name: setup python 3.11 for node-gyp
-        # noobs's native addon is built from source by node-gyp during `npm ci`.
-        # node-gyp needs Python's `distutils`, which the stdlib dropped in 3.12.
-        # We previously re-provided it via `pip install --upgrade setuptools`,
-        # but setuptools >= 80 removed its distutils shim, so that stopped
-        # working once the windows-latest image bumped setuptools/Python — node-gyp
-        # then fails and npm silently rolls back the *optional* noobs subtree,
-        # shipping a recorder with no OBS binaries (copyNoobs then fails the build).
-        # Pinning Python 3.11 guarantees stdlib distutils is present, with no
-        # dependency on setuptools internals.
+        # noobs's native addon is built from source by `node-gyp rebuild` during
+        # `npm ci`. The node-gyp that runs it is the 9.x hoisted into the repo's
+        # node_modules (resolved from node_modules/.bin), and node-gyp 9.x imports
+        # Python's `distutils` — which the stdlib removed in 3.12. On the
+        # windows-latest runner node-gyp otherwise auto-discovers a 3.12+ Python,
+        # the configure step throws `No module named 'distutils'`, and npm
+        # silently rolls back the *optional* noobs subtree — shipping a recorder
+        # with no OBS binaries (copyNoobs then fails the build).
+        #
+        # Python 3.11 still ships stdlib distutils, so we install it and force
+        # node-gyp onto this exact interpreter via PYTHON / npm_config_python
+        # below (PATH alone isn't enough — node-gyp picks its own interpreter).
+        id: setup-python
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-      - name: install node-gyp
-        run: npm i -g node-gyp@latest
       - name: clean npm cache
         run: npm cache clean -f
       - name: install dependencies
+        env:
+          PYTHON: ${{ steps.setup-python.outputs.python-path }}
+          npm_config_python: ${{ steps.setup-python.outputs.python-path }}
         run: npm ci
       - name: build for windows
         run: npm run build:app:windows

--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -25,7 +25,13 @@ jobs:
     if: >-
       github.event_name != 'workflow_dispatch'
       || inputs.build_on_win
-    runs-on: windows-latest
+    # Pinned to windows-2022 (Visual Studio 2022 / v17). `windows-latest` rolled
+    # to the windows-2025-vs2026 image (Visual Studio 18), which the old
+    # node-gyp 9.x that builds noobs's native addon can't detect ("unknown
+    # version" -> "could not find a version of Visual Studio 2017 or newer"),
+    # so npm silently drops the optional noobs subtree and copyNoobs fails the
+    # build. VS2022 is the toolchain this build last succeeded on.
+    runs-on: windows-2022
     env:
       CI: false
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -42,11 +48,11 @@ jobs:
         # noobs's native addon is built from source by `node-gyp rebuild` during
         # `npm ci`. The node-gyp that runs it is the 9.x hoisted into the repo's
         # node_modules (resolved from node_modules/.bin), and node-gyp 9.x imports
-        # Python's `distutils` — which the stdlib removed in 3.12. On the
-        # windows-latest runner node-gyp otherwise auto-discovers a 3.12+ Python,
-        # the configure step throws `No module named 'distutils'`, and npm
-        # silently rolls back the *optional* noobs subtree — shipping a recorder
-        # with no OBS binaries (copyNoobs then fails the build).
+        # Python's `distutils` — which the stdlib removed in 3.12. The runner
+        # otherwise auto-discovers a 3.12+ Python, the configure step throws
+        # `No module named 'distutils'`, and npm silently rolls back the
+        # *optional* noobs subtree — shipping a recorder with no OBS binaries
+        # (copyNoobs then fails the build).
         #
         # Python 3.11 still ships stdlib distutils, so we install it and force
         # node-gyp onto this exact interpreter via PYTHON / npm_config_python

--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -38,14 +38,21 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22
-      - name: restore distutils for node-gyp (Python 3.12+ dropped it)
-        # The runner's Python 3.12 removed the stdlib `distutils` module, but the
-        # node-gyp (9.x) that builds noobs's native addon imports it, so the
-        # build fails at "gyp configure" and npm silently rolls back the
-        # *optional* noobs subtree — shipping a recorder with no OBS binaries.
-        # setuptools re-provides distutils, so node-gyp rebuild succeeds and
-        # npm ci installs noobs natively (verified in CI).
-        run: python -m pip install --upgrade setuptools
+      - name: setup python 3.11 for node-gyp
+        # noobs's native addon is built from source by node-gyp during `npm ci`.
+        # node-gyp needs Python's `distutils`, which the stdlib dropped in 3.12.
+        # We previously re-provided it via `pip install --upgrade setuptools`,
+        # but setuptools >= 80 removed its distutils shim, so that stopped
+        # working once the windows-latest image bumped setuptools/Python — node-gyp
+        # then fails and npm silently rolls back the *optional* noobs subtree,
+        # shipping a recorder with no OBS binaries (copyNoobs then fails the build).
+        # Pinning Python 3.11 guarantees stdlib distutils is present, with no
+        # dependency on setuptools internals.
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: install node-gyp
+        run: npm i -g node-gyp@latest
       - name: clean npm cache
         run: npm cache clean -f
       - name: install dependencies


### PR DESCRIPTION
## Problem

`build_on_win` has been failing on every PR since ~June 13:

```
[copyNoobs] noobs module not found. It is required for Windows recording builds.
```

### Root cause (diagnosed by surfacing the swallowed node-gyp output)

`noobs` (the libobs native bindings) is compiled **from source by `node-gyp` during `npm ci`** — the install script is `node-gyp rebuild`, run by the **node-gyp 9.x hoisted in the repo's `node_modules`**. Because `noobs` is an **`optionalDependency`**, any build failure is **silently rolled back** by npm (no error surfaced), and `copyNoobs.ts` then fails the build because the module is gone.

The CI workflow file is unchanged between the last green Windows run (`bf5996e`, Jun 12) and now, so the regression came entirely from the `windows-latest` runner image refreshing under us. Two things broke at once:

1. **Visual Studio:** `windows-latest` rolled to the **`windows-2025-vs2026`** image (Visual Studio 18, at `C:\Program Files\Microsoft Visual Studio\18\Enterprise`). node-gyp 9.x can't recognize VS 18 — `find VS unknown version "undefined"` → `could not find a version of Visual Studio 2017 or newer`.
2. **Python:** the runner's default Python is now 3.12+, which removed stdlib `distutils`; node-gyp 9.x does `from distutils.version import StrictVersion`. The old `pip install --upgrade setuptools` workaround stopped working because setuptools ≥ 80 dropped its distutils shim.

## Fix

- **Pin `runs-on: windows-2022`** (Visual Studio 2022 / v17) — the toolchain this build last succeeded on, which node-gyp 9.x can detect. (VS2026 is too new for any released node-gyp, so upgrading node-gyp isn't an option yet.)
- **Force node-gyp onto Python 3.11** (still ships stdlib `distutils`) via `PYTHON` / `npm_config_python` on the `npm ci` step. PATH alone isn't enough — node-gyp does its own interpreter discovery.
- **`npm ci --foreground-scripts`** so future native-build failures are visible inline instead of being silently swallowed by the optional-dependency rollback.

## Verification

`build_on_win` now passes — logs show `find Python ... 3.11.9`, `noobs.vcxproj -> noobs.node`, `gyp info ok`. lint / test / build_on_linux / build_on_mac green.

Merging this unblocks `build_on_win` for all open PRs (including #499).

🤖 Generated with [Claude Code](https://claude.com/claude-code)