### PR TITLE
Fix Windows builds: hoist node-gyp 12 instead of pinning the toolchain

### DIFF
--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -25,13 +25,7 @@ jobs:
     if: >-
       github.event_name != 'workflow_dispatch'
       || inputs.build_on_win
-    # Pinned to windows-2022 (Visual Studio 2022 / v17). `windows-latest` rolled
-    # to the windows-2025-vs2026 image (Visual Studio 18), which the old
-    # node-gyp 9.x that builds noobs's native addon can't detect ("unknown
-    # version" -> "could not find a version of Visual Studio 2017 or newer"),
-    # so npm silently drops the optional noobs subtree and copyNoobs fails the
-    # build. VS2022 is the toolchain this build last succeeded on.
-    runs-on: windows-2022
+    runs-on: windows-latest
     env:
       CI: false
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -44,31 +38,22 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22
-      - name: setup python 3.11 for node-gyp
-        # noobs's native addon is built from source by `node-gyp rebuild` during
-        # `npm ci`. The node-gyp that runs it is the 9.x hoisted into the repo's
-        # node_modules (resolved from node_modules/.bin), and node-gyp 9.x imports
-        # Python's `distutils` — which the stdlib removed in 3.12. The runner
-        # otherwise auto-discovers a 3.12+ Python, the configure step throws
-        # `No module named 'distutils'`, and npm silently rolls back the
-        # *optional* noobs subtree — shipping a recorder with no OBS binaries
-        # (copyNoobs then fails the build).
-        #
-        # Python 3.11 still ships stdlib distutils, so we install it and force
-        # node-gyp onto this exact interpreter via PYTHON / npm_config_python
-        # below (PATH alone isn't enough — node-gyp picks its own interpreter).
-        id: setup-python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
       - name: clean npm cache
         run: npm cache clean -f
       - name: install dependencies
-        env:
-          PYTHON: ${{ steps.setup-python.outputs.python-path }}
-          npm_config_python: ${{ steps.setup-python.outputs.python-path }}
-        # --foreground-scripts surfaces noobs's node-gyp output inline; without it
-        # npm hides the build error and silently rolls back the optional subtree.
+        # noobs (the recorder's libobs bindings) is an *optional* dependency whose
+        # `install` script is `node-gyp rebuild`, so npm compiles it from source on
+        # every install. When that compile fails npm silently rolls back the whole
+        # noobs subtree and still reports success — shipping a recorder with no OBS
+        # binaries (copyNoobs then fails the build).
+        #
+        # The compiler is whichever node-gyp is hoisted into node_modules/.bin. The
+        # root package.json therefore pins node-gyp 12 as a devDependency: the 9.4.1
+        # that @electron/rebuild would otherwise hoist is from 2023 and can neither
+        # run under Python 3.12+ (it imports the removed stdlib `distutils`) nor
+        # detect Visual Studio 2026 on the current windows-latest image.
+        #
+        # --foreground-scripts surfaces node-gyp's output inline instead of hiding it.
         run: npm ci --foreground-scripts
       - name: build for windows
         run: npm run build:app:windows

--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -32,23 +32,28 @@ jobs:
         env:
           CLOUDSDK_PYTHON: ${{env.pythonLocation}}\python.exe
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 22
-      - name: restore distutils for node-gyp (Python 3.12+ dropped it)
-        # Python 3.12 removed the stdlib `distutils` module, but the node-gyp
-        # (9.x) that builds noobs's native addon imports it, so the build fails
-        # at "gyp configure" and npm silently rolls back the *optional* noobs
-        # subtree — shipping a recorder with no OBS binaries. setuptools
-        # re-provides distutils so node-gyp rebuild succeeds and npm ci installs
-        # noobs natively.
-        run: python -m pip install --upgrade setuptools
       - name: clean npm cache
         run: npm cache clean -f
       - name: install dependencies
-        run: npm ci
+        # noobs (the recorder's libobs bindings) is an *optional* dependency whose
+        # `install` script is `node-gyp rebuild`, so npm compiles it from source on
+        # every install. When that compile fails npm silently rolls back the whole
+        # noobs subtree and still reports success — shipping a recorder with no OBS
+        # binaries (copyNoobs then fails the build).
+        #
+        # The compiler is whichever node-gyp is hoisted into node_modules/.bin. The
+        # root package.json therefore pins node-gyp 12 as a devDependency: the 9.4.1
+        # that @electron/rebuild would otherwise hoist is from 2023 and can neither
+        # run under Python 3.12+ (it imports the removed stdlib `distutils`) nor
+        # detect Visual Studio 2026 on the current windows-latest image.
+        #
+        # --foreground-scripts surfaces node-gyp's output inline instead of hiding it.
+        run: npm ci --foreground-scripts
       - name: build for windows
         run: npm run publish:app:windows
       - name: upload to google cloud storage

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wowarenalogs",
-  "version": "12.7.1",
+  "version": "12.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wowarenalogs",
-      "version": "12.7.1",
+      "version": "12.9.0",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
@@ -28,6 +28,7 @@
         "electron-builder": "^25.1.8",
         "eslint": "^8.49.0",
         "husky": "^7.0.4",
