### PR TITLE
Fix search pagination crash on a bare /search visit

### DIFF
--- a/packages/shared/src/components/pages/SearchPage.tsx
+++ b/packages/shared/src/components/pages/SearchPage.tsx
@@ -46,12 +46,21 @@ export const SearchPage = () => {
   const searchParams = useSearchParams();
   const page = searchParams.get('page');
   const search = searchParams.get('search');
-  const pageNum = parseInt(page?.toString() || '0');
+  const parsedPage = parseInt(page?.toString() || '0');
+  const pageNum = Number.isFinite(parsedPage) && parsedPage > 0 ? parsedPage : 0;
 
   const filters = useMemo(() => {
-    return search ? (JSON.parse(base64url.decode(search as string)) as IPublicMatchesFilters) : DEFAULT_FILTERS;
+    if (!search) {
+      return DEFAULT_FILTERS;
+    }
+    try {
+      return { ...DEFAULT_FILTERS, ...(JSON.parse(base64url.decode(search)) as IPublicMatchesFilters) };
+    } catch {
+      return DEFAULT_FILTERS;
+    }
   }, [search]);
   const teamSize = filters.bracket === '2v2' ? 2 : 3;
+  const pageUrl = (targetPage: number) => `${pathname}?page=${targetPage}` + (search ? `&search=${search}` : '');
 
   useEffect(() => {
     logAnalyticsEvent('search', {
@@ -265,7 +274,7 @@ export const SearchPage = () => {
               <button
                 className="btn btn-outline btn-sm"
                 onClick={() => {
-                  router.push(`${pathname}?page=0&search=${search}`);
+                  router.push(pageUrl(0));
                 }}
               >
                 First
@@ -275,7 +284,7 @@ export const SearchPage = () => {
               <button
                 className="btn btn-outline btn-sm"
                 onClick={() => {
-                  router.push(`${pathname}?page=${pageNum - 1}&search=${search}`);
+                  router.push(pageUrl(pageNum - 1));
                 }}
               >
                 Previous
@@ -284,7 +293,7 @@ export const SearchPage = () => {
             <button
               className="btn btn-outline btn-sm"
               onClick={() => {
-                router.push(`${pathname}?page=${pageNum + 1}&search=${search}`);
+                router.push(pageUrl(pageNum + 1));
               }}
             >
               Next Page


### PR DESCRIPTION
## Problem

Navigating to https://wowarenalogs.com/search and clicking **NEXT PAGE** breaks the page:

```
Something went wrong
Unexpected token '', "e" is not valid JSON

    at JSON.parse (<anonymous>)
    at page-892250cc35382db1.js:1:630
    at Object.aq [as useMemo] (87c73c54-09e1ba5c70e60a51.js:1:59705)
```

## Cause

On a bare `/search` visit, `searchParams.get('search')` is `null`. The First / Previous / Next Page buttons interpolated it into the URL unconditionally:

```ts
router.push(`${pathname}?page=${pageNum + 1}&search=${search}`);  // → ?page=1&search=null
```

On the next render `base64url.decode("null")` decodes those four base64 chars to the bytes `9E E9 65` → `"\uFFFD\uFFFDe"`, and `JSON.parse` throws inside the filters `useMemo` — matching the reported string and stack frames exactly.

It only reproduces from a fresh `/search` load. Arriving via a filter change writes a real `search` param first, which hid the bug.

## Changes

- Add a `pageUrl(n)` helper that omits `&search=` when there is no search param; use it for all three pagination buttons.
- Guard the filters parse with `try/catch` falling back to `DEFAULT_FILTERS`, so a malformed or truncated share link renders the page instead of crashing it. The parsed result is spread over the defaults so a partial payload can't leave `team1SpecIds` undefined.
- Clamp `pageNum` to 0 on `NaN`/negative input — `?page=abc` previously sent `offset: NaN` to the GraphQL query.

## Testing

- `npx eslint packages/shared/src/components/pages/SearchPage.tsx` — clean
- `npx prettier --check` on the file — clean
- Decode verified locally: `base64url.decode('null')` → `"\uFFFD\uFFFDe"`, byte-for-byte the reported error.

Note: `tsc -p packages/shared` fails on a pre-existing project-references config error (`packages/parser` lacks `"composite": true`), unrelated to this change, so the file was not type-checked in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dom5QzWanh54uyA7joD6ey
