### PR TITLE
fix(app): read log files in chunks so large imports survive

### DIFF
--- a/packages/app/src/nativeBridge/modules/common/desktopUtils.ts
+++ b/packages/app/src/nativeBridge/modules/common/desktopUtils.ts
@@ -1,6 +1,7 @@
 import { WoWCombatLogParser, WowVersion } from '@wowarenalogs/parser';
-import { closeSync, existsSync, openSync, readFileSync, readSync } from 'fs-extra';
+import { closeSync, existsSync, openSync, readSync } from 'fs-extra';
 import { join } from 'path';
+import { StringDecoder } from 'string_decoder';
 
 const chunkParitialsBuffer: Record<string, string> = {};
 
@@ -32,16 +33,28 @@ export class DesktopUtils {
   }
 
   public static parseLogFile(parser: WoWCombatLogParser, path: string) {
+    const CHUNK_SIZE = 16 * 1024 * 1024;
     try {
       const fd = openSync(path, 'r');
-      const buffer = readFileSync(fd);
-      closeSync(fd);
-      const bufferString = buffer.toString('utf-8');
-
-      const lines = bufferString.split('\n');
-      lines.forEach((line) => {
-        parser.parseLine(line);
-      });
+      try {
+        const buffer = Buffer.alloc(CHUNK_SIZE);
+        const decoder = new StringDecoder('utf-8');
+        let partialLine = '';
+        let bytesRead = 0;
+        while ((bytesRead = readSync(fd, buffer, 0, CHUNK_SIZE, null)) > 0) {
+          const lines = (partialLine + decoder.write(buffer.subarray(0, bytesRead))).split('\n');
+          partialLine = lines.pop() ?? '';
+          lines.forEach((line) => {
+            parser.parseLine(line);
+          });
+        }
+        partialLine += decoder.end();
+        if (partialLine.length > 0) {
+          parser.parseLine(partialLine);
+        }
+      } finally {
+        closeSync(fd);
+      }
     } catch (_e) {
       // TODO: try to come up with some strategy to avoid these
       // Can reproduce by copy+pasting a new log file into wow folder while logger is watching (win32)


### PR DESCRIPTION
`DesktopUtils.parseLogFile` reads the whole file and calls `.toString('utf-8')` on it. V8 caps a single string at `buffer.constants.MAX_STRING_LENGTH` — 536,870,888 characters (~512 MiB) on 64-bit — so any combat log past that throws `ERR_STRING_TOO_LONG`. The surrounding `catch (_e) { return false }` swallows it, and `importLogFiles` ignores the return value, so a manual import of a large log does nothing at all and reports nothing.

This only affects the manual import path. The live watcher goes through `parseLogFileChunk` and is not impacted.

### Reproducing

Any single `WoWCombatLog-*.txt` larger than ~512 MB. Nothing about the contents matters — it is purely byte length, so the simplest repro is to leave logging enabled across a long session and import the resulting file.

That size is not unusual. On my own `_retail_/Logs` directory, 43 of 200 logs (22%) are over the limit and the largest is 1.99 GiB.

Verified against two real logs, running the current `parseLogFile` body directly:

| Log | Bytes | Before | After |
| --- | --- | --- | --- |
| `WoWCombatLog-070526_173630.txt` | 505,084,422 | parses, 1,776,003 lines | unchanged |
| `WoWCombatLog-080326_190300.txt` | 553,400,454 | `ERR_STRING_TOO_LONG` | parses, 1,739,156 lines |

The second file is only 16 MB past the cap and has *fewer* lines than the first, which is what puts the boundary at the string limit rather than anything about line count or content.

### Change

Read in 16 MB chunks and feed the parser line by line. A `StringDecoder` carries a multi-byte UTF-8 sequence split across a chunk boundary, and the trailing partial line is carried into the next chunk, so decoding is identical to the old whole-file path. The final partial line is flushed once the read ends. `closeSync` moves into a `finally` so a throw during the read no longer leaks the descriptor.

Peak memory drops from "the entire file, twice" to one 16 MB buffer.

### Notes

No unit test: a fixture would have to exceed 512 MB to exercise the failure, which is not something to commit or generate in CI. The chunk-boundary behaviour it relies on is the same logic covered by the tests in #506.

Merges cleanly with #506, which rewrites `parseLogFileChunk` in the same file but does not touch `parseLogFile`. I verified the merged result typechecks and that #506's tests still pass on it.