+        "node-gyp": "^12.4.0",
         "patch-package": "^8.0.0",
         "prettier": "^3.0.3",
         "shx": "^0.3.4",
@@ -4026,6 +4027,48 @@
         "node": ">=12.13.0"
       }
     },
+    "node_modules/@electron/rebuild/node_modules/node-gyp": {
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-9.4.1.tgz",
+      "integrity": "sha512-OQkWKbjQKbGkMf/xqI1jjy3oCTgMKJac58G2+bjZb3fza6gW2YrCSdMQYaoTb70crvE//Gngr4f0AgVHmqHvBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.0",
+        "exponential-backoff": "^3.1.1",
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.6",
+        "make-fetch-happen": "^10.0.3",
+        "nopt": "^6.0.0",
+        "npmlog": "^6.0.0",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.5",
+        "tar": "^6.1.2",
+        "which": "^2.0.2"
+      },
+      "bin": {
+        "node-gyp": "bin/node-gyp.js"
+      },
+      "engines": {
+        "node": "^12.13 || ^14.13 || >=16"
+      }
+    },
+    "node_modules/@electron/rebuild/node_modules/nopt": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-6.0.0.tgz",
+      "integrity": "sha512-ZwLpbTgdhuZUnZzjd7nb1ZV+4DoiC6/sfiVKok72ym/4Tlf+DFdlHYmT2JPmcNNWV6Pi3SDf1kT+A4r9RTuT9g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^1.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
     "node_modules/@electron/rebuild/node_modules/semver": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
@@ -6884,6 +6927,29 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass/node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -7921,9 +7987,9 @@
       }
     },
     "node_modules/@npmcli/fs/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -13789,9 +13855,9 @@
       "license": "MIT"
     },
     "node_modules/cacache/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13820,9 +13886,9 @@
       }
     },
     "node_modules/cacache/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -21236,9 +21302,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.7.0.tgz",
+      "integrity": "sha512-BGFsyJd5mpXp3rK6jIdADLNgpJUK1jnjzvYF8lK+VyDab9JAmqN0YOKDdP17HlgKb2+ehPgDc8EtnRLbGCAMhA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -25471,11 +25537,11 @@
       }
     },
     "node_modules/minipass-flush": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.5.tgz",
-      "integrity": "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.7.tgz",
+      "integrity": "sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -26050,29 +26116,28 @@
       }
     },
     "node_modules/node-gyp": {
-      "version": "9.4.1",
-      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-9.4.1.tgz",
-      "integrity": "sha512-OQkWKbjQKbGkMf/xqI1jjy3oCTgMKJac58G2+bjZb3fza6gW2YrCSdMQYaoTb70crvE//Gngr4f0AgVHmqHvBQ==",
+      "version": "12.4.0",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-12.4.0.tgz",
+      "integrity": "sha512-OMcPNvqTCFUnNaBlmdgq+lfNqY7gTiSmNRDjY3uAXRyudeKZEZxu3CLtjMQrx4zZxCX2b/mpNqTtwuCJgXhHkw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "env-paths": "^2.2.0",
         "exponential-backoff": "^3.1.1",
-        "glob": "^7.1.4",
         "graceful-fs": "^4.2.6",
-        "make-fetch-happen": "^10.0.3",
-        "nopt": "^6.0.0",
-        "npmlog": "^6.0.0",
-        "rimraf": "^3.0.2",
+        "nopt": "^9.0.0",
+        "proc-log": "^6.0.0",
         "semver": "^7.3.5",
-        "tar": "^6.1.2",
-        "which": "^2.0.2"
+        "tar": "^7.5.4",
+        "tinyglobby": "^0.2.12",
+        "undici": "^6.25.0",
+        "which": "^6.0.0"
       },
       "bin": {
         "node-gyp": "bin/node-gyp.js"
       },
       "engines": {
-        "node": "^12.13 || ^14.13 || >=16"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/node-gyp-build": {
@@ -26086,6 +26151,49 @@
         "node-gyp-build-test": "build-test.js"
       }
     },
+    "node_modules/node-gyp/node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/node-gyp/node_modules/isexe": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+      "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/node-gyp/node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/node-gyp/node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/node-gyp/node_modules/semver": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
@@ -26097,6 +26205,49 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/node-gyp/node_modules/tar": {
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/node-gyp/node_modules/which": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
+      "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^4.0.0"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/node-gyp/node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/node-int64": {
@@ -26185,19 +26336,29 @@
       }
     },
     "node_modules/nopt": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-6.0.0.tgz",
