### PR TITLE
fix(app): stop handing partial log lines to the parser

### DIFF
--- a/packages/app/jest.config.js
+++ b/packages/app/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  testEnvironment: 'node',
+};

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
+    "test": "npx tsdx test",
     "lint": "eslint . --max-warnings 0",
     "lint:fix": "eslint . --fix",
     "build:app": "shx rm -rf dist && tsc -p . && webpack --config webpack.config.js && webpack --config webpack.preload.config.js && shx cp -r public dist/public && cross-env ts-node script/copyNoobs.ts",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -6,7 +6,7 @@
     "test": "npx tsdx test",
     "lint": "eslint . --max-warnings 0",
     "lint:fix": "eslint . --fix",
-    "build:app": "shx rm -rf dist && tsc -p . && webpack --config webpack.config.js && webpack --config webpack.preload.config.js && shx cp -r public dist/public && cross-env ts-node script/copyNoobs.ts",
+    "build:app": "shx rm -rf dist && tsc -p tsconfig.build.json && webpack --config webpack.config.js && webpack --config webpack.preload.config.js && shx cp -r public dist/public && cross-env ts-node script/copyNoobs.ts",
     "gen:app:preload": "cross-env ts-node script/generatePreload.ts && npm run lint:fix",
     "release:app": "git checkout release/wowarenalogs/app && git pull && git merge --no-edit --no-ff main && git push && git checkout main"
   },

