### PR TITLE
feat(shared): let viewers pick a round in a solo shuffle report

### DIFF
--- a/packages/shared/src/components/CombatReport/CombatReportContext.tsx
+++ b/packages/shared/src/components/CombatReport/CombatReportContext.tsx
@@ -1,4 +1,11 @@
-import { AtomicArenaCombat, CombatUnitReaction, CombatUnitType, ICombatUnit, LogEvent } from '@wowarenalogs/parser';
+import {
+  AtomicArenaCombat,
+  CombatUnitReaction,
+  CombatUnitType,
+  ICombatUnit,
+  IShuffleRound,
+  LogEvent,
+} from '@wowarenalogs/parser';
 import _ from 'lodash';
 import React, { useContext, useEffect, useMemo, useState } from 'react';
 
@@ -7,6 +14,9 @@ import { ccSpellIds } from '../../data/spellTags';
 interface ICombatReportContextData {
   viewerIsOwner: boolean;
   combat: AtomicArenaCombat | null;
+  shuffleRounds: IShuffleRound[];
+  navigateToRound: ((round: IShuffleRound) => void) | null;
+  canSelectRound: boolean;
   activePlayerId: string | null;
   navigateToPlayerView: (playerId: string) => void;
   activeTab: string;
@@ -26,6 +36,9 @@ interface ICombatReportContextData {
 
 export const CombatReportContext = React.createContext<ICombatReportContextData>({
   combat: null,
+  shuffleRounds: [],
+  navigateToRound: null,
+  canSelectRound: false,
   viewerIsOwner: true,
   activePlayerId: null,
   navigateToPlayerView: (_playerId: string) => {
@@ -50,6 +63,8 @@ export const CombatReportContext = React.createContext<ICombatReportContextData>
 
 interface IProps {
   combat: AtomicArenaCombat;
+  shuffleRounds?: IShuffleRound[];
+  onRoundSelected?: (round: IShuffleRound) => void;
   viewerIsOwner: boolean;
   children: React.ReactNode | React.ReactNode[];
 }
@@ -57,6 +72,7 @@ interface IProps {
 export const CombatReportContextProvider = (props: IProps) => {
   const [activePlayerId, setActivePlayerId] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<string>('summary');
+  const shuffleRounds = useMemo(() => props.shuffleRounds ?? [], [props.shuffleRounds]);
 
   const [
     players,
@@ -207,15 +223,17 @@ export const CombatReportContextProvider = (props: IProps) => {
 
   useEffect(() => {
     if (players && players.length > 0) {
-      setActivePlayerId(players[0].id);
+      setActivePlayerId((prev) => (prev && players.some((p) => p.id === prev) ? prev : players[0].id));
     } else {
       setActivePlayerId(null);
     }
   }, [players]);
 
+  const combatGroupId =
+    props.combat.dataType === 'ShuffleRound' && shuffleRounds.length > 0 ? shuffleRounds[0].id : props.combat.id;
   useEffect(() => {
     setActiveTab('summary');
-  }, [props.combat]);
+  }, [combatGroupId]);
 
   return (
     <CombatReportContext.Provider
@@ -239,6 +257,9 @@ export const CombatReportContextProvider = (props: IProps) => {
         playerInterruptsTaken,
         playerTotalSupportIn,
         combat: props.combat,
+        shuffleRounds,
+        navigateToRound: props.onRoundSelected ?? null,
+        canSelectRound: props.combat.dataType === 'ShuffleRound' && !!props.onRoundSelected && shuffleRounds.length > 1,
         viewerIsOwner: props.viewerIsOwner,
       }}
     >

--- a/packages/shared/src/components/CombatReport/CombatReportMobile.tsx
+++ b/packages/shared/src/components/CombatReport/CombatReportMobile.tsx
@@ -12,6 +12,7 @@ import { getDampeningPercentage } from '../../utils/dampening';
 import { healerSpecs, Utils } from '../../utils/utils';
 import { useCombatReportContext } from './CombatReportContext';
 import { CombatUnitName } from './CombatUnitName';
+import { ShuffleRoundSelector } from './ShuffleRoundSelector';
 import { SpellIcon } from './SpellIcon';
 
 type MobileSection = 'summary' | 'deaths';
@@ -984,7 +985,7 @@ function MobileDeathLogSection() {
 export const CombatReportMobile = ({ matchId, roundId }: { matchId: string; roundId?: string }) => {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const { combat } = useCombatReportContext();
+  const { combat, canSelectRound } = useCombatReportContext();
   const [activeSection, setActiveSection] = useState<MobileSection>('summary');
   const [urlCopied, setUrlCopied] = useState(false);
 
@@ -996,7 +997,7 @@ export const CombatReportMobile = ({ matchId, roundId }: { matchId: string; roun
     return null;
   }
 
-  const sequence = combat.dataType === 'ShuffleRound' ? combat.sequenceNumber + 1 : null;
+  const sequence = combat.dataType === 'ShuffleRound' && !canSelectRound ? combat.sequenceNumber + 1 : null;
 
   return (
     <div className="flex h-full w-full flex-col p-2 animate-fadein">
@@ -1012,6 +1013,11 @@ export const CombatReportMobile = ({ matchId, roundId }: { matchId: string; roun
             {combat.startInfo.bracket}
           </h2>
           <div className="text-sm opacity-70">{zoneMetadata[combat.startInfo.zoneId ?? '0'].name}</div>
+          {canSelectRound && (
+            <div className="mt-2">
+              <ShuffleRoundSelector size="xs" />
+            </div>
+          )}
         </div>
         <label htmlFor="toggle-share-mobile" className="btn btn-ghost btn-sm">
           <FaShare />

--- a/packages/shared/src/components/CombatReport/ShuffleRoundSelector.tsx
+++ b/packages/shared/src/components/CombatReport/ShuffleRoundSelector.tsx
@@ -1,0 +1,63 @@
+import { CombatResult, IShuffleRound } from '@wowarenalogs/parser';
+
+import { useCombatReportContext } from './CombatReportContext';
+
+function roundResultLabel(round: IShuffleRound) {
+  switch (round.result) {
+    case CombatResult.Win:
+      return 'win';
+    case CombatResult.Lose:
+      return 'loss';
+    case CombatResult.DrawGame:
+      return 'draw';
+    default:
+      return 'unknown result';
+  }
+}
+
+function roundResultClass(round: IShuffleRound, isActive: boolean) {
+  switch (round.result) {
+    case CombatResult.Win:
+      return isActive ? 'btn-success' : 'btn-success btn-outline';
+    case CombatResult.Lose:
+      return isActive ? 'btn-error' : 'btn-error btn-outline';
+    default:
+      return isActive ? '' : 'btn-ghost';
+  }
+}
+
+export const ShuffleRoundSelector = ({ size = 'sm' }: { size?: 'sm' | 'xs' }) => {
+  const { combat, shuffleRounds, navigateToRound, canSelectRound } = useCombatReportContext();
+
+  if (!canSelectRound || !navigateToRound || combat?.dataType !== 'ShuffleRound') {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-row items-center gap-2">
+      <span className="text-xs font-semibold uppercase tracking-wide opacity-60">Round</span>
+      <div className="btn-group">
+        {shuffleRounds.map((round) => {
+          const isActive = round.sequenceNumber === combat.sequenceNumber;
+          const sequence = round.sequenceNumber + 1;
+          return (
+            <button
+              key={round.id}
+              className={`btn ${size === 'xs' ? 'btn-xs' : 'btn-sm'} ${roundResultClass(round, isActive)} ${
+                isActive ? 'btn-active' : ''
+              }`}
+              title={`Round ${sequence} (${roundResultLabel(round)})`}
+              onClick={() => {
+                if (!isActive) {
+                  navigateToRound(round);
+                }
+              }}
+            >
+              {sequence}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+};

--- a/packages/shared/src/components/CombatReport/index.tsx
+++ b/packages/shared/src/components/CombatReport/index.tsx
@@ -1,4 +1,4 @@
-import { AtomicArenaCombat } from '@wowarenalogs/parser';
+import { AtomicArenaCombat, IShuffleRound } from '@wowarenalogs/parser';
 import dynamic from 'next/dynamic';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useEffect, useMemo, useRef, useState } from 'react';
@@ -24,6 +24,7 @@ import { CombatScoreboard } from './CombatScoreboard';
 import { CombatSummary } from './CombatSummary';
 import { CombatTimeline } from './CombatTimeline';
 import { CombatVideo } from './CombatVideo';
+import { ShuffleRoundSelector } from './ShuffleRoundSelector';
 
 const CombatReplay = dynamic(
   () => {
@@ -37,6 +38,8 @@ interface IProps {
   matchId: string;
   roundId?: string;
   combat: AtomicArenaCombat;
+  shuffleRounds?: IShuffleRound[];
+  onRoundSelected?: (round: IShuffleRound) => void;
   viewerIsOwner?: boolean;
 }
 
@@ -45,7 +48,7 @@ export const CombatReportInternal = ({ matchId, roundId }: { matchId: string; ro
   const router = useRouter();
   const searchParams = useSearchParams();
   const { data: user } = useGetProfileQuery();
-  const { combat, activeTab, setActiveTab, activePlayerId, viewerIsOwner } = useCombatReportContext();
+  const { combat, activeTab, setActiveTab, activePlayerId, viewerIsOwner, canSelectRound } = useCombatReportContext();
   const [isMobileViewport, setIsMobileViewport] = useState<boolean | null>(null);
 
   const [urlCopied, setUrlCopied] = useState(false);
@@ -93,8 +96,8 @@ export const CombatReportInternal = ({ matchId, roundId }: { matchId: string; ro
     return <CombatReportMobile matchId={matchId} roundId={roundId} />;
   }
 
-  const sequence = combat.dataType === 'ShuffleRound' ? combat.sequenceNumber + 1 : null;
   const isShuffle = combat.dataType === 'ShuffleRound';
+  const sequence = isShuffle && !canSelectRound ? combat.sequenceNumber + 1 : null;
 
   return (
     <div className="w-full h-full flex flex-col p-2 animate-fadein">
@@ -109,6 +112,11 @@ export const CombatReportInternal = ({ matchId, roundId }: { matchId: string; ro
           {sequence && <span className="mr-2">Round {sequence} of</span>}
           {`${combat.startInfo.bracket} at ${zoneMetadata[combat.startInfo.zoneId ?? '0'].name}`}
         </h2>
+        {canSelectRound && (
+          <div className="ml-4">
+            <ShuffleRoundSelector />
+          </div>
+        )}
         <div className="flex flex-1" />
         <label htmlFor="toggle-share" className="btn btn-ghost btn-sm">
           <FaShare className="mr-2" />
@@ -273,9 +281,14 @@ export const CombatReportInternal = ({ matchId, roundId }: { matchId: string; ro
   );
 };
 
-export const CombatReport = ({ combat, viewerIsOwner, matchId, roundId }: IProps) => {
+export const CombatReport = ({ combat, viewerIsOwner, matchId, roundId, shuffleRounds, onRoundSelected }: IProps) => {
   return (
-    <CombatReportContextProvider combat={combat} viewerIsOwner={viewerIsOwner || false}>
+    <CombatReportContextProvider
+      combat={combat}
+      shuffleRounds={shuffleRounds}
+      onRoundSelected={onRoundSelected}
+      viewerIsOwner={viewerIsOwner || false}
+    >
       <CombatReportInternal matchId={matchId} roundId={roundId} />
     </CombatReportContextProvider>
   );

--- a/packages/shared/src/components/common/CombatReportFromStorage.tsx
+++ b/packages/shared/src/components/common/CombatReportFromStorage.tsx
@@ -1,3 +1,7 @@
+import { IShuffleRound } from '@wowarenalogs/parser';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { useCallback } from 'react';
+
 import { useCombatFromStorage } from '../../hooks/useCombatFromStorage';
 import { CombatReport } from '../CombatReport';
 import { ErrorPage } from './ErrorPage';
@@ -14,6 +18,19 @@ export function CombatReportFromStorage(props: IProps) {
   const defaultErrorMessage = 'There was a problem loading the page, please refresh!';
   const combatQuery = useCombatFromStorage(id?.toString() || '', roundId);
 
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const onRoundSelected = useCallback(
+    (round: IShuffleRound) => {
+      const params = new URLSearchParams(searchParams?.toString() ?? '');
+      params.set('roundId', (round.sequenceNumber + 1).toString());
+      router.replace(`${pathname}?${params.toString()}`, { scroll: false });
+    },
+    [router, pathname, searchParams],
+  );
+
   if (combatQuery.loading) {
     return <LoadingPage />;
   }
@@ -24,6 +41,8 @@ export function CombatReportFromStorage(props: IProps) {
         combat={combatQuery.combat}
         matchId={combatQuery.matchId}
         roundId={combatQuery.roundId}
+        shuffleRounds={combatQuery.shuffleRounds}
+        onRoundSelected={onRoundSelected}
       />
     );
   } else {

--- a/packages/shared/src/hooks/useCombatFromStorage.ts
+++ b/packages/shared/src/hooks/useCombatFromStorage.ts
@@ -1,4 +1,5 @@
 import { WowVersion } from '@wowarenalogs/parser';
+import { useMemo } from 'react';
 import { useQuery } from 'react-query';
 
 import { Utils } from '../utils/utils';
@@ -13,7 +14,7 @@ const combatRootURL =
 
 export function useCombatFromStorage(matchId: string, roundId?: string) {
   const queryParsedLog = useQuery(
-    ['log-file', matchId, roundId],
+    ['log-file', matchId],
     async () => {
       const logObjectUrl = `${combatRootURL}${matchId}`;
       const result = await fetch(logObjectUrl);
@@ -26,9 +27,8 @@ export function useCombatFromStorage(matchId: string, roundId?: string) {
 
       return {
         matchId,
-        combat:
-          results.arenaMatches.at(0) ||
-          (roundId ? results.shuffleMatches[0]?.rounds[parseInt(roundId) - 1] : undefined),
+        arenaMatch: results.arenaMatches.at(0),
+        shuffleRounds: results.shuffleMatches.at(0)?.rounds ?? [],
       };
     },
     {
@@ -38,10 +38,21 @@ export function useCombatFromStorage(matchId: string, roundId?: string) {
     },
   );
 
+  const arenaMatch = queryParsedLog.data?.arenaMatch;
+  const shuffleRounds = useMemo(() => queryParsedLog.data?.shuffleRounds ?? [], [queryParsedLog.data]);
+
+  const combat = useMemo(() => {
+    if (arenaMatch) {
+      return arenaMatch;
+    }
+    return (roundId ? shuffleRounds[parseInt(roundId) - 1] : undefined) ?? shuffleRounds.at(-1);
+  }, [arenaMatch, shuffleRounds, roundId]);
+
   return {
     matchId,
-    roundId,
-    combat: queryParsedLog.data?.combat,
+    roundId: combat?.dataType === 'ShuffleRound' ? (combat.sequenceNumber + 1).toString() : undefined,
+    combat,
+    shuffleRounds,
     loading: queryParsedLog.isLoading,
     error: queryParsedLog.error,
   };

--- a/packages/web/components/LatestMatchMonitor/index.tsx
+++ b/packages/web/components/LatestMatchMonitor/index.tsx
@@ -15,8 +15,15 @@ function trailingShuffleRounds(combats: AtomicArenaCombat[]): IShuffleRound[] {
       break;
     }
     rounds.unshift(combat);
+    // A shuffle is six rounds numbered 0..5, so the group is complete once round one is in.
+    if (combat.sequenceNumber === 0) {
+      break;
+    }
   }
-  return rounds;
+  // A shuffle whose ARENA_MATCH_END is never seen leaves the next lobby's first round
+  // numbered 6 rather than 0, which would otherwise chain onto the round 5 before it.
+  // Anything past round six belongs to a different lobby, so show it on its own.
+  return rounds.length > 6 ? rounds.slice(-1) : rounds;
 }
 
 export const LatestMatchMonitor = () => {

--- a/packages/web/components/LatestMatchMonitor/index.tsx
+++ b/packages/web/components/LatestMatchMonitor/index.tsx
@@ -1,19 +1,56 @@
+import { AtomicArenaCombat, IShuffleRound } from '@wowarenalogs/parser';
 import { canUseFeature, CombatReport, features } from '@wowarenalogs/shared';
 import Link from 'next/link';
+import { useEffect, useMemo, useState } from 'react';
 
 import { useAppConfig } from '../../hooks/AppConfigContext';
 import { useLocalCombats } from '../../hooks/LocalCombatsContext';
 
+function trailingShuffleRounds(combats: AtomicArenaCombat[]): IShuffleRound[] {
+  const rounds: IShuffleRound[] = [];
+  for (let i = combats.length - 1; i >= 0; i--) {
+    const combat = combats[i];
+    const next = rounds[0];
+    if (combat.dataType !== 'ShuffleRound' || (next && combat.sequenceNumber !== next.sequenceNumber - 1)) {
+      break;
+    }
+    rounds.unshift(combat);
+  }
+  return rounds;
+}
+
 export const LatestMatchMonitor = () => {
   const localCombats = useLocalCombats();
   const { appConfig } = useAppConfig();
+  const [selectedRoundId, setSelectedRoundId] = useState<string | null>(null);
 
   const latestLocalCombat = localCombats.localCombats.length
     ? localCombats.localCombats[localCombats.localCombats.length - 1]
     : null;
 
+  const shuffleRounds = useMemo(
+    () => (latestLocalCombat?.dataType === 'ShuffleRound' ? trailingShuffleRounds(localCombats.localCombats) : []),
+    [localCombats.localCombats, latestLocalCombat],
+  );
+
+  useEffect(() => {
+    setSelectedRoundId(null);
+  }, [latestLocalCombat?.id]);
+
   if (latestLocalCombat) {
-    return <CombatReport combat={latestLocalCombat} matchId={latestLocalCombat.id} viewerIsOwner={true} />;
+    const selectedRound = shuffleRounds.find((r) => r.id === selectedRoundId);
+    const combat = selectedRound ?? latestLocalCombat;
+    return (
+      <CombatReport
+        combat={combat}
+        matchId={combat.id}
+        viewerIsOwner={true}
+        shuffleRounds={shuffleRounds}
+        onRoundSelected={(round) => {
+          setSelectedRoundId(round.id);
+        }}
+      />
+    );
   }
 
   const needs470Upgrade = !window.wowarenalogs.obs?.getEncoders;


### PR DESCRIPTION
Opening a shuffle round gave no way to reach the other five without going back to the match list. The report header (desktop and mobile) now has a picker tinted by each round's result, shown only where the sibling rounds are available.

Stored matches keep the selection in the url so reports stay shareable. The log file already contained every round, so the parse is cached per match rather than per round and switching rounds no longer refetches. The desktop latest-match screen groups the trailing run of local shuffle rounds so rounds can be reviewed as they arrive.

Switching rounds preserves the active tab and the selected player.

<img width="759" height="49" alt="image" src="https://github.com/user-attachments/assets/752d3027-fbd1-4e94-9054-cdc5d5eb82bd" />
