### PR TITLE
fix(parser): make bad lines and segments non-fatal to the pipeline

### DIFF
--- a/packages/parser/src/pipeline/classic/segmentToCombat.ts
+++ b/packages/parser/src/pipeline/classic/segmentToCombat.ts
@@ -3,6 +3,7 @@ import { pipe } from 'rxjs';
 import { filter, map } from 'rxjs/operators';
 
 import { CombatData, IArenaMatch, IMalformedCombatData } from '../../CombatData';
+import { logInfo } from '../../logger';
 import { CombatUnitReaction, CombatUnitType, ICombatEventSegment } from '../../types';
 import { computeCanonicalHash, nullthrows } from '../../utils';
 import { isNonNull } from '../common/utils';
@@ -10,60 +11,64 @@ import { isNonNull } from '../common/utils';
 export const segmentToCombat = () => {
   return pipe(
     map((segment: ICombatEventSegment): IArenaMatch | IMalformedCombatData | null => {
-      if (segment.events.length >= 3) {
-        const combat = new CombatData('classic', segment.events[0].logLine.timezone);
-        combat.startTime = segment.events[0].timestamp || 0;
-        segment.events.forEach((e) => {
-          combat.readEvent(e);
-        });
-        combat.end();
+      try {
+        if (segment.events.length >= 3) {
+          const combat = new CombatData('classic', segment.events[0].logLine.timezone);
+          combat.startTime = segment.events[0].timestamp || 0;
+          segment.events.forEach((e) => {
+            combat.readEvent(e);
+          });
+          combat.end();
 
-        const friendlyTeamCount = Object.values(combat.units).filter(
-          (u) => u.type === CombatUnitType.Player && u.reaction === CombatUnitReaction.Friendly,
-        ).length;
-        const enemyTeamCount = Object.values(combat.units).filter(
-          (u) => u.type === CombatUnitType.Player && u.reaction === CombatUnitReaction.Hostile,
-        ).length;
-        const biggestTeam = Math.max(friendlyTeamCount, enemyTeamCount);
+          const friendlyTeamCount = Object.values(combat.units).filter(
+            (u) => u.type === CombatUnitType.Player && u.reaction === CombatUnitReaction.Friendly,
+          ).length;
+          const enemyTeamCount = Object.values(combat.units).filter(
+            (u) => u.type === CombatUnitType.Player && u.reaction === CombatUnitReaction.Hostile,
+          ).length;
+          const biggestTeam = Math.max(friendlyTeamCount, enemyTeamCount);
 
-        let inferredBracket = '2v2';
-        if (biggestTeam > 2) {
-          inferredBracket = '3v3';
-        }
-        if (biggestTeam > 3) {
-          inferredBracket = '5v5';
-        }
+          let inferredBracket = '2v2';
+          if (biggestTeam > 2) {
+            inferredBracket = '3v3';
+          }
+          if (biggestTeam > 3) {
+            inferredBracket = '5v5';
+          }
 
-        if (combat.isWellFormed) {
-          const plainCombatDataObject: IArenaMatch = {
-            playerId: combat.playerId,
-            dataType: 'ArenaMatch',
-            events: combat.events,
-            id: computeCanonicalHash(segment.lines),
-            wowVersion: combat.wowVersion,
-            startTime: combat.startTime,
-            endTime: combat.endTime,
-            units: combat.units,
-            playerTeamId: combat.playerTeamId,
-            playerTeamRating: combat.playerTeamRating,
-            result: combat.result,
-            hasAdvancedLogging: combat.hasAdvancedLogging,
-            rawLines: segment.lines,
-            linesNotParsedCount: segment.lines.length - segment.events.length,
-            startInfo: {
-              bracket: combat.startInfo?.bracket || inferredBracket,
-              isRanked: combat.startInfo?.isRanked || false,
-              item1: combat.startInfo?.item1 || '',
-              timestamp: combat.startInfo?.timestamp || 0,
-              zoneId: combat.startInfo?.zoneId || '',
-            },
-            timezone: combat.timezone,
-            durationInSeconds: (nullthrows(combat.endInfo).timestamp - nullthrows(combat.startInfo).timestamp) / 1000,
-            endInfo: nullthrows(combat.endInfo),
-            winningTeamId: nullthrows(combat.endInfo?.winningTeamId),
-          };
-          return plainCombatDataObject;
+          if (combat.isWellFormed) {
+            const plainCombatDataObject: IArenaMatch = {
+              playerId: combat.playerId,
+              dataType: 'ArenaMatch',
+              events: combat.events,
+              id: computeCanonicalHash(segment.lines),
+              wowVersion: combat.wowVersion,
+              startTime: combat.startTime,
+              endTime: combat.endTime,
+              units: combat.units,
+              playerTeamId: combat.playerTeamId,
+              playerTeamRating: combat.playerTeamRating,
+              result: combat.result,
+              hasAdvancedLogging: combat.hasAdvancedLogging,
+              rawLines: segment.lines,
+              linesNotParsedCount: segment.lines.length - segment.events.length,
+              startInfo: {
+                bracket: combat.startInfo?.bracket || inferredBracket,
+                isRanked: combat.startInfo?.isRanked || false,
+                item1: combat.startInfo?.item1 || '',
+                timestamp: combat.startInfo?.timestamp || 0,
+                zoneId: combat.startInfo?.zoneId || '',
+              },
+              timezone: combat.timezone,
+              durationInSeconds: (nullthrows(combat.endInfo).timestamp - nullthrows(combat.startInfo).timestamp) / 1000,
+              endInfo: nullthrows(combat.endInfo),
+              winningTeamId: nullthrows(combat.endInfo?.winningTeamId),
+            };
+            return plainCombatDataObject;
+          }
         }
+      } catch (e) {
+        logInfo(`segmentToCombat: dropping a segment that failed to process: ${String(e)}`);
       }
       return null;
     }),

--- a/packages/parser/src/pipeline/common/stringToLogLine.ts
+++ b/packages/parser/src/pipeline/common/stringToLogLine.ts
@@ -72,7 +72,15 @@ export const stringToLogLine = (timezone: string) => {
 
     const event = LogEvent[eventName as keyof typeof LogEvent];
     const jsonPayload = rest.slice(commaIndex + 1).trimEnd();
-    const jsonParameters = parseWowToJSON(jsonPayload);
+
+    let jsonParameters;
+    try {
+      jsonParameters = parseWowToJSON(jsonPayload);
+    } catch (e) {
+      logDebug(`FAILED TO PARSE JSON: ${line.slice(0, 200)} ${String(e)}`);
+      return line;
+    }
+
     const timestamp = parseCombatLogTimestamp(tsString, timezone);
 
     if (timestamp === null || isNaN(timestamp)) {


### PR DESCRIPTION
This was based on a real-world example where wow flushed a log to disk and stopped in the middle of a line. This caused the parser to read a partial line and crash.

A single log line parseWowToJSON couldn't handle threw out of the rxjs map() and terminated the entire subscription, silently ending match detection for the rest of the session. Same for a classic segment that failed to decode. Both now drop just the offending line or segment.