-      "integrity": "sha512-ZwLpbTgdhuZUnZzjd7nb1ZV+4DoiC6/sfiVKok72ym/4Tlf+DFdlHYmT2JPmcNNWV6Pi3SDf1kT+A4r9RTuT9g==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-9.0.0.tgz",
+      "integrity": "sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "abbrev": "^1.0.0"
+        "abbrev": "^4.0.0"
       },
       "bin": {
         "nopt": "bin/nopt.js"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/nopt/node_modules/abbrev": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-4.0.0.tgz",
+      "integrity": "sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/normalize-package-data": {
@@ -27824,6 +27985,16 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/proc-log": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+      "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/process": {
@@ -31531,13 +31702,13 @@
       }
     },
     "node_modules/socks": {
-      "version": "2.8.7",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
-      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ip-address": "^10.0.1",
+        "ip-address": "^10.1.1",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
@@ -35046,6 +35217,16 @@
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.7.tgz",
       "integrity": "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==",
       "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
     },
     "node_modules/undici-types": {
       "version": "7.16.0",

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "electron-builder": "^25.1.8",
     "eslint": "^8.49.0",
     "husky": "^7.0.4",
+    "node-gyp": "^12.4.0",
     "patch-package": "^8.0.0",
     "prettier": "^3.0.3",
     "shx": "^0.3.4",


### PR DESCRIPTION
## The failure

The Windows release build ([run 33664503857](https://github.com/wowarenalogs/wowarenalogs/actions/runs/33664503857/job/100362802357)) dies at:

```
[copyNoobs] noobs module not found. It is required for Windows recording builds.
```

`noobs` (the recorder's libobs bindings) is an **optional** dependency whose install script is `node-gyp rebuild`, so npm compiles it from source on every install. When that compile fails, npm silently rolls the whole noobs subtree back and still reports success (`added 2725 packages`) — the build only blows up later, when `copyNoobs` can't find the module.

## Why the compile failed

The compiler is whichever node-gyp is hoisted into `node_modules/.bin` — and that was **node-gyp 9.4.1**, a mid-2023 release we never asked for. It arrives transitively via `@electron/rebuild@3.6.1` (`package-lock.json:4015`, `node-gyp: ^9.0.0`). Two things it can't do:

| Runner reality | node-gyp 9.4.1 | node-gyp 12.4.0 |
|---|---|---|
| Python 3.12+ (no stdlib `distutils`) | imports `distutils` -> `ModuleNotFoundError` | bundles gyp-next 0.22.2; zero `distutils` references, Python `>=3.6` |
| `windows-2025-vs2026` image (VS 18) | knows `[2019, 2022]` -> *"unknown version"* | `findVisualStudio2019OrNewer()` -> `[2019, 2022, 2026]` |

Either one alone is fatal.

## Why not keep pinning the environment

We had been holding the environment still around the stale tool: `windows-2022` + Python 3.11 in `build-app.yml`, and `pip install --upgrade setuptools` for its distutils shim in `release-app.yml`. Both pins decay — `windows-2022` gets retired, and setuptools >= 80 dropped the shim, which is exactly why `release-app.yml` broke again. `release-app.yml` also never received the `build-app.yml` fix, so the two workflows had drifted apart.

## The change

Declare `node-gyp: ^12.4.0` as a root devDependency. That hoists 12.4.0 to the top level (what noobs's install script picks up), while `@electron/rebuild` keeps its own nested 9.4.1 for the Electron rebuilds it was tested against:

```
node_modules/node-gyp                                 -> 12.4.0
node_modules/@electron/rebuild/node_modules/node-gyp  -> 9.4.1
```

**12 rather than 13** because node-gyp 13 requires node `^22.22.2` while this repo's `engines` allow `>=22` — contributors on earlier 22.x would get `EBADENGINE`. node-gyp 12 needs `^20.17.0 || >=22.9.0` and has the same VS 2026 and Python support.

Both Windows jobs now share one configuration: `windows-latest`, `checkout@v4` / `setup-node@v4` on node 22, and `npm ci --foreground-scripts` so node-gyp's output is visible rather than swallowed. Removed: the `windows-2022` pin, the Python 3.11 pin and its `PYTHON` / `npm_config_python` overrides, and the setuptools step.

## Verification

Locally, `node-gyp configure` on `noobs@0.0.184` with node-gyp 12.4.0:

```
gyp info find Python using Python version 3.14.4 found at "...\python.exe"
gyp info find VS using VS2022 (17.14.37216.2) found at:
gyp info ok
```

It self-discovers Python **3.14** and configures cleanly — that's the distutils half proven on the same Python major the runner uses. The VS 2026 half can't be reproduced locally (this box has VS2022), but 12.4.0's `find-visualstudio.js` handles `versionYear` 2026 explicitly. `build_on_win` in this PR runs on the real `windows-2025-vs2026` image, so CI here is the actual test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q6bQoYc3seKV4L3tbmVjPs
