### PR TITLE
fix(parser): make resetParserStates actually reset the pipeline

### DIFF
--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -85,14 +85,16 @@ export class WoWCombatLogParser extends EventEmitter<LogParserSpec> {
 
   public resetParserStates(wowVersion: WowVersion | null = null): void {
     logTrace(`WoWCombatLogParser.resetParserStates ${wowVersion}`);
-    if (wowVersion === null) {
-      this.context = {
-        wowVersion,
-        pipeline: () => {
-          return;
-        },
-      };
-    } else {
+    // Drop the existing pipeline first: setWowVersion refuses to re-init one that exists, so
+    // without this the reset was a no-op and the old pipeline's buffered match survived.
+    this.context = {
+      wowVersion: null,
+      pipeline: () => {
+        return;
+      },
+    };
+
+    if (wowVersion !== null) {
       this.setWowVersion(wowVersion);
     }
   }

--- a/packages/parser/test/parser_reset_states.test.ts
+++ b/packages/parser/test/parser_reset_states.test.ts
@@ -1,0 +1,61 @@
+import fs from 'fs';
+import path from 'path';
+
+import { WoWCombatLogParser } from '../src';
+import { IArenaMatch, IMalformedCombatData } from '../src/CombatData';
+
+// The desktop app calls resetParserStates when it starts reading a new combat log file, which is
+// what happens after the game is closed mid-match and reopened. Whatever the pipeline had
+// buffered for the abandoned match has to go with it.
+describe('WoWCombatLogParser.resetParserStates', () => {
+  const readFixture = (name: string): string[] =>
+    fs
+      .readFileSync(path.join(__dirname, 'testlogs', name))
+      .toString()
+      .split('\n');
+
+  const parseWith = (feed: (parser: WoWCombatLogParser) => void) => {
+    const parser = new WoWCombatLogParser(null, 'America/New_York');
+    const combats: IArenaMatch[] = [];
+    const malformedCombats: IMalformedCombatData[] = [];
+
+    parser.on('arena_match_ended', (data) => combats.push(data));
+    parser.on('malformed_arena_match_detected', (data) => malformedCombats.push(data));
+
+    feed(parser);
+    parser.flush();
+
+    return { combats, malformedCombats };
+  };
+
+  it('should discard a match left half-parsed when the log file changes', () => {
+    const lines = readFixture('hunter_priest_match.txt');
+    // The game is closed partway through: no ARENA_MATCH_END, nothing to close the segment.
+    const abandoned = lines.slice(0, Math.floor(lines.length / 2));
+
+    const { combats, malformedCombats } = parseWith((parser) => {
+      abandoned.forEach((line) => parser.parseLine(line));
+
+      // What the app does on seeing a new combat log file.
+      parser.resetParserStates('retail');
+
+      lines.forEach((line) => parser.parseLine(line));
+    });
+
+    // Only the complete match is reported, and the abandoned half is not surfaced as a
+    // malformed match - it belonged to a log file we are no longer reading.
+    expect(combats).toHaveLength(1);
+    expect(malformedCombats).toHaveLength(0);
+  });
+
+  it('should leave the parser usable when it had no pipeline yet', () => {
+    const lines = readFixture('hunter_priest_match.txt');
+
+    const { combats } = parseWith((parser) => {
+      parser.resetParserStates('retail');
+      lines.forEach((line) => parser.parseLine(line));
+    });
+
+    expect(combats).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
### The bug

`resetParserStates` delegates to `setWowVersion`, which deliberately returns early when a pipeline already exists so a stray `COMBAT_LOG_VERSION` line mid-stream cannot re-init it. That guard also swallowed the explicit reset — for an already-initialized parser, `resetParserStates('retail')` did nothing at all.

### Why it matters

The desktop log watcher calls it on seeing a new combat log file:

```ts
// we are now reading a new combat log file, resetting states
bridge.logParser.resetParserStates(wowVersion);
```

which is what happens when the game is closed mid-match and reopened (alt-F4 in an arena writes no `ZONE_CHANGE` — the log simply stops, and the next session starts a new file). The old pipeline survived, so the abandoned match's buffered lines were still there and got emitted as a **malformed match** once the next `ARENA_MATCH_START` arrived — surfacing in the app as a broken match belonging to a log file it had stopped reading.

The added test reproduces exactly that. Without the fix it reports one `MalformedCombat`; with it, only the complete match.

### The fix

Clear the context before delegating, so `setWowVersion` builds a fresh pipeline while keeping its guard against accidental re-init from `parseLine`.

### Known limitation

This does not yet clear buffered solo shuffle rounds: `recentShuffleRoundsBuffer` and `recentScoreboardBuffer` in `pipeline/retail/segmentToCombat.ts` are module-level, so they outlive any pipeline. Making them per-pipeline is part of #505; once that lands this reset covers shuffles too. Deliberately not touched here to avoid conflicting with that PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)