--- a/packages/app/src/nativeBridge/modules/common/desktopUtils.test.ts
+++ b/packages/app/src/nativeBridge/modules/common/desktopUtils.test.ts
@@ -1,0 +1,71 @@
+import { appendFileSync, mkdtempSync, statSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { DesktopUtils } from './desktopUtils';
+
+// DesktopUtils only uses WoWCombatLogParser as a type, so a stub is enough to observe
+// which lines the watcher hands to the parser.
+class ParserStub {
+  public readonly lines: string[] = [];
+
+  public parseLine(line: string) {
+    this.lines.push(line);
+  }
+}
+
+function logLine(seconds: number, spellName = `Spell${seconds}`) {
+  return (
+    `9/1/2026 12:00:${seconds.toString().padStart(2, '0')}.000  SPELL_AURA_APPLIED,` +
+    `Player-1-A,"A-Realm",0x511,0x0,Player-1-B,"B-Realm",0x512,0x0,${1000 + seconds},"${spellName}",0x1,BUFF`
+  );
+}
+
+// Mirrors how LogsModule drives the watcher: read everything appended since the last chunk.
+class LogFile {
+  public readonly path: string;
+  public readonly parser = new ParserStub();
+  private offset = 0;
+
+  constructor(name: string) {
+    this.path = join(mkdtempSync(join(tmpdir(), 'walogs-')), name);
+    writeFileSync(this.path, '');
+  }
+
+  public append(contents: string | Buffer) {
+    appendFileSync(this.path, contents);
+    const size = statSync(this.path).size;
+    DesktopUtils.parseLogFileChunk(this.parser as never, this.path, this.offset, size - this.offset);
+    this.offset = size;
+  }
+}
+
+describe('parseLogFileChunk', () => {
+  it('does not corrupt lines in chunks that follow one ending mid-line', () => {
+    const file = new LogFile('WoWCombatLog-mid-line.txt');
+    const halfWritten = logLine(3);
+
+    // WoW flushes two whole lines and stops part way through a third.
+    file.append(`${logLine(1)}\n${logLine(2)}\n${halfWritten.slice(0, 40)}`);
+    // The rest of the third line arrives with a fourth.
+    file.append(`${halfWritten.slice(40)}\n${logLine(4)}\n`);
+    // An ordinary flush, with nothing partial about it.
+    file.append(`${logLine(5)}\n${logLine(6)}\n`);
+
+    expect(file.parser.lines).toEqual([logLine(1), logLine(2), logLine(3), logLine(4), logLine(5), logLine(6)]);
+  });
+
+  it('does not corrupt a multi-byte character split across a chunk boundary', () => {
+    const file = new LogFile('WoWCombatLog-multibyte.txt');
+    const line = logLine(2, '尋找草藥');
+    const bytes = Buffer.from(`${line}\n`, 'utf-8');
+    // Cut one byte into the first character of the spell name.
+    const splitAt = bytes.indexOf(Buffer.from('尋', 'utf-8')) + 1;
+
+    file.append(`${logLine(1)}\n`);
+    file.append(bytes.subarray(0, splitAt));
+    file.append(bytes.subarray(splitAt));
+
+    expect(file.parser.lines).toEqual([logLine(1), line]);
+  });
+});

--- a/packages/app/src/nativeBridge/modules/common/desktopUtils.test.ts
+++ b/packages/app/src/nativeBridge/modules/common/desktopUtils.test.ts
@@ -35,8 +35,8 @@ class LogFile {
   public append(contents: string | Buffer) {
     appendFileSync(this.path, contents);
     const size = statSync(this.path).size;
-    DesktopUtils.parseLogFileChunk(this.parser as never, this.path, this.offset, size - this.offset);
-    this.offset = size;
+    const consumed = DesktopUtils.parseLogFileChunk(this.parser as never, this.path, this.offset, size - this.offset);
+    this.offset += consumed ?? 0;
   }
 }
 

--- a/packages/app/src/nativeBridge/modules/common/desktopUtils.ts
+++ b/packages/app/src/nativeBridge/modules/common/desktopUtils.ts
@@ -2,7 +2,7 @@ import { WoWCombatLogParser, WowVersion } from '@wowarenalogs/parser';
 import { closeSync, existsSync, openSync, readFileSync, readSync } from 'fs-extra';
 import { join } from 'path';
 
-const chunkParitialsBuffer: Record<string, string> = {};
+const NEWLINE = 0x0a;
 
 export class DesktopUtils {
   public static async getWowInstallsFromPath(path: string) {
@@ -54,35 +54,35 @@ export class DesktopUtils {
 
   public static parseLogFileChunk(parser: WoWCombatLogParser, path: string, start: number, size: number) {
     if (size <= 0) {
-      return true;
+      return 0;
     }
     try {
       const fd = openSync(path, 'r');
       const buffer = Buffer.alloc(size);
-      readSync(fd, buffer, 0, size, start);
+      const bytesRead = readSync(fd, buffer, 0, size, start);
       closeSync(fd);
-      let bufferString = buffer.toString('utf-8');
-      // Was there a partial line left over from a previous call?
-      if (chunkParitialsBuffer[path]) {
-        bufferString = chunkParitialsBuffer[path] + bufferString;
+
+      const lastNewline = bytesRead > 0 ? buffer.lastIndexOf(NEWLINE, bytesRead - 1) : -1;
+      if (lastNewline < 0) {
+        return 0;
       }
-      const lines = bufferString.split('\n');
-      lines.forEach((line, idx) => {
-        if (idx === lines.length - 1) {
-          if (line.length > 0) {
-            chunkParitialsBuffer[path] = line;
-          }
-        } else {
+
+      // Cutting on a newline keeps multi-byte characters intact across the boundary.
+      buffer
+        .subarray(0, lastNewline)
+        .toString('utf-8')
+        .split('\n')
+        .forEach((line) => {
           parser.parseLine(line);
-        }
-      });
+        });
+
+      return lastNewline + 1;
     } catch (_e) {
       // TODO: try to come up with some strategy to avoid these
       // Can reproduce by copy+pasting a new log file into wow folder while logger is watching (win32)
       // There are still some transient bugs
       // https://stackoverflow.com/questions/1764809/filesystemwatcher-changed-event-is-raised-twice
-      return false;
+      return null;
     }
-    return true;
   }
 }

--- a/packages/app/src/nativeBridge/modules/logsModule/index.ts
+++ b/packages/app/src/nativeBridge/modules/logsModule/index.ts
@@ -194,10 +194,10 @@ export class LogsModule extends NativeBridgeModule {
 
     const lastKnownFileStats = new Map<string, ILastKnownCombatLogState>();
 
-    const updateLastKnownStats = (path: string, stats: Stats | undefined) => {
+    const updateLastKnownStats = (path: string, stats: Stats | undefined, consumedBytes?: number) => {
       lastKnownFileStats.set(path, {
         lastFileCreationTime: stats?.birthtimeMs || 0,
-        lastFileSize: stats?.size || 0,
+        lastFileSize: consumedBytes ?? stats?.size ?? 0,
       });
     };
 
@@ -220,7 +220,8 @@ export class LogsModule extends NativeBridgeModule {
       const fileSizeDelta = (stats?.size || 0) - lastKnownState.lastFileSize;
       const fileCreationTimeDelta = Math.abs((stats?.birthtimeMs || 0) - lastKnownState.lastFileCreationTime);
 
-      let parseOK = false;
+      let start = 0;
+      let consumed: number | null;
 
       if (
         // we are reading the same file if the creation time is close enough
@@ -228,16 +229,18 @@ export class LogsModule extends NativeBridgeModule {
         // and size is larger than before
         fileSizeDelta >= 0
       ) {
-        parseOK = DesktopUtils.parseLogFileChunk(bridge.logParser, path, lastKnownState.lastFileSize, fileSizeDelta);
+        start = lastKnownState.lastFileSize;
+        consumed = DesktopUtils.parseLogFileChunk(bridge.logParser, path, start, fileSizeDelta);
       } else {
         // we are now reading a new combat log file, resetting states
         bridge.logParser.resetParserStates(wowVersion);
 
-        parseOK = DesktopUtils.parseLogFileChunk(bridge.logParser, path, 0, stats?.size || 0);
+        consumed = DesktopUtils.parseLogFileChunk(bridge.logParser, path, start, stats?.size || 0);
       }
 
-      if (parseOK) {
-        updateLastKnownStats(path, stats);
+      // A trailing partial line is not consumed here; it is read again once wow finishes writing it.
+      if (consumed !== null) {
+        updateLastKnownStats(path, stats, start + consumed);
       }
     };
 

--- a/packages/app/tsconfig.build.json
+++ b/packages/app/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["script/generatePreload.ts", "script/copyNoobs.ts", "dist", "src/**/*.test.ts"]
+}

--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -67,3 +67,27 @@ npm run start:simlog
 CHUNK_SIZE determines how many lines will be written per chunk of file
 
 BUFFER_SLEEP_MS determines the sleep time between writing file chunks
+
+## Simulating partial lines
+
+By default each line is written whole, so the file is newline-aligned at every
+moment a watcher could look at it. Real wow flushes a buffer that ends wherever it
+ends, so a reader can catch the file part way through a line. Set `PARTIAL_LINES=1`
+to reproduce that:
+
+```
+PARTIAL_LINES=1
+FLUSH_SLEEP_MS=250
+```
+
+Each chunk is then written as two flushes cut inside the chunk's last line, with
+`FLUSH_SLEEP_MS` between them so the watcher has time to fire and read while the
+line is still incomplete. Lower it and the two flushes may land before anything
+looks at the file, which makes the split invisible and the run indistinguishable
+from the default mode.
+
+Both flushes are needed, not just the mid-line one: a reader that buffers the
+fragment has to be handed a following flush that ends exactly on a newline, which
+is where boundary handling tends to go wrong. Writing at some fixed byte size
+instead is not enough — if every flush ends mid-line, a reader that keeps only the
+most recent fragment never gets the chance to misuse a stale one.

--- a/packages/tools/src/simlog.ts
+++ b/packages/tools/src/simlog.ts
@@ -3,6 +3,8 @@ import { close, open, readFile, write } from 'fs-extra';
 
 const BUFFER_SLEEP_MS = parseInt(process.env.BUFFER_SLEEP_MS || '500');
 const CHUNK_SIZE = parseInt(process.env.CHUNK_SIZE || '500');
+const PARTIAL_LINES = process.env.PARTIAL_LINES === '1';
+const FLUSH_SLEEP_MS = parseInt(process.env.FLUSH_SLEEP_MS || '250');
 
 function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -17,6 +19,31 @@ async function writeSegment(fileName: string, segment: string[]) {
   await close(outputFile);
 }
 
+// Writes the same bytes as writeSegment, but as two flushes cut inside the
+// segment's final line, so a reader that polls on file size can observe the file
+// part way through a line. wow writes this way; writeSegment cannot, because a
+// whole line per write leaves the file newline-aligned at every observable moment.
+//
+// The pair matters, not just the first half: the mid-line flush is what a reader
+// has to buffer, and the flush that completes the line lands exactly on its
+// newline, which is the case a reader is most likely to mishandle.
+async function writeSegmentSplit(fileName: string, segment: string[]) {
+  if (segment.length === 0) {
+    return;
+  }
+  const outputFile = await open(fileName, 'a+');
+  const bytes = Buffer.from(segment.map((line) => line + '\n').join(''), 'utf-8');
+  const lastLineBytes = Buffer.byteLength(segment[segment.length - 1] + '\n', 'utf-8');
+  const cut = Math.max(1, bytes.length - Math.floor(lastLineBytes / 2));
+
+  await write(outputFile, bytes, 0, cut);
+  // Long enough for the watcher to fire and read while the line is incomplete.
+  // Without this the whole segment lands before anyone looks and the split is moot.
+  await sleep(FLUSH_SLEEP_MS);
+  await write(outputFile, bytes, cut, bytes.length - cut);
+  await close(outputFile);
+}
+
 async function main() {
   const inputFilePath = process.env.INPUT_PATH?.toString();
   if (!inputFilePath) throw new Error('No input file!');
@@ -27,13 +54,16 @@ async function main() {
   const outputFileName = outputFilePath + `WoWCombatLog-sim-${new Date().getTime()}.txt`;
   console.log(`Reading input log ${inputFilePath}`);
   console.log(`Writing to ${outputFileName}`);
+  if (PARTIAL_LINES) {
+    console.log(`Splitting each chunk mid-line, ${FLUSH_SLEEP_MS}ms between the two flushes`);
+  }
   const fin = await open(inputFilePath, 'r');
   const inputFileBuffer = await readFile(fin);
   const inputString = inputFileBuffer.toString().split('\n');
   for (let i = 0; i < inputString.length; i += CHUNK_SIZE) {
     const chunk = inputString.slice(i, i + CHUNK_SIZE);
     console.log(`chunk ${chunk.length}`);
-    await writeSegment(outputFileName, chunk);
+    await (PARTIAL_LINES ? writeSegmentSplit(outputFileName, chunk) : writeSegment(outputFileName, chunk));
     await sleep(BUFFER_SLEEP_MS);
   }
   await close(fin);


### PR DESCRIPTION
`parseLogFileChunk` buffered a trailing partial line in a module-scope map and prepended it to the next chunk, but never cleared it after use. Once any chunk ended mid-line, that fragment was glued onto the first line of every subsequent chunk:

```
  ok  2: 9/1/2026 12:00:03.000  SPELL_AURA_APPLIED,Player-1-A,"A-Realm",...
  ok  3: 9/1/2026 12:00:04.000  SPELL_AURA_APPLIED,Player-1-A,"A-Realm",...
 BAD  4: 9/1/2026 12:00:03.000  SPELL_AURA_APPLIE9/1/2026 12:00:05.000  SPELL_AUR
  ok  5: 9/1/2026 12:00:06.000  SPELL_AURA_APPLIED,Player-1-A,"A-Realm",...
```

Chunk 3 there is an ordinary flush with nothing partial about it, and line 5 is still destroyed. That is where the live `Expected ',' or ']'` failures come from — not from a mid-line cut, but from a fragment left over two chunks earlier.

Rather than clear the buffer, the chunk now stops at its last newline and reports how many bytes it consumed; the watcher advances by that instead of by the file size, so the unfinished tail is simply read again once wow writes the rest. Nothing partial reaches the parser and no state is carried between calls, which also removes the need to reset anything when a new log file is picked up.

Cutting on a newline in bytes fixes a second case the string buffer structurally could not: `readSync` into a fixed-size buffer followed by `.toString('utf-8')` splits multi-byte characters at the boundary, and the replacement characters are baked in before the buffer ever sees the string.

```
original : 00000,2383,"尋找草藥",0x1,BU
rejoined : 00000,2383,"���找草藥",0x1,
```

`parseLogFileChunk` returns consumed bytes (`null` on a failed read) instead of a boolean, so `updateLastKnownStats` takes the offset to record.

Two commits, as asked: the tests first (both fail on `main`), then the fix. `packages/app` had no test setup, so this adds a `jest.config.js` and a `test` script; it runs on the already-hoisted `tsdx`, the same way `build:app` uses the hoisted `cross-env`/`ts-node`, so there is no lockfile change.
