### PR TITLE
fix(shared): omit roundId from share url when there is no round

### DIFF
--- a/packages/shared/src/components/CombatReport/CombatReportMobile.tsx
+++ b/packages/shared/src/components/CombatReport/CombatReportMobile.tsx
@@ -989,7 +989,7 @@ export const CombatReportMobile = ({ matchId, roundId }: { matchId: string; roun
   const [urlCopied, setUrlCopied] = useState(false);
 
   const reportUrl = useMemo(() => {
-    return `https://wowarenalogs.com/match?id=${matchId}&roundId=${roundId}`;
+    return `https://wowarenalogs.com/match?id=${matchId}${roundId ? `&roundId=${roundId}` : ''}`;
   }, [matchId, roundId]);
 
   if (!combat) {

--- a/packages/shared/src/components/CombatReport/index.tsx
+++ b/packages/shared/src/components/CombatReport/index.tsx
@@ -50,7 +50,7 @@ export const CombatReportInternal = ({ matchId, roundId }: { matchId: string; ro
 
   const [urlCopied, setUrlCopied] = useState(false);
   const reportUrl = useMemo(() => {
-    const url = `https://wowarenalogs.com/match?id=${matchId}&roundId=${roundId}`;
+    const url = `https://wowarenalogs.com/match?id=${matchId}${roundId ? `&roundId=${roundId}` : ''}`;
     return url;
   }, [matchId, roundId]);
 


### PR DESCRIPTION
The share link on a combat report is built by interpolating `roundId` unconditionally. Regular (non-shuffle) arena matches have no round, so the copied URL reads `https://wowarenalogs.com/match?id=<id>&roundId=undefined`.

Only append the parameter when a round is present. Same one-line change in the desktop and mobile report headers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)