### PR TITLE
Fix talent export desync on tiered nodes

### DIFF
--- a/packages/shared/src/components/CombatReport/CombatPlayers/talentStrings.ts
+++ b/packages/shared/src/components/CombatReport/CombatPlayers/talentStrings.ts
@@ -254,19 +254,26 @@ function writeLoadoutContent(
       continue;
     }
 
-    const talentSelection = talentsPicked.find((i) => i.id1 === treeNode?.id);
+    const talentSelections = talentsPicked.filter((i) => i.id1 === treeNode?.id);
+    const talentSelection = talentSelections[0];
     // debug missing nodes, should never happen (lol)
     // if (!talentSelection) {
     //   console.log(treeNode);
     // }
 
     const isNodeSelected = talentSelection !== undefined;
+    // Tiered nodes (e.g. Stormstream Totem) report one talentsPicked entry per rank set, so
+    // the total ranks set has to be summed across all of them rather than read off one.
+    const ranksPurchased =
+      treeNode.type === 'tiered' ? talentSelections.reduce((sum, t) => sum + t.count, 0) : talentSelection?.count;
 
-    const isPartiallyRanked = 'maxRanks' in treeNode && talentSelection && talentSelection.count < treeNode.maxRanks;
-    const isChoiceNode = treeNode?.type === 'choice' || treeNode?.type === 'subtree';
+    const isPartiallyRanked =
+      'maxRanks' in treeNode && ranksPurchased !== undefined && ranksPurchased < treeNode.maxRanks;
+    // Keyed on entries.length, not type: tiered nodes (e.g. Stormstream Totem) have >1 entry too
+    const isChoiceNode = (treeNode?.entries?.length ?? 0) > 1;
 
     if ('freeNode' in treeNode && treeNode.freeNode) {
-      // Granted/free nodes are "selected but not purchased" per the Blizzard export format
+      // Granted/free nodes are "selected but not set" per the Blizzard export format
       addValue(exportStream, 1, 1); // isNodeSelected = true
       addValue(exportStream, 1, 0); // isNodePurchased = false
       continue;
@@ -279,17 +286,29 @@ function writeLoadoutContent(
 
       addValue(exportStream, 1, isPartiallyRanked ? 1 : 0);
 
-      if (isPartiallyRanked) {
-        addValue(exportStream, bitWidthRanksPurchased, talentSelection.count);
+      if (isPartiallyRanked && ranksPurchased !== undefined) {
+        addValue(exportStream, bitWidthRanksPurchased, ranksPurchased);
       }
 
       addValue(exportStream, 1, isChoiceNode ? 1 : 0);
 
       if (isChoiceNode) {
-        const entryIndex = treeNode.entries.findIndex((t) => t.id === talentSelection?.id2); // GET ACTIVE ENTRY TODO
+        let entryIndex = treeNode.entries.findIndex((t) => t.id === talentSelection?.id2); // GET ACTIVE ENTRY TODO
         // console.log('choice index', entryIndex);
-        if (entryIndex <= 0 || entryIndex > 4) {
-          // error("Error exporting tree node " .. treeNode.ID .. ". The active choice node entry index (" .. entryIndex .. ") is out of bounds. ");
+
+        // Tiered nodes don't report id2 as an entry id - derive the active entry from cumulative rank thresholds instead
+        if (entryIndex === -1 && treeNode.type === 'tiered' && ranksPurchased !== undefined) {
+          let cumulativeRanks = 0;
+          entryIndex = treeNode.entries.findIndex((entry) => {
+            cumulativeRanks += 'maxRanks' in entry ? entry.maxRanks : 1;
+            return ranksPurchased <= cumulativeRanks;
+          });
+        }
+
+        if (entryIndex < 0 || entryIndex > 3) {
+          throw new Error(
+            `Error exporting tree node ${treeNode.id}. The active choice node entry index (${entryIndex}) is out of bounds.`,
+          );
         }
         //-- store entry index as zero-index
         addValue(exportStream, 2, entryIndex);

--- a/packages/shared/src/data/talentIdMap.json
+++ b/packages/shared/src/data/talentIdMap.json
@@ -1029,7 +1029,7 @@
         "type": "single",
         "posX": 2100,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           82237,
@@ -1059,7 +1059,7 @@
         "type": "single",
         "posX": 2700,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -1084,7 +1084,7 @@
         "type": "single",
         "posX": 3300,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -1109,7 +1109,7 @@
         "type": "single",
         "posX": 3900,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "next": [
           82230,
@@ -1138,7 +1138,7 @@
         "type": "single",
         "posX": 4500,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -1163,7 +1163,7 @@
         "type": "choice",
         "posX": 5100,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -1198,7 +1198,7 @@
         "type": "single",
         "posX": 5700,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           100173,
@@ -1228,7 +1228,7 @@
         "type": "choice",
         "posX": 1500,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -1263,7 +1263,7 @@
         "type": "single",
         "posX": 2700,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -1288,7 +1288,7 @@
         "type": "single",
         "posX": 3300,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           82231
@@ -1315,7 +1315,7 @@
         "type": "choice",
         "posX": 3900,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           82231
@@ -1352,7 +1352,7 @@
         "type": "single",
         "posX": 4500,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           82231
@@ -1379,7 +1379,7 @@
         "type": "single",
         "posX": 5100,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -1404,7 +1404,7 @@
         "type": "single",
         "posX": 6300,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "next": [],
         "prev": [
@@ -1429,7 +1429,7 @@
         "type": "single",
         "posX": 2100,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -1454,7 +1454,7 @@
         "type": "single",
         "posX": 3900,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -1481,7 +1481,7 @@
         "type": "single",
         "posX": 5700,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -2134,7 +2134,7 @@
       },
       {
         "id": 88216,
-        "name": "Astral Communion",
+        "name": "Sculpt the Stars",
         "type": "single",
         "posX": 12300,
         "posY": 5100,
@@ -2153,9 +2153,9 @@
             "definitionId": 114855,
             "maxRanks": 1,
             "type": "passive",
-            "name": "Astral Communion",
-            "spellId": 450598,
-            "icon": "talentspec_druid_balance",
+            "name": "Sculpt the Stars",
+            "spellId": 1240188,
+            "icon": "ability_druid_eclipseorange",
             "index": 0
           }
         ]
@@ -2218,7 +2218,7 @@
       },
       {
         "id": 88220,
-        "name": "Sculpt the Stars",
+        "name": "Astral Communion",
         "type": "single",
         "posX": 10500,
         "posY": 5700,
@@ -2237,9 +2237,9 @@
             "definitionId": 122112,
             "maxRanks": 1,
             "type": "passive",
-            "name": "Sculpt the Stars",
-            "spellId": 1240188,
-            "icon": "ability_druid_eclipseorange",
+            "name": "Astral Communion",
+            "spellId": 450598,
+            "icon": "talentspec_druid_balance",
             "index": 0
           }
         ]
@@ -2613,6 +2613,64 @@
             "index": 100
           }
         ]
+      },
+      {
+        "id": 110421,
+        "name": "Ascendant Eclipses / Ascendant Eclipses / Ascendant Eclipses",
+        "type": "tiered",
+        "posX": 12300,
+        "posY": 7650,
+        "reqPoints": 20,
+        "maxRanks": 4,
+        "rankLevels": [
+          {
+            "level": 81,
+            "maxRanks": 1
+          },
+          {
+            "level": 84,
+            "maxRanks": 3
+          },
+          {
+            "level": 90,
+            "maxRanks": 4
+          }
+        ],
+        "entryNode": true,
+        "next": [],
+        "prev": [],
+        "entries": [
+          {
+            "id": 137031,
+            "definitionId": 141794,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Ascendant Eclipses",
+            "spellId": 1261564,
+            "icon": "inv12_apextalent_druid_ascendanceeclipses",
+            "index": 0
+          },
+          {
+            "id": 137030,
+            "definitionId": 141793,
+            "maxRanks": 2,
+            "type": "tierrank",
+            "name": "Ascendant Eclipses",
+            "spellId": 1261565,
+            "icon": "inv12_apextalent_druid_ascendanceeclipses",
+            "index": 100
+          },
+          {
+            "id": 137029,
+            "definitionId": 141792,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Ascendant Eclipses",
+            "spellId": 1261566,
+            "icon": "inv12_apextalent_druid_ascendanceeclipses",
+            "index": 200
+          }
+        ]
       }
     ],
     "heroNodes": [
@@ -2645,7 +2703,8 @@
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 94598,
@@ -3061,7 +3120,8 @@
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 94599,
@@ -3798,7 +3858,12 @@
       109721,
       109722,
       109723,
-      110279
+      110279,
+      110421,
+      110424,
+      110426,
+      110431,
+      110694
     ]
   },
   {
@@ -4831,7 +4896,7 @@
         "type": "single",
         "posX": 2100,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           82237,
@@ -4861,7 +4926,7 @@
         "type": "single",
         "posX": 2700,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -4886,7 +4951,7 @@
         "type": "single",
         "posX": 3300,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -4911,7 +4976,7 @@
         "type": "single",
         "posX": 3900,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "next": [
           82230,
@@ -4940,7 +5005,7 @@
         "type": "single",
         "posX": 4500,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -4965,7 +5030,7 @@
         "type": "choice",
         "posX": 5100,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -5000,7 +5065,7 @@
         "type": "single",
         "posX": 5700,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           100173,
@@ -5030,7 +5095,7 @@
         "type": "choice",
         "posX": 1500,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -5065,7 +5130,7 @@
         "type": "single",
         "posX": 2700,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -5090,7 +5155,7 @@
         "type": "single",
         "posX": 3300,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           82231
@@ -5117,7 +5182,7 @@
         "type": "choice",
         "posX": 3900,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           82231
@@ -5154,7 +5219,7 @@
         "type": "single",
         "posX": 4500,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           82231
@@ -5181,7 +5246,7 @@
         "type": "single",
         "posX": 5100,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -5206,7 +5271,7 @@
         "type": "single",
         "posX": 6300,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "next": [],
         "prev": [
@@ -5231,7 +5296,7 @@
         "type": "single",
         "posX": 2100,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -5256,7 +5321,7 @@
         "type": "single",
         "posX": 3900,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -5283,7 +5348,7 @@
         "type": "single",
         "posX": 5700,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -5413,7 +5478,7 @@
       },
       {
         "id": 82098,
-        "name": "Merciless Claws",
+        "name": "Rampant Ferocity",
         "type": "single",
         "posX": 11100,
         "posY": 2700,
@@ -5430,9 +5495,9 @@
             "definitionId": 108164,
             "maxRanks": 1,
             "type": "passive",
-            "name": "Merciless Claws",
-            "spellId": 231063,
-            "icon": "inv_misc_monsterclaw_03",
+            "name": "Rampant Ferocity",
+            "spellId": 391709,
+            "icon": "ability_druid_primaltenacity",
             "index": 100
           }
         ]
@@ -5775,7 +5840,7 @@
       },
       {
         "id": 82103,
-        "name": "Panther's Guile",
+        "name": "Merciless Claws",
         "type": "single",
         "posX": 12900,
         "posY": 4500,
@@ -5793,16 +5858,16 @@
             "definitionId": 108169,
             "maxRanks": 1,
             "type": "passive",
-            "name": "Panther's Guile",
-            "spellId": 1280316,
-            "icon": "ability_mount_blackpanther",
+            "name": "Merciless Claws",
+            "spellId": 231063,
+            "icon": "inv_misc_monsterclaw_03",
             "index": 100
           }
         ]
       },
       {
         "id": 82117,
-        "name": "Rampant Ferocity",
+        "name": "Panther's Guile",
         "type": "single",
         "posX": 13500,
         "posY": 4500,
@@ -5822,9 +5887,9 @@
             "definitionId": 108186,
             "maxRanks": 1,
             "type": "passive",
-            "name": "Rampant Ferocity",
-            "spellId": 391709,
-            "icon": "ability_druid_primaltenacity",
+            "name": "Panther's Guile",
+            "spellId": 1280316,
+            "icon": "ability_mount_blackpanther",
             "index": 100
           }
         ]
@@ -6409,6 +6474,64 @@
             "index": 100
           }
         ]
+      },
+      {
+        "id": 110426,
+        "name": "Unseen Predator / Unseen Predator / Unseen Predator",
+        "type": "tiered",
+        "posX": 12300,
+        "posY": 7650,
+        "reqPoints": 20,
+        "maxRanks": 4,
+        "rankLevels": [
+          {
+            "level": 81,
+            "maxRanks": 1
+          },
+          {
+            "level": 84,
+            "maxRanks": 3
+          },
+          {
+            "level": 90,
+            "maxRanks": 4
+          }
+        ],
+        "entryNode": true,
+        "next": [],
+        "prev": [],
+        "entries": [
+          {
+            "id": 137046,
+            "definitionId": 141809,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Unseen Predator",
+            "spellId": 1263657,
+            "icon": "inv12_apextalent_druid_unseenpredator",
+            "index": 100
+          },
+          {
+            "id": 137045,
+            "definitionId": 141808,
+            "maxRanks": 2,
+            "type": "tierrank",
+            "name": "Unseen Predator",
+            "spellId": 1263658,
+            "icon": "inv12_apextalent_druid_unseenpredator",
+            "index": 200
+          },
+          {
+            "id": 137044,
+            "definitionId": 141807,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Unseen Predator",
+            "spellId": 1263660,
+            "icon": "inv12_apextalent_druid_unseenpredator",
+            "index": 300
+          }
+        ]
       }
     ],
     "heroNodes": [
@@ -6440,7 +6563,8 @@
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 94629,
@@ -6862,7 +6986,8 @@
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 94618,
@@ -7587,7 +7712,12 @@
       109721,
       109722,
       109723,
-      110279
+      110279,
+      110421,
+      110424,
+      110426,
+      110431,
+      110694
     ]
   },
   {
@@ -8620,7 +8750,7 @@
         "type": "single",
         "posX": 2100,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           82237,
@@ -8650,7 +8780,7 @@
         "type": "single",
         "posX": 2700,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -8675,7 +8805,7 @@
         "type": "single",
         "posX": 3300,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -8700,7 +8830,7 @@
         "type": "single",
         "posX": 3900,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "next": [
           82230,
@@ -8729,7 +8859,7 @@
         "type": "single",
         "posX": 4500,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -8754,7 +8884,7 @@
         "type": "choice",
         "posX": 5100,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -8789,7 +8919,7 @@
         "type": "single",
         "posX": 5700,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           100173,
@@ -8819,7 +8949,7 @@
         "type": "choice",
         "posX": 1500,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -8854,7 +8984,7 @@
         "type": "single",
         "posX": 2700,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -8879,7 +9009,7 @@
         "type": "single",
         "posX": 3300,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           82231
@@ -8906,7 +9036,7 @@
         "type": "choice",
         "posX": 3900,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           82231
@@ -8943,7 +9073,7 @@
         "type": "single",
         "posX": 4500,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           82231
@@ -8970,7 +9100,7 @@
         "type": "single",
         "posX": 5100,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -8995,7 +9125,7 @@
         "type": "single",
         "posX": 6300,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "next": [],
         "prev": [
@@ -9020,7 +9150,7 @@
         "type": "single",
         "posX": 2100,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -9045,7 +9175,7 @@
         "type": "single",
         "posX": 3900,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -9072,7 +9202,7 @@
         "type": "single",
         "posX": 5700,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -10266,6 +10396,64 @@
             "index": 0
           }
         ]
+      },
+      {
+        "id": 110431,
+        "name": "Wild Guardian / Wild Guardian / Wild Guardian",
+        "type": "tiered",
+        "posX": 12300,
+        "posY": 7650,
+        "reqPoints": 20,
+        "maxRanks": 4,
+        "rankLevels": [
+          {
+            "level": 81,
+            "maxRanks": 1
+          },
+          {
+            "level": 84,
+            "maxRanks": 3
+          },
+          {
+            "level": 90,
+            "maxRanks": 4
+          }
+        ],
+        "entryNode": true,
+        "next": [],
+        "prev": [],
+        "entries": [
+          {
+            "id": 137061,
+            "definitionId": 141824,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Wild Guardian",
+            "spellId": 1269614,
+            "icon": "inv12_apextalent_druid_wildguardian",
+            "index": 0
+          },
+          {
+            "id": 137060,
+            "definitionId": 141823,
+            "maxRanks": 2,
+            "type": "tierrank",
+            "name": "Wild Guardian",
+            "spellId": 1269617,
+            "icon": "inv12_apextalent_druid_wildguardian",
+            "index": 100
+          },
+          {
+            "id": 137059,
+            "definitionId": 141822,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Wild Guardian",
+            "spellId": 1269619,
+            "icon": "inv12_apextalent_druid_wildguardian",
+            "index": 200
+          }
+        ]
       }
     ],
     "heroNodes": [
@@ -10298,7 +10486,8 @@
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 94598,
@@ -10713,7 +10902,8 @@
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 94618,
@@ -11438,7 +11628,12 @@
       109721,
       109722,
       109723,
-      110279
+      110279,
+      110421,
+      110424,
+      110426,
+      110431,
+      110694
     ]
   },
   {
@@ -12445,7 +12640,7 @@
         "type": "single",
         "posX": 2100,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           82237,
@@ -12475,7 +12670,7 @@
         "type": "single",
         "posX": 2700,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -12500,7 +12695,7 @@
         "type": "single",
         "posX": 3300,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -12525,7 +12720,7 @@
         "type": "single",
         "posX": 3900,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "next": [
           82230,
@@ -12554,7 +12749,7 @@
         "type": "single",
         "posX": 4500,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -12579,7 +12774,7 @@
         "type": "choice",
         "posX": 5100,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -12614,7 +12809,7 @@
         "type": "single",
         "posX": 5700,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           100173,
@@ -12644,7 +12839,7 @@
         "type": "choice",
         "posX": 1500,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -12679,7 +12874,7 @@
         "type": "single",
         "posX": 2700,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -12704,7 +12899,7 @@
         "type": "single",
         "posX": 3300,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           82231
@@ -12731,7 +12926,7 @@
         "type": "choice",
         "posX": 3900,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           82231
@@ -12768,7 +12963,7 @@
         "type": "single",
         "posX": 4500,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           82231
@@ -12795,7 +12990,7 @@
         "type": "single",
         "posX": 5100,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -12820,7 +13015,7 @@
         "type": "single",
         "posX": 6300,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "next": [],
         "prev": [
@@ -12845,7 +13040,7 @@
         "type": "single",
         "posX": 2100,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -12870,7 +13065,7 @@
         "type": "single",
         "posX": 3900,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -12897,7 +13092,7 @@
         "type": "single",
         "posX": 5700,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -13039,30 +13234,30 @@
         ],
         "entries": [
           {
-            "id": 103137,
-            "definitionId": 108142,
+            "id": 137508,
+            "definitionId": 142268,
             "maxRanks": 1,
             "type": "passive",
             "name": "Verdant Infusion",
             "spellId": 392410,
             "icon": "inv_relics_totemoflife",
-            "index": 100
+            "index": 300
           },
           {
-            "id": 103136,
-            "definitionId": 108141,
+            "id": 137507,
+            "definitionId": 142267,
             "maxRanks": 1,
             "type": "passive",
             "name": "Prosperity",
             "spellId": 200383,
             "icon": "ability_druid_giftoftheearthmother",
-            "index": 200
+            "index": 400
           }
         ]
       },
       {
         "id": 82051,
-        "name": "Nature's Splendor / Passing Seasons",
+        "name": "Overgrowth / Passing Seasons",
         "type": "choice",
         "posX": 12300,
         "posY": 2700,
@@ -13080,9 +13275,9 @@
             "definitionId": 108108,
             "maxRanks": 1,
             "type": "passive",
-            "name": "Nature's Splendor",
-            "spellId": 392288,
-            "icon": "spell_nature_spiritarmor",
+            "name": "Overgrowth",
+            "spellId": 203651,
+            "icon": "ability_druid_overgrowth",
             "index": 100
           },
           {
@@ -13270,7 +13465,7 @@
       },
       {
         "id": 82059,
-        "name": "Verdancy",
+        "name": "Germination",
         "type": "single",
         "posX": 10500,
         "posY": 4500,
@@ -13290,9 +13485,9 @@
             "definitionId": 108118,
             "maxRanks": 1,
             "type": "passive",
-            "name": "Verdancy",
-            "spellId": 392325,
-            "icon": "inv_10_herb_seed_magiccolor5",
+            "name": "Germination",
+            "spellId": 155675,
+            "icon": "spell_druid_germination",
             "index": 100
           }
         ]
@@ -13355,8 +13550,8 @@
       },
       {
         "id": 82053,
-        "name": "Inner Peace / Flourish",
-        "type": "choice",
+        "name": "Flourish",
+        "type": "single",
         "posX": 12300,
         "posY": 4500,
         "reqPoints": 8,
@@ -13368,16 +13563,6 @@
           82054
         ],
         "entries": [
-          {
-            "id": 103107,
-            "definitionId": 108112,
-            "maxRanks": 1,
-            "type": "passive",
-            "name": "Inner Peace",
-            "spellId": 197073,
-            "icon": "ability_druid_dreamstate",
-            "index": 200
-          },
           {
             "id": 103106,
             "definitionId": 108111,
@@ -13392,7 +13577,7 @@
       },
       {
         "id": 82056,
-        "name": "Cultivation",
+        "name": "Flash of Clarity",
         "type": "single",
         "posX": 12900,
         "posY": 4500,
@@ -13400,6 +13585,7 @@
         "maxRanks": 1,
         "next": [
           82065,
+          110694,
           82080
         ],
         "prev": [
@@ -13411,9 +13597,9 @@
             "definitionId": 108115,
             "maxRanks": 1,
             "type": "passive",
-            "name": "Cultivation",
-            "spellId": 200390,
-            "icon": "spell_nature_healingtouch",
+            "name": "Flash of Clarity",
+            "spellId": 392220,
+            "icon": "spell_nature_crystalball",
             "index": 100
           }
         ]
@@ -13627,6 +13813,33 @@
         ]
       },
       {
+        "id": 110694,
+        "name": "Cultivation",
+        "type": "single",
+        "posX": 12900,
+        "posY": 5100,
+        "reqPoints": 8,
+        "maxRanks": 2,
+        "next": [
+          82067
+        ],
+        "prev": [
+          82056
+        ],
+        "entries": [
+          {
+            "id": 137510,
+            "definitionId": 142270,
+            "maxRanks": 2,
+            "type": "passive",
+            "name": "Cultivation",
+            "spellId": 200390,
+            "icon": "spell_nature_healingtouch",
+            "index": 100
+          }
+        ]
+      },
+      {
         "id": 82080,
         "name": "Unstoppable Growth",
         "type": "single",
@@ -13798,7 +14011,8 @@
         ],
         "prev": [
           82080,
-          82065
+          82065,
+          110694
         ],
         "entries": [
           {
@@ -14188,7 +14402,7 @@
       },
       {
         "id": 82071,
-        "name": "Germination",
+        "name": "Verdancy",
         "type": "single",
         "posX": 14100,
         "posY": 6900,
@@ -14206,10 +14420,68 @@
             "definitionId": 108132,
             "maxRanks": 1,
             "type": "passive",
-            "name": "Germination",
-            "spellId": 155675,
-            "icon": "spell_druid_germination",
+            "name": "Verdancy",
+            "spellId": 392325,
+            "icon": "inv_10_herb_seed_magiccolor5",
             "index": 100
+          }
+        ]
+      },
+      {
+        "id": 110424,
+        "name": "Everbloom / Everbloom / Everbloom",
+        "type": "tiered",
+        "posX": 12300,
+        "posY": 7650,
+        "reqPoints": 20,
+        "maxRanks": 4,
+        "rankLevels": [
+          {
+            "level": 81,
+            "maxRanks": 1
+          },
+          {
+            "level": 84,
+            "maxRanks": 3
+          },
+          {
+            "level": 90,
+            "maxRanks": 4
+          }
+        ],
+        "entryNode": true,
+        "next": [],
+        "prev": [],
+        "entries": [
+          {
+            "id": 137040,
+            "definitionId": 141803,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Everbloom",
+            "spellId": 392167,
+            "icon": "inv12_apextalent_druid_everbloom",
+            "index": 100
+          },
+          {
+            "id": 137039,
+            "definitionId": 141802,
+            "maxRanks": 2,
+            "type": "tierrank",
+            "name": "Everbloom",
+            "spellId": 1244331,
+            "icon": "inv12_apextalent_druid_everbloom",
+            "index": 200
+          },
+          {
+            "id": 137038,
+            "definitionId": 141801,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Everbloom",
+            "spellId": 1244470,
+            "icon": "inv12_apextalent_druid_everbloom",
+            "index": 300
           }
         ]
       }
@@ -14243,7 +14515,8 @@
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 94629,
@@ -14666,7 +14939,8 @@
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 94599,
@@ -15403,7 +15677,12 @@
       109721,
       109722,
       109723,
-      110279
+      110279,
+      110421,
+      110424,
+      110426,
+      110431,
+      110694
     ]
   },
   {
@@ -16283,7 +16562,7 @@
         "type": "single",
         "posX": 2100,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           110065,
@@ -16311,7 +16590,7 @@
         "type": "single",
         "posX": 2700,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           93343
@@ -16338,7 +16617,7 @@
         "type": "single",
         "posX": 3300,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           93343,
@@ -16369,7 +16648,7 @@
         "type": "single",
         "posX": 3900,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           93352
@@ -16396,7 +16675,7 @@
         "type": "single",
         "posX": 4500,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           93352,
@@ -16426,7 +16705,7 @@
         "type": "single",
         "posX": 5100,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "next": [
           93346
@@ -16453,7 +16732,7 @@
         "type": "single",
         "posX": 5700,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           93715
@@ -16480,7 +16759,7 @@
         "type": "single",
         "posX": 2100,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           93342
@@ -16507,7 +16786,7 @@
         "type": "single",
         "posX": 2700,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           93342
@@ -16536,7 +16815,7 @@
         "type": "single",
         "posX": 3300,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -16561,7 +16840,7 @@
         "type": "single",
         "posX": 3900,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           93351
@@ -16590,7 +16869,7 @@
         "type": "single",
         "posX": 4500,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           93346
@@ -16617,7 +16896,7 @@
         "type": "single",
         "posX": 5700,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           93346
@@ -16644,7 +16923,7 @@
         "type": "single",
         "posX": 2700,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -16670,7 +16949,7 @@
         "type": "choice",
         "posX": 3900,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -16705,7 +16984,7 @@
         "type": "single",
         "posX": 5100,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -17782,6 +18061,64 @@
             "index": 100
           }
         ]
+      },
+      {
+        "id": 110414,
+        "name": "Rising Fury / Rising Fury / Rising Fury",
+        "type": "tiered",
+        "posX": 12300,
+        "posY": 7650,
+        "reqPoints": 20,
+        "maxRanks": 4,
+        "rankLevels": [
+          {
+            "level": 81,
+            "maxRanks": 1
+          },
+          {
+            "level": 84,
+            "maxRanks": 3
+          },
+          {
+            "level": 90,
+            "maxRanks": 4
+          }
+        ],
+        "entryNode": true,
+        "next": [],
+        "prev": [],
+        "entries": [
+          {
+            "id": 137010,
+            "definitionId": 141773,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Rising Fury",
+            "spellId": 1271687,
+            "icon": "inv12_apextalent_evoker_risingfury",
+            "index": 100
+          },
+          {
+            "id": 137009,
+            "definitionId": 141772,
+            "maxRanks": 2,
+            "type": "tierrank",
+            "name": "Rising Fury",
+            "spellId": 1271796,
+            "icon": "inv12_apextalent_evoker_risingfury",
+            "index": 200
+          },
+          {
+            "id": 137008,
+            "definitionId": 141771,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Rising Fury",
+            "spellId": 1271788,
+            "icon": "inv12_apextalent_evoker_risingfury",
+            "index": 300
+          }
+        ]
       }
     ],
     "heroNodes": [
@@ -17809,11 +18146,12 @@
             "type": "passive",
             "name": "Mass Disintegrate",
             "spellId": 436335,
-            "icon": "ability_evoker_dragonrage2_blue",
+            "icon": "inv_1205_ability_evoker_massdisintegration",
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 94950,
@@ -17843,7 +18181,8 @@
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 94952,
@@ -17857,8 +18196,7 @@
           94921
         ],
         "prev": [
-          94939,
-          98931
+          94939
         ],
         "entries": [
           {
@@ -17885,8 +18223,7 @@
           94953
         ],
         "prev": [
-          94939,
-          98931
+          94939
         ],
         "entries": [
           {
@@ -17913,8 +18250,7 @@
           94934
         ],
         "prev": [
-          94939,
-          98931
+          94939
         ],
         "entries": [
           {
@@ -17941,7 +18277,6 @@
           109794
         ],
         "prev": [
-          98931,
           94939
         ],
         "entries": [
@@ -18893,7 +19228,10 @@
       109797,
       109798,
       110064,
-      110065
+      110065,
+      110413,
+      110414,
+      110415
     ]
   },
   {
@@ -19773,7 +20111,7 @@
         "type": "single",
         "posX": 2100,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           110065,
@@ -19801,7 +20139,7 @@
         "type": "single",
         "posX": 2700,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           93343
@@ -19828,7 +20166,7 @@
         "type": "single",
         "posX": 3300,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           93343,
@@ -19859,7 +20197,7 @@
         "type": "single",
         "posX": 3900,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           93352
@@ -19886,7 +20224,7 @@
         "type": "single",
         "posX": 4500,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           93352,
@@ -19916,7 +20254,7 @@
         "type": "single",
         "posX": 5100,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "next": [
           93346
@@ -19943,7 +20281,7 @@
         "type": "single",
         "posX": 5700,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           93715
@@ -19970,7 +20308,7 @@
         "type": "single",
         "posX": 2100,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           93342
@@ -19997,7 +20335,7 @@
         "type": "single",
         "posX": 2700,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           93342
@@ -20026,7 +20364,7 @@
         "type": "single",
         "posX": 3300,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -20051,7 +20389,7 @@
         "type": "single",
         "posX": 3900,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           93351
@@ -20080,7 +20418,7 @@
         "type": "single",
         "posX": 4500,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           93346
@@ -20107,7 +20445,7 @@
         "type": "single",
         "posX": 5700,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           93346
@@ -20134,7 +20472,7 @@
         "type": "single",
         "posX": 2700,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -20160,7 +20498,7 @@
         "type": "choice",
         "posX": 3900,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -20195,7 +20533,7 @@
         "type": "single",
         "posX": 5100,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -20823,7 +21161,7 @@
       },
       {
         "id": 93258,
-        "name": "Resonating Sphere / Nozdormu's Teachings",
+        "name": "Temporal Barrier / Nozdormu's Teachings",
         "type": "choice",
         "posX": 14100,
         "posY": 4500,
@@ -20841,8 +21179,8 @@
             "definitionId": 120575,
             "maxRanks": 1,
             "type": "passive",
-            "name": "Resonating Sphere",
-            "spellId": 376236,
+            "name": "Temporal Barrier",
+            "spellId": 1291636,
             "icon": "ability_evoker_bronze_01",
             "index": 100
           },
@@ -21375,6 +21713,64 @@
             "index": 200
           }
         ]
+      },
+      {
+        "id": 110413,
+        "name": "Merithra's Blessing / Merithra's Blessing / Merithra's Blessing",
+        "type": "tiered",
+        "posX": 12300,
+        "posY": 7650,
+        "reqPoints": 20,
+        "maxRanks": 4,
+        "rankLevels": [
+          {
+            "level": 81,
+            "maxRanks": 1
+          },
+          {
+            "level": 84,
+            "maxRanks": 3
+          },
+          {
+            "level": 90,
+            "maxRanks": 4
+          }
+        ],
+        "entryNode": true,
+        "next": [],
+        "prev": [],
+        "entries": [
+          {
+            "id": 137007,
+            "definitionId": 141770,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Merithra's Blessing",
+            "spellId": 1256577,
+            "icon": "inv12_apextalent_evoker_merithrasblessing",
+            "index": 200
+          },
+          {
+            "id": 137006,
+            "definitionId": 141769,
+            "maxRanks": 2,
+            "type": "tierrank",
+            "name": "Merithra's Blessing",
+            "spellId": 1256682,
+            "icon": "ability_evoker_reversion_green",
+            "index": 300
+          },
+          {
+            "id": 137005,
+            "definitionId": 141768,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Merithra's Blessing",
+            "spellId": 1256689,
+            "icon": "ability_evoker_giftoftheaspects",
+            "index": 400
+          }
+        ]
       }
     ],
     "heroNodes": [
@@ -21406,7 +21802,8 @@
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 94937,
@@ -21818,7 +22215,8 @@
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 94948,
@@ -21996,7 +22394,7 @@
       },
       {
         "id": 109509,
-        "name": "Energy Cycles",
+        "name": "Chronal Dynamo",
         "type": "single",
         "posX": 8100,
         "posY": 5400,
@@ -22015,9 +22413,9 @@
             "definitionId": 140497,
             "maxRanks": 1,
             "type": "passive",
-            "name": "Energy Cycles",
-            "spellId": 1260568,
-            "icon": "ability_evoker_innatemagic4",
+            "name": "Chronal Dynamo",
+            "spellId": 1291522,
+            "icon": "inv_10_dungeonjewelry_dragon_trinket_1arcanemagical_red",
             "index": 100
           }
         ]
@@ -22475,7 +22873,10 @@
       109797,
       109798,
       110064,
-      110065
+      110065,
+      110413,
+      110414,
+      110415
     ]
   },
   {
@@ -23355,7 +23756,7 @@
         "type": "single",
         "posX": 2100,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           110065,
@@ -23383,7 +23784,7 @@
         "type": "single",
         "posX": 2700,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           93343
@@ -23410,7 +23811,7 @@
         "type": "single",
         "posX": 3300,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           93343,
@@ -23441,7 +23842,7 @@
         "type": "single",
         "posX": 3900,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           93352
@@ -23468,7 +23869,7 @@
         "type": "single",
         "posX": 4500,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           93352,
@@ -23498,7 +23899,7 @@
         "type": "single",
         "posX": 5100,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "next": [
           93346
@@ -23525,7 +23926,7 @@
         "type": "single",
         "posX": 5700,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           93715
@@ -23552,7 +23953,7 @@
         "type": "single",
         "posX": 2100,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           93342
@@ -23579,7 +23980,7 @@
         "type": "single",
         "posX": 2700,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           93342
@@ -23608,7 +24009,7 @@
         "type": "single",
         "posX": 3300,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -23633,7 +24034,7 @@
         "type": "single",
         "posX": 3900,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           93351
@@ -23662,7 +24063,7 @@
         "type": "single",
         "posX": 4500,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           93346
@@ -23689,7 +24090,7 @@
         "type": "single",
         "posX": 5700,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           93346
@@ -23716,7 +24117,7 @@
         "type": "single",
         "posX": 2700,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -23742,7 +24143,7 @@
         "type": "choice",
         "posX": 3900,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -23777,7 +24178,7 @@
         "type": "single",
         "posX": 5100,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -24451,7 +24852,7 @@
             "type": "passive",
             "name": "Regenerative Chitin",
             "spellId": 406907,
-            "icon": "inv_tradeskill_skinning_prismaticscale",
+            "icon": "inv12_ability_evoker_blisteringscalesinfinite",
             "index": 100
           },
           {
@@ -25035,7 +25436,7 @@
       },
       {
         "id": 102249,
-        "name": "Molten Embers",
+        "name": "Mighty Inferno",
         "type": "single",
         "posX": 14100,
         "posY": 6900,
@@ -25051,10 +25452,68 @@
             "definitionId": 131131,
             "maxRanks": 1,
             "type": "passive",
-            "name": "Molten Embers",
-            "spellId": 459725,
-            "icon": "ability_evoker_earthensky",
+            "name": "Mighty Inferno",
+            "spellId": 1291457,
+            "icon": "ability_warlock_burningembers",
             "index": 100
+          }
+        ]
+      },
+      {
+        "id": 110415,
+        "name": "Duplicate / Duplicate / Duplicate",
+        "type": "tiered",
+        "posX": 12300,
+        "posY": 7650,
+        "reqPoints": 20,
+        "maxRanks": 4,
+        "rankLevels": [
+          {
+            "level": 81,
+            "maxRanks": 1
+          },
+          {
+            "level": 84,
+            "maxRanks": 3
+          },
+          {
+            "level": 90,
+            "maxRanks": 4
+          }
+        ],
+        "entryNode": true,
+        "next": [],
+        "prev": [],
+        "entries": [
+          {
+            "id": 137013,
+            "definitionId": 141776,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Duplicate",
+            "spellId": 1259173,
+            "icon": "inv12_apextalent_evoker_duplicate",
+            "index": 100
+          },
+          {
+            "id": 137012,
+            "definitionId": 141775,
+            "maxRanks": 2,
+            "type": "tierrank",
+            "name": "Duplicate",
+            "spellId": 1259174,
+            "icon": "ability_evoker_masterytimewalker",
+            "index": 200
+          },
+          {
+            "id": 137011,
+            "definitionId": 141774,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Duplicate",
+            "spellId": 1259175,
+            "icon": "ability_evoker_ouroboros",
+            "index": 300
           }
         ]
       }
@@ -25088,7 +25547,8 @@
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 94952,
@@ -25102,7 +25562,6 @@
           94921
         ],
         "prev": [
-          94939,
           98931
         ],
         "entries": [
@@ -25130,7 +25589,6 @@
           94953
         ],
         "prev": [
-          94939,
           98931
         ],
         "entries": [
@@ -25158,7 +25616,6 @@
           94934
         ],
         "prev": [
-          94939,
           98931
         ],
         "entries": [
@@ -25186,8 +25643,7 @@
           109794
         ],
         "prev": [
-          98931,
-          94939
+          98931
         ],
         "entries": [
           {
@@ -25504,7 +25960,8 @@
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 94948,
@@ -25682,7 +26139,7 @@
       },
       {
         "id": 109509,
-        "name": "Energy Cycles",
+        "name": "Chronal Dynamo",
         "type": "single",
         "posX": 8100,
         "posY": 5400,
@@ -25701,9 +26158,9 @@
             "definitionId": 140497,
             "maxRanks": 1,
             "type": "passive",
-            "name": "Energy Cycles",
-            "spellId": 1260568,
-            "icon": "ability_evoker_innatemagic4",
+            "name": "Chronal Dynamo",
+            "spellId": 1291522,
+            "icon": "inv_10_dungeonjewelry_dragon_trinket_1arcanemagical_red",
             "index": 100
           }
         ]
@@ -26162,7 +26619,10 @@
       109797,
       109798,
       110064,
-      110065
+      110065,
+      110413,
+      110414,
+      110415
     ]
   },
   {
@@ -26647,7 +27107,7 @@
       },
       {
         "id": 82687,
-        "name": "Strength of Soul",
+        "name": "Strength of Resolve",
         "type": "single",
         "posX": 5100,
         "posY": 3300,
@@ -26666,7 +27126,7 @@
             "definitionId": 108842,
             "maxRanks": 1,
             "type": "passive",
-            "name": "Strength of Soul",
+            "name": "Strength of Resolve",
             "spellId": 1250820,
             "icon": "spell_holy_ashestoashes",
             "index": 100
@@ -26918,7 +27378,7 @@
       },
       {
         "id": 82693,
-        "name": "Shackle Undead",
+        "name": "Shackle Horror",
         "type": "single",
         "posX": 6900,
         "posY": 3900,
@@ -26937,7 +27397,7 @@
             "definitionId": 108848,
             "maxRanks": 1,
             "type": "active",
-            "name": "Shackle Undead",
+            "name": "Shackle Horror",
             "spellId": 9484,
             "icon": "spell_nature_slow",
             "index": 100
@@ -27182,7 +27642,7 @@
         "type": "single",
         "posX": 2700,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           82679,
@@ -27210,7 +27670,7 @@
         "type": "single",
         "posX": 3900,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           82697,
@@ -27239,7 +27699,7 @@
         "type": "single",
         "posX": 5100,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           109010
@@ -27268,7 +27728,7 @@
         "type": "single",
         "posX": 5700,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           82674
@@ -27295,7 +27755,7 @@
         "type": "single",
         "posX": 6300,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "next": [
           82674,
@@ -27323,7 +27783,7 @@
         "type": "single",
         "posX": 2700,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           82675
@@ -27350,7 +27810,7 @@
         "type": "single",
         "posX": 3300,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "next": [
           82675,
@@ -27379,7 +27839,7 @@
         "type": "single",
         "posX": 4500,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "next": [
           82676,
@@ -27408,7 +27868,7 @@
         "type": "single",
         "posX": 5700,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           82673,
@@ -27437,7 +27897,7 @@
         "type": "single",
         "posX": 2700,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -27463,7 +27923,7 @@
         "type": "choice",
         "posX": 3900,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -27499,7 +27959,7 @@
         "type": "single",
         "posX": 5100,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -27525,7 +27985,7 @@
         "type": "single",
         "posX": 6300,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -28188,7 +28648,7 @@
       },
       {
         "id": 82600,
-        "name": "Borrowed Time",
+        "name": "Harsh Discipline",
         "type": "single",
         "posX": 11700,
         "posY": 5100,
@@ -28208,9 +28668,9 @@
             "definitionId": 108734,
             "maxRanks": 2,
             "type": "passive",
-            "name": "Borrowed Time",
-            "spellId": 390691,
-            "icon": "spell_holy_borrowedtime",
+            "name": "Harsh Discipline",
+            "spellId": 373180,
+            "icon": "ability_paladin_handoflight",
             "index": 100
           }
         ]
@@ -28380,6 +28840,7 @@
         "maxRanks": 1,
         "next": [
           82568,
+          110648,
           110277
         ],
         "prev": [
@@ -28393,7 +28854,7 @@
             "maxRanks": 1,
             "type": "passive",
             "name": "Shadow Mend",
-            "spellId": 1252215,
+            "spellId": 1252217,
             "icon": "spell_shadow_shadowmend",
             "index": 0
           }
@@ -28434,8 +28895,10 @@
         "posX": 11100,
         "posY": 6300,
         "reqPoints": 20,
-        "maxRanks": 2,
-        "next": [],
+        "maxRanks": 1,
+        "next": [
+          86730
+        ],
         "prev": [
           82599
         ],
@@ -28443,7 +28906,7 @@
           {
             "id": 103694,
             "definitionId": 108699,
-            "maxRanks": 2,
+            "maxRanks": 1,
             "type": "passive",
             "name": "Greater Smite",
             "spellId": 1253724,
@@ -28482,13 +28945,14 @@
       },
       {
         "id": 82572,
-        "name": "Harsh Discipline",
+        "name": "Borrowed Time",
         "type": "single",
         "posX": 12300,
         "posY": 6300,
         "reqPoints": 20,
         "maxRanks": 2,
         "next": [
+          86730,
           82573
         ],
         "prev": [
@@ -28501,9 +28965,9 @@
             "definitionId": 108702,
             "maxRanks": 2,
             "type": "passive",
-            "name": "Harsh Discipline",
-            "spellId": 373180,
-            "icon": "ability_paladin_handoflight",
+            "name": "Borrowed Time",
+            "spellId": 390691,
+            "icon": "spell_holy_borrowedtime",
             "index": 200
           }
         ]
@@ -28512,7 +28976,7 @@
         "id": 82568,
         "name": "Blaze of Light",
         "type": "single",
-        "posX": 13500,
+        "posX": 12900,
         "posY": 6300,
         "reqPoints": 20,
         "maxRanks": 2,
@@ -28533,6 +28997,34 @@
             "spellId": 215768,
             "icon": "spell_holy_searinglight",
             "index": 100
+          }
+        ]
+      },
+      {
+        "id": 110648,
+        "name": "Grim Deliverance",
+        "type": "single",
+        "posX": 13500,
+        "posY": 6300,
+        "reqPoints": 20,
+        "maxRanks": 1,
+        "next": [
+          82586,
+          82585
+        ],
+        "prev": [
+          82567
+        ],
+        "entries": [
+          {
+            "id": 137463,
+            "definitionId": 142223,
+            "maxRanks": 1,
+            "type": "passive",
+            "name": "Grim Deliverance",
+            "spellId": 1298779,
+            "icon": "spell_bastion_priest_shadow",
+            "index": 0
           }
         ]
       },
@@ -28572,7 +29064,9 @@
         "posY": 6300,
         "reqPoints": 20,
         "maxRanks": 1,
-        "next": [],
+        "next": [
+          82585
+        ],
         "prev": [
           82570
         ],
@@ -28599,7 +29093,9 @@
         "maxRanks": 1,
         "next": [],
         "prev": [
-          82602
+          82602,
+          82572,
+          82569
         ],
         "entries": [
           {
@@ -28643,13 +29139,14 @@
         "id": 82586,
         "name": "Searing Light",
         "type": "single",
-        "posX": 13500,
+        "posX": 12900,
         "posY": 6900,
         "reqPoints": 20,
         "maxRanks": 1,
         "next": [],
         "prev": [
-          82568
+          82568,
+          110648
         ],
         "entries": [
           {
@@ -28674,7 +29171,9 @@
         "maxRanks": 2,
         "next": [],
         "prev": [
-          110277
+          110277,
+          110278,
+          110648
         ],
         "entries": [
           {
@@ -28686,6 +29185,64 @@
             "spellId": 390832,
             "icon": "spell_shadow_shadowpower",
             "index": 200
+          }
+        ]
+      },
+      {
+        "id": 110410,
+        "name": "Master the Darkness / Master the Darkness / Master the Darkness",
+        "type": "tiered",
+        "posX": 12900,
+        "posY": 7650,
+        "reqPoints": 20,
+        "maxRanks": 4,
+        "rankLevels": [
+          {
+            "level": 81,
+            "maxRanks": 1
+          },
+          {
+            "level": 84,
+            "maxRanks": 3
+          },
+          {
+            "level": 90,
+            "maxRanks": 4
+          }
+        ],
+        "entryNode": true,
+        "next": [],
+        "prev": [],
+        "entries": [
+          {
+            "id": 136998,
+            "definitionId": 141761,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Master the Darkness",
+            "spellId": 1253590,
+            "icon": "inv12_apextalent_priest_voidshield",
+            "index": 100
+          },
+          {
+            "id": 136997,
+            "definitionId": 141760,
+            "maxRanks": 2,
+            "type": "tierrank",
+            "name": "Master the Darkness",
+            "spellId": 1253845,
+            "icon": "inv12_apextalent_priest_voidshield",
+            "index": 200
+          },
+          {
+            "id": 136996,
+            "definitionId": 141759,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Master the Darkness",
+            "spellId": 1253827,
+            "icon": "inv12_apextalent_priest_voidshield",
+            "index": 300
           }
         ]
       }
@@ -28719,7 +29276,8 @@
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 94698,
@@ -29121,7 +29679,8 @@
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 94693,
@@ -29135,7 +29694,6 @@
           94668
         ],
         "prev": [
-          94684,
           110008
         ],
         "entries": [
@@ -29173,7 +29731,6 @@
           94695
         ],
         "prev": [
-          94684,
           110008
         ],
         "entries": [
@@ -29201,7 +29758,6 @@
           100212
         ],
         "prev": [
-          94684,
           110008
         ],
         "entries": [
@@ -29229,7 +29785,6 @@
           109779
         ],
         "prev": [
-          94684,
           110008
         ],
         "entries": [
@@ -29796,7 +30351,11 @@
       109917,
       110008,
       110277,
-      110278
+      110278,
+      110408,
+      110409,
+      110410,
+      110648
     ]
   },
   {
@@ -30281,7 +30840,7 @@
       },
       {
         "id": 82687,
-        "name": "Strength of Soul",
+        "name": "Strength of Resolve",
         "type": "single",
         "posX": 5100,
         "posY": 3300,
@@ -30300,7 +30859,7 @@
             "definitionId": 108842,
             "maxRanks": 1,
             "type": "passive",
-            "name": "Strength of Soul",
+            "name": "Strength of Resolve",
             "spellId": 1250820,
             "icon": "spell_holy_ashestoashes",
             "index": 100
@@ -30552,7 +31111,7 @@
       },
       {
         "id": 82693,
-        "name": "Shackle Undead",
+        "name": "Shackle Horror",
         "type": "single",
         "posX": 6900,
         "posY": 3900,
@@ -30571,7 +31130,7 @@
             "definitionId": 108848,
             "maxRanks": 1,
             "type": "active",
-            "name": "Shackle Undead",
+            "name": "Shackle Horror",
             "spellId": 9484,
             "icon": "spell_nature_slow",
             "index": 100
@@ -30816,7 +31375,7 @@
         "type": "single",
         "posX": 2700,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           82679,
@@ -30844,7 +31403,7 @@
         "type": "single",
         "posX": 3900,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           82697,
@@ -30873,7 +31432,7 @@
         "type": "single",
         "posX": 5100,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           109010
@@ -30902,7 +31461,7 @@
         "type": "single",
         "posX": 5700,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           82674
@@ -30929,7 +31488,7 @@
         "type": "single",
         "posX": 6300,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "next": [
           82674,
@@ -30957,7 +31516,7 @@
         "type": "single",
         "posX": 2700,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           82675
@@ -30984,7 +31543,7 @@
         "type": "single",
         "posX": 3300,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "next": [
           82675,
@@ -31013,7 +31572,7 @@
         "type": "single",
         "posX": 4500,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "next": [
           82676,
@@ -31042,7 +31601,7 @@
         "type": "single",
         "posX": 5700,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           82673,
@@ -31071,7 +31630,7 @@
         "type": "single",
         "posX": 2700,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -31097,7 +31656,7 @@
         "type": "choice",
         "posX": 3900,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -31133,7 +31692,7 @@
         "type": "single",
         "posX": 5100,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -31159,7 +31718,7 @@
         "type": "single",
         "posX": 6300,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -31659,7 +32218,7 @@
       },
       {
         "id": 82641,
-        "name": "Benediction",
+        "name": "Light's Resurgence",
         "type": "single",
         "posX": 14100,
         "posY": 3900,
@@ -31679,7 +32238,7 @@
             "definitionId": 108784,
             "maxRanks": 1,
             "type": "passive",
-            "name": "Benediction",
+            "name": "Light's Resurgence",
             "spellId": 193157,
             "icon": "spell_monk_diffusemagic",
             "index": 100
@@ -32392,6 +32951,64 @@
             "index": 100
           }
         ]
+      },
+      {
+        "id": 110409,
+        "name": "Benediction / Benediction / Benediction",
+        "type": "tiered",
+        "posX": 12900,
+        "posY": 7650,
+        "reqPoints": 20,
+        "maxRanks": 4,
+        "rankLevels": [
+          {
+            "level": 81,
+            "maxRanks": 1
+          },
+          {
+            "level": 84,
+            "maxRanks": 3
+          },
+          {
+            "level": 90,
+            "maxRanks": 4
+          }
+        ],
+        "entryNode": true,
+        "next": [],
+        "prev": [],
+        "entries": [
+          {
+            "id": 136995,
+            "definitionId": 141758,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Benediction",
+            "spellId": 1262755,
+            "icon": "inv12_apextalent_priest_benediction",
+            "index": 200
+          },
+          {
+            "id": 136994,
+            "definitionId": 141757,
+            "maxRanks": 2,
+            "type": "tierrank",
+            "name": "Benediction",
+            "spellId": 1262758,
+            "icon": "inv12_apextalent_priest_benediction",
+            "index": 300
+          },
+          {
+            "id": 136993,
+            "definitionId": 141756,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Benediction",
+            "spellId": 1262760,
+            "icon": "inv12_apextalent_priest_benediction",
+            "index": 400
+          }
+        ]
       }
     ],
     "heroNodes": [
@@ -32423,7 +33040,8 @@
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 108724,
@@ -32453,7 +33071,8 @@
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 94698,
@@ -32575,7 +33194,6 @@
           94686
         ],
         "prev": [
-          94697,
           108724
         ],
         "entries": [
@@ -32603,7 +33221,6 @@
           94680
         ],
         "prev": [
-          94697,
           108724
         ],
         "entries": [
@@ -32631,7 +33248,6 @@
           94688
         ],
         "prev": [
-          94697,
           108724
         ],
         "entries": [
@@ -32659,8 +33275,7 @@
           109776
         ],
         "prev": [
-          108724,
-          94697
+          108724
         ],
         "entries": [
           {
@@ -33098,7 +33713,7 @@
             "type": "passive",
             "name": "Resonant Energy",
             "spellId": 453845,
-            "icon": "ability_priest_halo",
+            "icon": "inv_ability_holyfire_orb",
             "index": 100
           }
         ]
@@ -33510,7 +34125,11 @@
       109917,
       110008,
       110277,
-      110278
+      110278,
+      110408,
+      110409,
+      110410,
+      110648
     ]
   },
   {
@@ -33995,7 +34614,7 @@
       },
       {
         "id": 82687,
-        "name": "Strength of Soul",
+        "name": "Strength of Resolve",
         "type": "single",
         "posX": 5100,
         "posY": 3300,
@@ -34014,7 +34633,7 @@
             "definitionId": 108842,
             "maxRanks": 1,
             "type": "passive",
-            "name": "Strength of Soul",
+            "name": "Strength of Resolve",
             "spellId": 1250820,
             "icon": "spell_holy_ashestoashes",
             "index": 100
@@ -34266,7 +34885,7 @@
       },
       {
         "id": 82693,
-        "name": "Shackle Undead",
+        "name": "Shackle Horror",
         "type": "single",
         "posX": 6900,
         "posY": 3900,
@@ -34285,7 +34904,7 @@
             "definitionId": 108848,
             "maxRanks": 1,
             "type": "active",
-            "name": "Shackle Undead",
+            "name": "Shackle Horror",
             "spellId": 9484,
             "icon": "spell_nature_slow",
             "index": 100
@@ -34530,7 +35149,7 @@
         "type": "single",
         "posX": 2700,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           82679,
@@ -34558,7 +35177,7 @@
         "type": "single",
         "posX": 3900,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           82697,
@@ -34587,7 +35206,7 @@
         "type": "single",
         "posX": 5100,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           109010
@@ -34616,7 +35235,7 @@
         "type": "single",
         "posX": 5700,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           82674
@@ -34643,7 +35262,7 @@
         "type": "single",
         "posX": 6300,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "next": [
           82674,
@@ -34671,7 +35290,7 @@
         "type": "single",
         "posX": 2700,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           82675
@@ -34698,7 +35317,7 @@
         "type": "single",
         "posX": 3300,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "next": [
           82675,
@@ -34727,7 +35346,7 @@
         "type": "single",
         "posX": 4500,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "next": [
           82676,
@@ -34756,7 +35375,7 @@
         "type": "single",
         "posX": 5700,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           82673,
@@ -34785,7 +35404,7 @@
         "type": "single",
         "posX": 2700,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -34811,7 +35430,7 @@
         "type": "choice",
         "posX": 3900,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -34847,7 +35466,7 @@
         "type": "single",
         "posX": 5100,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -34873,7 +35492,7 @@
         "type": "single",
         "posX": 6300,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -35450,7 +36069,7 @@
       },
       {
         "id": 82646,
-        "name": "Phantom Menace",
+        "name": "Shadeburst",
         "type": "single",
         "posX": 13500,
         "posY": 4500,
@@ -35471,9 +36090,9 @@
             "definitionId": 108790,
             "maxRanks": 1,
             "type": "passive",
-            "name": "Phantom Menace",
-            "spellId": 1242779,
-            "icon": "spell_priest_spectralguise",
+            "name": "Shadeburst",
+            "spellId": 73510,
+            "icon": "ability_warlock_voidzone",
             "index": 100
           }
         ]
@@ -36145,6 +36764,64 @@
             "index": 100
           }
         ]
+      },
+      {
+        "id": 110408,
+        "name": "Void Apparitions / Void Apparitions / Void Apparitions",
+        "type": "tiered",
+        "posX": 12900,
+        "posY": 7650,
+        "reqPoints": 20,
+        "maxRanks": 4,
+        "rankLevels": [
+          {
+            "level": 81,
+            "maxRanks": 1
+          },
+          {
+            "level": 84,
+            "maxRanks": 3
+          },
+          {
+            "level": 90,
+            "maxRanks": 4
+          }
+        ],
+        "entryNode": true,
+        "next": [],
+        "prev": [],
+        "entries": [
+          {
+            "id": 136992,
+            "definitionId": 141755,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Void Apparitions",
+            "spellId": 1264096,
+            "icon": "inv12_apextalent_priest_voidapparitions",
+            "index": 100
+          },
+          {
+            "id": 136991,
+            "definitionId": 141754,
+            "maxRanks": 2,
+            "type": "tierrank",
+            "name": "Void Apparitions",
+            "spellId": 1264104,
+            "icon": "inv12_apextalent_priest_voidapparitions",
+            "index": 200
+          },
+          {
+            "id": 136990,
+            "definitionId": 141753,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Void Apparitions",
+            "spellId": 1264107,
+            "icon": "inv12_apextalent_priest_voidapparitions",
+            "index": 300
+          }
+        ]
       }
     ],
     "heroNodes": [
@@ -36176,7 +36853,8 @@
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 94677,
@@ -36190,8 +36868,7 @@
           94686
         ],
         "prev": [
-          94697,
-          108724
+          94697
         ],
         "entries": [
           {
@@ -36218,8 +36895,7 @@
           94680
         ],
         "prev": [
-          94697,
-          108724
+          94697
         ],
         "entries": [
           {
@@ -36246,8 +36922,7 @@
           94688
         ],
         "prev": [
-          94697,
-          108724
+          94697
         ],
         "entries": [
           {
@@ -36274,7 +36949,6 @@
           109776
         ],
         "prev": [
-          108724,
           94697
         ],
         "entries": [
@@ -36477,7 +37151,7 @@
             "type": "passive",
             "name": "Resonant Energy",
             "spellId": 453845,
-            "icon": "ability_priest_halo",
+            "icon": "inv_ability_holyfire_orb",
             "index": 100
           }
         ]
@@ -36602,7 +37276,8 @@
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 94693,
@@ -36616,8 +37291,7 @@
           94668
         ],
         "prev": [
-          94684,
-          110008
+          94684
         ],
         "entries": [
           {
@@ -36654,8 +37328,7 @@
           94695
         ],
         "prev": [
-          94684,
-          110008
+          94684
         ],
         "entries": [
           {
@@ -36682,8 +37355,7 @@
           100212
         ],
         "prev": [
-          94684,
-          110008
+          94684
         ],
         "entries": [
           {
@@ -36710,8 +37382,7 @@
           109779
         ],
         "prev": [
-          94684,
-          110008
+          94684
         ],
         "entries": [
           {
@@ -37278,7 +37949,11 @@
       109917,
       110008,
       110277,
-      110278
+      110278,
+      110408,
+      110409,
+      110410,
+      110648
     ]
   },
   {
@@ -38230,7 +38905,7 @@
         "type": "single",
         "posX": 2400,
         "posY": 5400,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           76079
@@ -38257,7 +38932,7 @@
         "type": "single",
         "posX": 3600,
         "posY": 5400,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           76079,
@@ -38286,7 +38961,7 @@
         "type": "single",
         "posX": 4800,
         "posY": 5400,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           76080,
@@ -38315,7 +38990,7 @@
         "type": "single",
         "posX": 6000,
         "posY": 5400,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           76054
@@ -38342,7 +39017,7 @@
         "type": "single",
         "posX": 3000,
         "posY": 6000,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "next": [
           102008,
@@ -38371,7 +39046,7 @@
         "type": "single",
         "posX": 4200,
         "posY": 6000,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           76050,
@@ -38400,7 +39075,7 @@
         "type": "single",
         "posX": 5400,
         "posY": 6000,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "next": [
           102007,
@@ -38429,7 +39104,7 @@
         "type": "single",
         "posX": 2400,
         "posY": 6600,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -38454,7 +39129,7 @@
         "type": "single",
         "posX": 3600,
         "posY": 6600,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -38480,7 +39155,7 @@
         "type": "single",
         "posX": 4800,
         "posY": 6600,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -38506,7 +39181,7 @@
         "type": "single",
         "posX": 6000,
         "posY": 6600,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -39651,6 +40326,65 @@
             "index": 100
           }
         ]
+      },
+      {
+        "id": 110353,
+        "name": "Dance of Midnight / Dance of Midnight / Dance of Midnight",
+        "type": "tiered",
+        "posX": 12600,
+        "posY": 7350,
+        "reqPoints": 20,
+        "maxRanks": 4,
+        "rankLevels": [
+          {
+            "level": 81,
+            "maxRanks": 1
+          },
+          {
+            "level": 84,
+            "maxRanks": 3
+          },
+          {
+            "level": 90,
+            "maxRanks": 4
+          }
+        ],
+        "entryNode": true,
+        "requiresNode": 0,
+        "next": [],
+        "prev": [],
+        "entries": [
+          {
+            "id": 136917,
+            "definitionId": 141680,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Dance of Midnight",
+            "spellId": 1264506,
+            "icon": "inv12_apextalent_deathknight_danceofmidnight",
+            "index": 100
+          },
+          {
+            "id": 136916,
+            "definitionId": 141679,
+            "maxRanks": 2,
+            "type": "tierrank",
+            "name": "Dance of Midnight",
+            "spellId": 1264405,
+            "icon": "ability_demonhunter_bladedance",
+            "index": 200
+          },
+          {
+            "id": 136915,
+            "definitionId": 141678,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Dance of Midnight",
+            "spellId": 1264351,
+            "icon": "ability_demonhunter_bladedance",
+            "index": 300
+          }
+        ]
       }
     ],
     "heroNodes": [
@@ -39682,7 +40416,8 @@
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 95051,
@@ -39712,7 +40447,8 @@
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 95036,
@@ -39989,7 +40725,7 @@
       },
       {
         "id": 95034,
-        "name": "Grim Reaper / Reaper of Souls",
+        "name": "Grim Reaper",
         "type": "single",
         "posX": 7800,
         "posY": 2400,
@@ -40011,16 +40747,6 @@
             "spellId": 434905,
             "icon": "spell_misc_zandalari_council_soulswap",
             "index": 100
-          },
-          {
-            "id": 128235,
-            "definitionId": 133042,
-            "maxRanks": 1,
-            "type": "passive",
-            "name": "Reaper of Souls",
-            "spellId": 440002,
-            "icon": "pvp_soulrip",
-            "index": 200
           }
         ]
       },
@@ -40688,7 +41414,6 @@
       76192,
       76193,
       76194,
-      76195,
       76196,
       76197,
       95032,
@@ -40765,8 +41490,10 @@
       110029,
       110030,
       110031,
-      110259,
-      110260
+      110260,
+      110353,
+      110354,
+      110400
     ]
   },
   {
@@ -41718,7 +42445,7 @@
         "type": "single",
         "posX": 2400,
         "posY": 5400,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           76079
@@ -41745,7 +42472,7 @@
         "type": "single",
         "posX": 3600,
         "posY": 5400,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           76079,
@@ -41774,7 +42501,7 @@
         "type": "single",
         "posX": 4800,
         "posY": 5400,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           76080,
@@ -41803,7 +42530,7 @@
         "type": "single",
         "posX": 6000,
         "posY": 5400,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           76054
@@ -41830,7 +42557,7 @@
         "type": "single",
         "posX": 3000,
         "posY": 6000,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "next": [
           102008,
@@ -41859,7 +42586,7 @@
         "type": "single",
         "posX": 4200,
         "posY": 6000,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           76050,
@@ -41888,7 +42615,7 @@
         "type": "single",
         "posX": 5400,
         "posY": 6000,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "next": [
           102007,
@@ -41917,7 +42644,7 @@
         "type": "single",
         "posX": 2400,
         "posY": 6600,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -41942,7 +42669,7 @@
         "type": "single",
         "posX": 3600,
         "posY": 6600,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -41968,7 +42695,7 @@
         "type": "single",
         "posX": 4800,
         "posY": 6600,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -41994,7 +42721,7 @@
         "type": "single",
         "posX": 6000,
         "posY": 6600,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -43084,6 +43811,64 @@
             "index": 100
           }
         ]
+      },
+      {
+        "id": 110400,
+        "name": "Chosen of Frostbrood / Chosen of Frostbrood / Chosen of Frostbrood",
+        "type": "tiered",
+        "posX": 12600,
+        "posY": 7350,
+        "reqPoints": 20,
+        "maxRanks": 4,
+        "rankLevels": [
+          {
+            "level": 81,
+            "maxRanks": 1
+          },
+          {
+            "level": 84,
+            "maxRanks": 3
+          },
+          {
+            "level": 90,
+            "maxRanks": 4
+          }
+        ],
+        "entryNode": true,
+        "next": [],
+        "prev": [],
+        "entries": [
+          {
+            "id": 136968,
+            "definitionId": 141731,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Chosen of Frostbrood",
+            "spellId": 1265632,
+            "icon": "inv12_apextalent_deathknight_chosenofthefrostbrood",
+            "index": 100
+          },
+          {
+            "id": 136967,
+            "definitionId": 141730,
+            "maxRanks": 2,
+            "type": "tierrank",
+            "name": "Chosen of Frostbrood",
+            "spellId": 1265633,
+            "icon": "achievement_reputation_wyrmresttemple",
+            "index": 200
+          },
+          {
+            "id": 136966,
+            "definitionId": 141729,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Chosen of Frostbrood",
+            "spellId": 1265637,
+            "icon": "achievement_reputation_wyrmresttemple",
+            "index": 300
+          }
+        ]
       }
     ],
     "heroNodes": [
@@ -43115,7 +43900,8 @@
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 95036,
@@ -43254,7 +44040,7 @@
       },
       {
         "id": 95034,
-        "name": "Grim Reaper / Reaper of Souls",
+        "name": "Grim Reaper",
         "type": "single",
         "posX": 7800,
         "posY": 2400,
@@ -43276,16 +44062,6 @@
             "spellId": 434905,
             "icon": "spell_misc_zandalari_council_soulswap",
             "index": 100
-          },
-          {
-            "id": 128235,
-            "definitionId": 133042,
-            "maxRanks": 1,
-            "type": "passive",
-            "name": "Reaper of Souls",
-            "spellId": 440002,
-            "icon": "pvp_soulrip",
-            "index": 200
           }
         ]
       },
@@ -43537,7 +44313,8 @@
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 95060,
@@ -44112,7 +44889,6 @@
       76192,
       76193,
       76194,
-      76195,
       76196,
       76197,
       95032,
@@ -44189,8 +44965,10 @@
       110029,
       110030,
       110031,
-      110259,
-      110260
+      110260,
+      110353,
+      110354,
+      110400
     ]
   },
   {
@@ -45142,7 +45920,7 @@
         "type": "single",
         "posX": 2400,
         "posY": 5400,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           76079
@@ -45169,7 +45947,7 @@
         "type": "single",
         "posX": 3600,
         "posY": 5400,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           76079,
@@ -45198,7 +45976,7 @@
         "type": "single",
         "posX": 4800,
         "posY": 5400,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           76080,
@@ -45227,7 +46005,7 @@
         "type": "single",
         "posX": 6000,
         "posY": 5400,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           76054
@@ -45254,7 +46032,7 @@
         "type": "single",
         "posX": 3000,
         "posY": 6000,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "next": [
           102008,
@@ -45283,7 +46061,7 @@
         "type": "single",
         "posX": 4200,
         "posY": 6000,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           76050,
@@ -45312,7 +46090,7 @@
         "type": "single",
         "posX": 5400,
         "posY": 6000,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "next": [
           102007,
@@ -45341,7 +46119,7 @@
         "type": "single",
         "posX": 2400,
         "posY": 6600,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -45366,7 +46144,7 @@
         "type": "single",
         "posX": 3600,
         "posY": 6600,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -45392,7 +46170,7 @@
         "type": "single",
         "posX": 4800,
         "posY": 6600,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -45418,7 +46196,7 @@
         "type": "single",
         "posX": 6000,
         "posY": 6600,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -45586,7 +46364,7 @@
         "reqPoints": 0,
         "maxRanks": 1,
         "next": [
-          108130
+          110260
         ],
         "prev": [
           76191
@@ -45643,7 +46421,7 @@
         "maxRanks": 1,
         "next": [
           76192,
-          110259,
+          76179,
           76196
         ],
         "prev": [
@@ -45673,15 +46451,15 @@
         ]
       },
       {
-        "id": 108130,
-        "name": "Doomed Bidding",
+        "id": 110260,
+        "name": "Necromancer's Cunning",
         "type": "single",
         "posX": 13800,
         "posY": 3000,
         "reqPoints": 0,
         "maxRanks": 1,
         "next": [
-          110259,
+          76179,
           76148,
           76187
         ],
@@ -45690,26 +46468,27 @@
         ],
         "entries": [
           {
-            "id": 125816,
-            "definitionId": 130648,
+            "id": 136797,
+            "definitionId": 141560,
             "maxRanks": 1,
             "type": "passive",
-            "name": "Doomed Bidding",
-            "spellId": 455386,
-            "icon": "ability_deathknight_shatteringbone",
+            "name": "Necromancer's Cunning",
+            "spellId": 288848,
+            "icon": "artifactability_unholydeathknight_deathsembrace",
             "index": 100
           }
         ]
       },
       {
         "id": 76197,
-        "name": "Morbidity",
+        "name": "Ebon Fever",
         "type": "single",
         "posX": 10800,
         "posY": 3600,
         "reqPoints": 8,
         "maxRanks": 1,
         "next": [
+          76155,
           76160
         ],
         "prev": [
@@ -45721,9 +46500,9 @@
             "definitionId": 101336,
             "maxRanks": 1,
             "type": "passive",
-            "name": "Morbidity",
-            "spellId": 377592,
-            "icon": "spell_necro_deathlyecho",
+            "name": "Ebon Fever",
+            "spellId": 207269,
+            "icon": "spell_shadow_creepingplague",
             "index": 100
           }
         ]
@@ -45737,7 +46516,6 @@
         "reqPoints": 8,
         "maxRanks": 1,
         "next": [
-          76160,
           76155,
           76156
         ],
@@ -45759,7 +46537,7 @@
       },
       {
         "id": 76192,
-        "name": "Rapid Variant",
+        "name": "Superstrain",
         "type": "single",
         "posX": 12000,
         "posY": 3600,
@@ -45779,16 +46557,16 @@
             "definitionId": 101331,
             "maxRanks": 1,
             "type": "passive",
-            "name": "Rapid Variant",
-            "spellId": 1242561,
-            "icon": "ability_warlock_everlastingaffliction",
+            "name": "Superstrain",
+            "spellId": 390283,
+            "icon": "spell_deathknight_explode_ghoul",
             "index": 100
           }
         ]
       },
       {
-        "id": 110259,
-        "name": "March of Madness",
+        "id": 76179,
+        "name": "Soul Reaper",
         "type": "single",
         "posX": 13200,
         "posY": 3600,
@@ -45796,21 +46574,21 @@
         "maxRanks": 1,
         "next": [
           76196,
-          76184
+          109392
         ],
         "prev": [
-          108130,
+          110260,
           76186
         ],
         "entries": [
           {
-            "id": 133521,
-            "definitionId": 138307,
+            "id": 96314,
+            "definitionId": 101316,
             "maxRanks": 1,
-            "type": "passive",
-            "name": "March of Madness",
-            "spellId": 1241707,
-            "icon": "inv_10xp_worldevent_special_ghoulfigure",
+            "type": "active",
+            "name": "Soul Reaper",
+            "spellId": 343294,
+            "icon": "ability_deathknight_soulreaper",
             "index": 100
           }
         ]
@@ -45824,12 +46602,12 @@
         "reqPoints": 8,
         "maxRanks": 1,
         "next": [
-          76184,
+          109392,
           101882,
           76194
         ],
         "prev": [
-          108130
+          110260
         ],
         "entries": [
           {
@@ -45856,7 +46634,7 @@
           76194
         ],
         "prev": [
-          108130
+          110260
         ],
         "entries": [
           {
@@ -45872,15 +46650,17 @@
         ]
       },
       {
-        "id": 76160,
-        "name": "Ebon Fever",
+        "id": 76155,
+        "name": "Cycle of Death",
         "type": "single",
-        "posX": 10800,
+        "posX": 11400,
         "posY": 4200,
         "reqPoints": 8,
         "maxRanks": 1,
         "next": [
-          76195
+          76160,
+          76178,
+          108126
         ],
         "prev": [
           76193,
@@ -45888,42 +46668,13 @@
         ],
         "entries": [
           {
-            "id": 96294,
-            "definitionId": 101296,
-            "maxRanks": 1,
-            "type": "passive",
-            "name": "Ebon Fever",
-            "spellId": 207269,
-            "icon": "spell_shadow_creepingplague",
-            "index": 100
-          }
-        ]
-      },
-      {
-        "id": 76155,
-        "name": "Superstrain",
-        "type": "single",
-        "posX": 11400,
-        "posY": 4200,
-        "reqPoints": 8,
-        "maxRanks": 1,
-        "next": [
-          76195,
-          76178,
-          108126
-        ],
-        "prev": [
-          76193
-        ],
-        "entries": [
-          {
             "id": 96289,
             "definitionId": 101291,
             "maxRanks": 1,
             "type": "passive",
-            "name": "Superstrain",
-            "spellId": 390283,
-            "icon": "spell_deathknight_explode_ghoul",
+            "name": "Cycle of Death",
+            "spellId": 1290864,
+            "icon": "ability_ironmaidens_whirlofblood",
             "index": 100
           }
         ]
@@ -45967,12 +46718,12 @@
         "next": [
           76178,
           76176,
-          108151
+          76184
         ],
         "prev": [
-          110259,
+          76192,
           76186,
-          76192
+          76179
         ],
         "entries": [
           {
@@ -45988,29 +46739,29 @@
         ]
       },
       {
-        "id": 76184,
-        "name": "Unholy Devotion",
+        "id": 109392,
+        "name": "Reaping",
         "type": "single",
         "posX": 13200,
         "posY": 4200,
         "reqPoints": 8,
         "maxRanks": 1,
         "next": [
-          108151
+          76184
         ],
         "prev": [
           76148,
-          110259
+          76179
         ],
         "entries": [
           {
-            "id": 96321,
-            "definitionId": 101323,
+            "id": 133517,
+            "definitionId": 138303,
             "maxRanks": 1,
             "type": "passive",
-            "name": "Unholy Devotion",
-            "spellId": 1241858,
-            "icon": "ability_creature_cursed_03",
+            "name": "Reaping",
+            "spellId": 377514,
+            "icon": "ability_deathwing_bloodcorruption_death",
             "index": 100
           }
         ]
@@ -46024,9 +46775,9 @@
         "reqPoints": 8,
         "maxRanks": 1,
         "next": [
-          108151,
+          76184,
           76181,
-          110260
+          108130
         ],
         "prev": [
           76148
@@ -46073,8 +46824,8 @@
         ]
       },
       {
-        "id": 76195,
-        "name": "Blightfall",
+        "id": 76160,
+        "name": "Morbidity",
         "type": "single",
         "posX": 10800,
         "posY": 4800,
@@ -46084,18 +46835,18 @@
           108126
         ],
         "prev": [
-          76155,
-          76160
+          76197,
+          76155
         ],
         "entries": [
           {
-            "id": 96332,
-            "definitionId": 101334,
+            "id": 96294,
+            "definitionId": 101296,
             "maxRanks": 1,
             "type": "passive",
-            "name": "Blightfall",
-            "spellId": 1242616,
-            "icon": "inv_nullstone_shadow",
+            "name": "Morbidity",
+            "spellId": 377592,
+            "icon": "spell_necro_deathlyecho",
             "index": 100
           }
         ]
@@ -46110,7 +46861,7 @@
         "maxRanks": 1,
         "next": [
           108126,
-          76179
+          108151
         ],
         "prev": [
           76196,
@@ -46139,7 +46890,7 @@
         "reqPoints": 8,
         "maxRanks": 1,
         "next": [
-          76179
+          108151
         ],
         "prev": [
           76196
@@ -46168,31 +46919,31 @@
         ]
       },
       {
-        "id": 108151,
-        "name": "Putrid Echoes",
+        "id": 76184,
+        "name": "Unholy Devotion",
         "type": "single",
         "posX": 13200,
         "posY": 4800,
         "reqPoints": 8,
         "maxRanks": 1,
         "next": [
-          76179,
-          110260
+          108151,
+          108130
         ],
         "prev": [
+          76196,
           101882,
-          76184,
-          76196
+          109392
         ],
         "entries": [
           {
-            "id": 133546,
-            "definitionId": 138332,
+            "id": 96321,
+            "definitionId": 101323,
             "maxRanks": 1,
             "type": "passive",
-            "name": "Putrid Echoes",
-            "spellId": 377580,
-            "icon": "inv12_ability_deathknight_dreadplague",
+            "name": "Unholy Devotion",
+            "spellId": 1241858,
+            "icon": "ability_creature_cursed_03",
             "index": 100
           }
         ]
@@ -46206,7 +46957,7 @@
         "reqPoints": 8,
         "maxRanks": 1,
         "next": [
-          110260
+          108130
         ],
         "prev": [
           76194,
@@ -46240,7 +46991,7 @@
         "prev": [
           76155,
           76178,
-          76195
+          76160
         ],
         "entries": [
           {
@@ -46256,8 +47007,8 @@
         ]
       },
       {
-        "id": 76179,
-        "name": "Soul Reaper",
+        "id": 108151,
+        "name": "Putrid Echoes",
         "type": "single",
         "posX": 12600,
         "posY": 5400,
@@ -46265,30 +47016,29 @@
         "maxRanks": 1,
         "next": [
           76152,
-          109392,
           76150
         ],
         "prev": [
-          76176,
+          76184,
           76178,
-          108151
+          76176
         ],
         "entries": [
           {
-            "id": 96314,
-            "definitionId": 101316,
+            "id": 133546,
+            "definitionId": 138332,
             "maxRanks": 1,
-            "type": "active",
-            "name": "Soul Reaper",
-            "spellId": 343294,
-            "icon": "ability_deathknight_soulreaper",
+            "type": "passive",
+            "name": "Putrid Echoes",
+            "spellId": 377580,
+            "icon": "inv12_ability_deathknight_dreadplague",
             "index": 100
           }
         ]
       },
       {
-        "id": 110260,
-        "name": "Necromancer's Cunning",
+        "id": 108130,
+        "name": "Doomed Bidding",
         "type": "single",
         "posX": 13800,
         "posY": 5400,
@@ -46301,17 +47051,17 @@
         "prev": [
           101882,
           76181,
-          108151
+          76184
         ],
         "entries": [
           {
-            "id": 136797,
-            "definitionId": 141560,
+            "id": 125816,
+            "definitionId": 130648,
             "maxRanks": 1,
             "type": "passive",
-            "name": "Necromancer's Cunning",
-            "spellId": 288848,
-            "icon": "artifactability_unholydeathknight_deathsembrace",
+            "name": "Doomed Bidding",
+            "spellId": 455386,
+            "icon": "ability_deathknight_shatteringbone",
             "index": 100
           }
         ]
@@ -46356,7 +47106,7 @@
         ],
         "prev": [
           108126,
-          76179
+          108151
         ],
         "entries": [
           {
@@ -46367,33 +47117,6 @@
             "name": "Ancient Power",
             "spellId": 377590,
             "icon": "inv_relics_runestone",
-            "index": 100
-          }
-        ]
-      },
-      {
-        "id": 109392,
-        "name": "Reaping",
-        "type": "single",
-        "posX": 12600,
-        "posY": 6000,
-        "reqPoints": 20,
-        "maxRanks": 1,
-        "next": [
-          109458
-        ],
-        "prev": [
-          76179
-        ],
-        "entries": [
-          {
-            "id": 133517,
-            "definitionId": 138303,
-            "maxRanks": 1,
-            "type": "passive",
-            "name": "Reaping",
-            "spellId": 377514,
-            "icon": "ability_deathwing_bloodcorruption_death",
             "index": 100
           }
         ]
@@ -46410,8 +47133,8 @@
           109458
         ],
         "prev": [
-          110260,
-          76179
+          108130,
+          108151
         ],
         "entries": [
           {
@@ -46438,7 +47161,7 @@
           76182
         ],
         "prev": [
-          110260
+          108130
         ],
         "entries": [
           {
@@ -46455,7 +47178,7 @@
       },
       {
         "id": 108124,
-        "name": "Pestilence",
+        "name": "Blightfall",
         "type": "single",
         "posX": 11400,
         "posY": 6600,
@@ -46471,16 +47194,16 @@
             "definitionId": 138299,
             "maxRanks": 1,
             "type": "passive",
-            "name": "Pestilence",
+            "name": "Blightfall",
             "spellId": 1271974,
-            "icon": "spell_shadow_plaguecloud",
+            "icon": "inv_nullstone_shadow",
             "index": 100
           }
         ]
       },
       {
         "id": 109458,
-        "name": "Reanimation",
+        "name": "Lord of the Dead",
         "type": "single",
         "posX": 12600,
         "posY": 6600,
@@ -46489,8 +47212,7 @@
         "next": [],
         "prev": [
           76150,
-          76152,
-          109392
+          76152
         ],
         "entries": [
           {
@@ -46498,9 +47220,9 @@
             "definitionId": 140432,
             "maxRanks": 1,
             "type": "passive",
-            "name": "Reanimation",
+            "name": "Lord of the Dead",
             "spellId": 1256813,
-            "icon": "achievement_dungeon_thenecroticwake_amarth",
+            "icon": "achievement_dungeon_thenecroticwake_nalthor",
             "index": 100
           }
         ]
@@ -46527,6 +47249,64 @@
             "spellId": 1241705,
             "icon": "spell_shadow_darksummoning",
             "index": 100
+          }
+        ]
+      },
+      {
+        "id": 110354,
+        "name": "Forbidden Knowledge / Forbidden Knowledge / Forbidden Knowledge",
+        "type": "tiered",
+        "posX": 12600,
+        "posY": 7350,
+        "reqPoints": 20,
+        "maxRanks": 4,
+        "rankLevels": [
+          {
+            "level": 81,
+            "maxRanks": 1
+          },
+          {
+            "level": 84,
+            "maxRanks": 3
+          },
+          {
+            "level": 90,
+            "maxRanks": 4
+          }
+        ],
+        "entryNode": true,
+        "next": [],
+        "prev": [],
+        "entries": [
+          {
+            "id": 136920,
+            "definitionId": 141683,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Forbidden Knowledge",
+            "spellId": 1242158,
+            "icon": "inv12_apextalent_deathknight_forbiddenknowledge",
+            "index": 100
+          },
+          {
+            "id": 136919,
+            "definitionId": 141682,
+            "maxRanks": 2,
+            "type": "tierrank",
+            "name": "Forbidden Knowledge",
+            "spellId": 1256565,
+            "icon": "spell_shadow_fingerofdeath",
+            "index": 200
+          },
+          {
+            "id": 136918,
+            "definitionId": 141681,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Forbidden Knowledge",
+            "spellId": 1256566,
+            "icon": "inv12_apextalent_deathknight_forbiddenknowledge",
+            "index": 300
           }
         ]
       }
@@ -46560,7 +47340,8 @@
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 95064,
@@ -46982,7 +47763,8 @@
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 95060,
@@ -47557,7 +48339,6 @@
       76192,
       76193,
       76194,
-      76195,
       76196,
       76197,
       95032,
@@ -47634,8 +48415,10 @@
       110029,
       110030,
       110031,
-      110259,
-      110260
+      110260,
+      110353,
+      110354,
+      110400
     ]
   },
   {
@@ -48452,7 +49235,7 @@
         "type": "single",
         "posX": 2400,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           110153
@@ -48479,7 +49262,7 @@
         "type": "single",
         "posX": 3000,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           110153,
@@ -48508,7 +49291,7 @@
         "type": "single",
         "posX": 3600,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           102416
@@ -48536,7 +49319,7 @@
         "type": "single",
         "posX": 4200,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           102416,
@@ -48564,7 +49347,7 @@
         "type": "single",
         "posX": 4800,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           102409
@@ -48592,7 +49375,7 @@
         "type": "single",
         "posX": 5400,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           102409,
@@ -48621,7 +49404,7 @@
         "type": "choice",
         "posX": 6000,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           102418
@@ -48658,7 +49441,7 @@
         "type": "single",
         "posX": 2400,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           102389
@@ -48686,7 +49469,7 @@
         "type": "choice",
         "posX": 3000,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -48721,7 +49504,7 @@
         "type": "single",
         "posX": 3600,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "next": [
           102389,
@@ -48751,7 +49534,7 @@
         "type": "single",
         "posX": 4800,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "next": [
           110164,
@@ -48781,7 +49564,7 @@
         "type": "choice",
         "posX": 5400,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -48816,7 +49599,7 @@
         "type": "single",
         "posX": 6000,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           102387
@@ -48844,7 +49627,7 @@
         "type": "single",
         "posX": 3000,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -48870,7 +49653,7 @@
         "type": "choice",
         "posX": 4200,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -48906,7 +49689,7 @@
         "type": "single",
         "posX": 5400,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -49845,7 +50628,7 @@
       },
       {
         "id": 102360,
-        "name": "Heart of the Pack",
+        "name": "Razor Sharp",
         "type": "single",
         "posX": 12000,
         "posY": 6300,
@@ -49862,7 +50645,7 @@
             "definitionId": 131248,
             "maxRanks": 1,
             "type": "passive",
-            "name": "Heart of the Pack",
+            "name": "Razor Sharp",
             "spellId": 1265052,
             "icon": "ability_druid_berserk",
             "index": 100
@@ -49878,7 +50661,7 @@
         "reqPoints": 20,
         "maxRanks": 1,
         "next": [
-          102339
+          110692
         ],
         "prev": [
           102336
@@ -50003,9 +50786,9 @@
         ]
       },
       {
-        "id": 102339,
-        "name": "Wild Instincts / Bloody Frenzy",
-        "type": "choice",
+        "id": 110692,
+        "name": "Bloody Frenzy",
+        "type": "single",
         "posX": 12600,
         "posY": 6900,
         "reqPoints": 20,
@@ -50016,16 +50799,6 @@
         ],
         "entries": [
           {
-            "id": 126401,
-            "definitionId": 131227,
-            "maxRanks": 1,
-            "type": "passive",
-            "name": "Wild Instincts",
-            "spellId": 378442,
-            "icon": "ability_hunter_beastwithin",
-            "index": 100
-          },
-          {
             "id": 126400,
             "definitionId": 131226,
             "maxRanks": 1,
@@ -50033,7 +50806,7 @@
             "name": "Bloody Frenzy",
             "spellId": 407412,
             "icon": "ability_racial_cannibalize",
-            "index": 200
+            "index": 100
           }
         ]
       },
@@ -50062,39 +50835,67 @@
             "index": 100
           }
         ]
-      }
-    ],
-    "heroNodes": [
+      },
       {
-        "id": 94987,
-        "name": "Black Arrow",
-        "type": "single",
-        "posX": 8100,
-        "posY": 1200,
-        "maxRanks": 1,
-        "entryNode": true,
-        "subTreeId": 44,
-        "next": [
-          94961,
-          94968,
-          94974,
-          109801
+        "id": 110428,
+        "name": "Nature's Ally / Nature's Ally / Nature's Ally",
+        "type": "tiered",
+        "posX": 12600,
+        "posY": 7650,
+        "reqPoints": 20,
+        "maxRanks": 4,
+        "rankLevels": [
+          {
+            "level": 81,
+            "maxRanks": 1
+          },
+          {
+            "level": 84,
+            "maxRanks": 3
+          },
+          {
+            "level": 90,
+            "maxRanks": 4
+          }
         ],
+        "entryNode": true,
+        "next": [],
         "prev": [],
         "entries": [
           {
-            "id": 117584,
-            "definitionId": 122596,
+            "id": 137052,
+            "definitionId": 141815,
             "maxRanks": 1,
-            "type": "passive",
-            "name": "Black Arrow",
-            "spellId": 466932,
-            "icon": "inv_ability_darkrangerhunter_blackarrow",
+            "type": "tierrank",
+            "name": "Nature's Ally",
+            "spellId": 1273043,
+            "icon": "inv12_apextalent_hunter_killfrenzy",
             "index": 100
+          },
+          {
+            "id": 137051,
+            "definitionId": 141814,
+            "maxRanks": 2,
+            "type": "tierrank",
+            "name": "Nature's Ally",
+            "spellId": 1273065,
+            "icon": "ability_hunter_pathfinding2",
+            "index": 200
+          },
+          {
+            "id": 137050,
+            "definitionId": 141813,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Nature's Ally",
+            "spellId": 1273126,
+            "icon": "ability_hunter_goforthethroat",
+            "index": 300
           }
-        ],
-        "freeNode": true
-      },
+        ]
+      }
+    ],
+    "heroNodes": [
       {
         "id": 109961,
         "name": "Black Arrow",
@@ -50123,7 +50924,8 @@
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 94961,
@@ -50137,7 +50939,6 @@
           94986
         ],
         "prev": [
-          94987,
           109961
         ],
         "entries": [
@@ -50165,7 +50966,6 @@
           94959
         ],
         "prev": [
-          94987,
           109961
         ],
         "entries": [
@@ -50193,7 +50993,6 @@
           94960
         ],
         "prev": [
-          94987,
           109961
         ],
         "entries": [
@@ -50221,7 +51020,6 @@
           109800
         ],
         "prev": [
-          94987,
           109961
         ],
         "entries": [
@@ -50302,6 +51100,43 @@
         ]
       },
       {
+        "id": 94960,
+        "name": "Dark Chains / Shadow Dagger",
+        "type": "choice",
+        "posX": 8400,
+        "posY": 2400,
+        "maxRanks": 1,
+        "subTreeId": 44,
+        "next": [
+          94982
+        ],
+        "prev": [
+          94974
+        ],
+        "entries": [
+          {
+            "id": 117557,
+            "definitionId": 122569,
+            "maxRanks": 1,
+            "type": "passive",
+            "name": "Dark Chains",
+            "spellId": 430712,
+            "icon": "inv_belt_44c",
+            "index": 100
+          },
+          {
+            "id": 128219,
+            "definitionId": 133026,
+            "maxRanks": 1,
+            "type": "passive",
+            "name": "Shadow Dagger",
+            "spellId": 467741,
+            "icon": "ability_throw",
+            "index": 200
+          }
+        ]
+      },
+      {
         "id": 109800,
         "name": "Wailing Dead",
         "type": "single",
@@ -50325,6 +51160,33 @@
             "spellId": 1264290,
             "icon": "ability_deathknight_summongargoyle",
             "index": 100
+          }
+        ]
+      },
+      {
+        "id": 94983,
+        "name": "Blighted Quiver",
+        "type": "single",
+        "posX": 7200,
+        "posY": 3000,
+        "maxRanks": 1,
+        "subTreeId": 44,
+        "next": [
+          94993
+        ],
+        "prev": [
+          94986
+        ],
+        "entries": [
+          {
+            "id": 128238,
+            "definitionId": 133045,
+            "maxRanks": 1,
+            "type": "passive",
+            "name": "Blighted Quiver",
+            "spellId": 1264291,
+            "icon": "inv_quiver_1h_sylvanas_d_01",
+            "index": 200
           }
         ]
       },
@@ -50476,7 +51338,8 @@
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 94985,
@@ -50980,7 +51843,6 @@
       102336,
       102337,
       102338,
-      102339,
       102340,
       102341,
       102342,
@@ -51045,7 +51907,6 @@
       102424,
       102425,
       103947,
-      103948,
       103950,
       103952,
       103955,
@@ -51058,15 +51919,11 @@
       103962,
       103964,
       103966,
-      103968,
-      103972,
-      103973,
       103974,
       103975,
       103977,
       103978,
       103979,
-      103981,
       103982,
       103984,
       103985,
@@ -51075,7 +51932,6 @@
       103989,
       103990,
       104095,
-      104126,
       104127,
       104130,
       107285,
@@ -51117,7 +51973,6 @@
       109804,
       109805,
       109807,
-      109938,
       109961,
       110028,
       110152,
@@ -51133,7 +51988,16 @@
       110162,
       110163,
       110164,
-      110208
+      110428,
+      110429,
+      110430,
+      110572,
+      110573,
+      110574,
+      110575,
+      110688,
+      110691,
+      110692
     ]
   },
   {
@@ -51950,7 +52814,7 @@
         "type": "single",
         "posX": 2400,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           110153
@@ -51977,7 +52841,7 @@
         "type": "single",
         "posX": 3000,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           110153,
@@ -52006,7 +52870,7 @@
         "type": "single",
         "posX": 3600,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           102416
@@ -52034,7 +52898,7 @@
         "type": "single",
         "posX": 4200,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           102416,
@@ -52062,7 +52926,7 @@
         "type": "single",
         "posX": 4800,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           102409
@@ -52090,7 +52954,7 @@
         "type": "single",
         "posX": 5400,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           102409,
@@ -52119,7 +52983,7 @@
         "type": "choice",
         "posX": 6000,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           102418
@@ -52156,7 +53020,7 @@
         "type": "single",
         "posX": 2400,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           102389
@@ -52184,7 +53048,7 @@
         "type": "choice",
         "posX": 3000,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -52219,7 +53083,7 @@
         "type": "single",
         "posX": 3600,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "next": [
           102389,
@@ -52249,7 +53113,7 @@
         "type": "single",
         "posX": 4800,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "next": [
           110164,
@@ -52279,7 +53143,7 @@
         "type": "choice",
         "posX": 5400,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -52314,7 +53178,7 @@
         "type": "single",
         "posX": 6000,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           102387
@@ -52342,7 +53206,7 @@
         "type": "single",
         "posX": 3000,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -52368,7 +53232,7 @@
         "type": "choice",
         "posX": 4200,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -52404,7 +53268,7 @@
         "type": "single",
         "posX": 5400,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -52447,7 +53311,7 @@
             "type": "active",
             "name": "Aimed Shot",
             "spellId": 19434,
-            "icon": "inv_spear_07",
+            "icon": "inv121_ability_hunter_aimedshot",
             "index": 100
           }
         ]
@@ -52460,7 +53324,8 @@
         "posY": 2100,
         "maxRanks": 1,
         "next": [
-          103975
+          103975,
+          104127
         ],
         "prev": [
           103982
@@ -52486,6 +53351,7 @@
         "posY": 2100,
         "maxRanks": 1,
         "next": [
+          104127,
           107289
         ],
         "prev": [
@@ -52512,8 +53378,7 @@
         "posY": 2700,
         "maxRanks": 1,
         "next": [
-          104130,
-          104127
+          104130
         ],
         "prev": [
           103961
@@ -52532,6 +53397,44 @@
         ]
       },
       {
+        "id": 104127,
+        "name": "Avian Specialization / Unbreakable Bond",
+        "type": "choice",
+        "posX": 12600,
+        "posY": 2700,
+        "maxRanks": 1,
+        "next": [
+          103986,
+          103964
+        ],
+        "prev": [
+          103977,
+          103961
+        ],
+        "entries": [
+          {
+            "id": 128710,
+            "definitionId": 133512,
+            "maxRanks": 1,
+            "type": "passive",
+            "name": "Avian Specialization",
+            "spellId": 466867,
+            "icon": "inv_111_hunter_ability_eyesinthesky",
+            "index": 100
+          },
+          {
+            "id": 129619,
+            "definitionId": 134420,
+            "maxRanks": 1,
+            "type": "passive",
+            "name": "Unbreakable Bond",
+            "spellId": 1223323,
+            "icon": "ability_hunter_separationanxiety",
+            "index": 200
+          }
+        ]
+      },
+      {
         "id": 107289,
         "name": "Lock and Load",
         "type": "single",
@@ -52539,7 +53442,7 @@
         "posY": 2700,
         "maxRanks": 1,
         "next": [
-          104127,
+          103964,
           103957
         ],
         "prev": [
@@ -52566,8 +53469,8 @@
         "posY": 3300,
         "maxRanks": 1,
         "next": [
-          103948,
-          103964
+          103959,
+          110572
         ],
         "prev": [
           103975
@@ -52586,41 +53489,67 @@
         ]
       },
       {
-        "id": 104127,
-        "name": "Avian Specialization / Unbreakable Bond",
+        "id": 103986,
+        "name": "Tenacious / Cunning",
         "type": "choice",
+        "posX": 12000,
+        "posY": 3300,
+        "maxRanks": 1,
+        "next": [
+          110572
+        ],
+        "prev": [
+          104127
+        ],
+        "entries": [
+          {
+            "id": 128408,
+            "definitionId": 133214,
+            "maxRanks": 1,
+            "type": "passive",
+            "name": "Tenacious",
+            "spellId": 474456,
+            "icon": "ability_druid_demoralizingroar",
+            "index": 100
+          },
+          {
+            "id": 128411,
+            "definitionId": 133217,
+            "maxRanks": 1,
+            "type": "passive",
+            "name": "Cunning",
+            "spellId": 474440,
+            "icon": "ability_eyeoftheowl",
+            "index": 200
+          }
+        ]
+      },
+      {
+        "id": 103964,
+        "name": "Penetrating Shots",
+        "type": "single",
         "posX": 12600,
         "posY": 3300,
         "maxRanks": 1,
         "next": [
-          103964,
-          103986,
-          103974
+          110572,
+          110575,
+          103947
         ],
         "prev": [
-          103975,
+          104127,
           107289
         ],
         "entries": [
           {
-            "id": 128710,
-            "definitionId": 133512,
+            "id": 128386,
+            "definitionId": 133192,
             "maxRanks": 1,
             "type": "passive",
-            "name": "Avian Specialization",
-            "spellId": 466867,
-            "icon": "inv_111_hunter_ability_eyesinthesky",
+            "name": "Penetrating Shots",
+            "spellId": 459783,
+            "icon": "achievement_guildperk_reinforce_rank2",
             "index": 100
-          },
-          {
-            "id": 129619,
-            "definitionId": 134420,
-            "maxRanks": 1,
-            "type": "passive",
-            "name": "Unbreakable Bond",
-            "spellId": 1223323,
-            "icon": "ability_hunter_separationanxiety",
-            "index": 200
           }
         ]
       },
@@ -52632,7 +53561,7 @@
         "posY": 3300,
         "maxRanks": 1,
         "next": [
-          103974,
+          110575,
           107288
         ],
         "prev": [
@@ -52662,170 +53591,18 @@
         ]
       },
       {
-        "id": 103948,
-        "name": "In the Rhythm",
-        "type": "single",
+        "id": 103959,
+        "name": "Obsidian Arrowhead / On Target",
+        "type": "choice",
         "posX": 10800,
         "posY": 3900,
         "reqPoints": 8,
         "maxRanks": 1,
         "next": [
-          103959
-        ],
-        "prev": [
-          104130
-        ],
-        "entries": [
-          {
-            "id": 128368,
-            "definitionId": 133174,
-            "maxRanks": 1,
-            "type": "passive",
-            "name": "In the Rhythm",
-            "spellId": 407404,
-            "icon": "ability_hunter_longshots",
-            "index": 100
-          }
-        ]
-      },
-      {
-        "id": 103964,
-        "name": "Penetrating Shots",
-        "type": "single",
-        "posX": 12000,
-        "posY": 3900,
-        "reqPoints": 8,
-        "maxRanks": 1,
-        "next": [
-          103959,
-          103955
-        ],
-        "prev": [
-          104127,
-          104130
-        ],
-        "entries": [
-          {
-            "id": 128386,
-            "definitionId": 133192,
-            "maxRanks": 1,
-            "type": "passive",
-            "name": "Penetrating Shots",
-            "spellId": 459783,
-            "icon": "achievement_guildperk_reinforce_rank2",
-            "index": 100
-          }
-        ]
-      },
-      {
-        "id": 103986,
-        "name": "Tenacious / Cunning",
-        "type": "choice",
-        "posX": 12600,
-        "posY": 3900,
-        "reqPoints": 8,
-        "maxRanks": 1,
-        "next": [
-          103947
-        ],
-        "prev": [
-          104127
-        ],
-        "entries": [
-          {
-            "id": 128408,
-            "definitionId": 133214,
-            "maxRanks": 1,
-            "type": "passive",
-            "name": "Tenacious",
-            "spellId": 474456,
-            "icon": "ability_druid_demoralizingroar",
-            "index": 100
-          },
-          {
-            "id": 128411,
-            "definitionId": 133217,
-            "maxRanks": 1,
-            "type": "passive",
-            "name": "Cunning",
-            "spellId": 474440,
-            "icon": "ability_eyeoftheowl",
-            "index": 200
-          }
-        ]
-      },
-      {
-        "id": 103974,
-        "name": "Master Marksman",
-        "type": "single",
-        "posX": 13200,
-        "posY": 3900,
-        "reqPoints": 8,
-        "maxRanks": 1,
-        "next": [
-          104126,
           109490
         ],
         "prev": [
-          104127,
-          103957
-        ],
-        "entries": [
-          {
-            "id": 128396,
-            "definitionId": 133202,
-            "maxRanks": 1,
-            "type": "passive",
-            "name": "Master Marksman",
-            "spellId": 260309,
-            "icon": "ability_hunter_mastermarksman",
-            "index": 100
-          }
-        ]
-      },
-      {
-        "id": 107288,
-        "name": "Light Ammo",
-        "type": "single",
-        "posX": 14400,
-        "posY": 3900,
-        "reqPoints": 8,
-        "maxRanks": 1,
-        "next": [
-          109490
-        ],
-        "prev": [
-          103957
-        ],
-        "entries": [
-          {
-            "id": 132192,
-            "definitionId": 136993,
-            "maxRanks": 1,
-            "type": "passive",
-            "name": "Light Ammo",
-            "spellId": 378913,
-            "icon": "ships_ability_armorpiercingammo",
-            "index": 100
-          }
-        ]
-      },
-      {
-        "id": 103959,
-        "name": "Obsidian Arrowhead / On Target",
-        "type": "choice",
-        "posX": 11400,
-        "posY": 4500,
-        "reqPoints": 8,
-        "maxRanks": 1,
-        "next": [
-          103968,
-          110208,
-          103978
-        ],
-        "prev": [
-          103964,
-          103948
+          104130
         ],
         "entries": [
           {
@@ -52851,84 +53628,89 @@
         ]
       },
       {
-        "id": 103955,
-        "name": "Small Game Hunter",
+        "id": 110572,
+        "name": "No Scope",
         "type": "single",
         "posX": 12000,
-        "posY": 4500,
+        "posY": 3900,
         "reqPoints": 8,
         "maxRanks": 1,
         "next": [
-          103978
+          109490,
+          103947,
+          103985
         ],
         "prev": [
+          103964,
+          103986,
+          104130
+        ],
+        "entries": [
+          {
+            "id": 137375,
+            "definitionId": 142135,
+            "maxRanks": 1,
+            "type": "passive",
+            "name": "No Scope",
+            "spellId": 473385,
+            "icon": "inv_eng_crowsnestscope",
+            "index": 100
+          }
+        ]
+      },
+      {
+        "id": 110575,
+        "name": "Explosive Shot",
+        "type": "single",
+        "posX": 13200,
+        "posY": 3900,
+        "reqPoints": 8,
+        "maxRanks": 1,
+        "next": [
+          103947,
+          110573,
+          110574
+        ],
+        "prev": [
+          103957,
           103964
         ],
         "entries": [
           {
-            "id": 128375,
-            "definitionId": 133181,
+            "id": 137378,
+            "definitionId": 142138,
             "maxRanks": 1,
-            "type": "passive",
-            "name": "Small Game Hunter",
-            "spellId": 459802,
-            "icon": "inv_rabbit2_darkmoon",
+            "type": "active",
+            "name": "Explosive Shot",
+            "spellId": 212431,
+            "icon": "ability_hunter_explosiveshot",
             "index": 100
           }
         ]
       },
       {
-        "id": 103947,
-        "name": "Trueshot",
+        "id": 107288,
+        "name": "Light Ammo",
         "type": "single",
-        "posX": 12600,
-        "posY": 4500,
+        "posX": 14400,
+        "posY": 3900,
         "reqPoints": 8,
         "maxRanks": 1,
         "next": [
-          103978,
-          103984,
-          103985
+          103955
         ],
         "prev": [
-          103986
+          103957
         ],
         "entries": [
           {
-            "id": 128367,
-            "definitionId": 133173,
+            "id": 132192,
+            "definitionId": 136993,
             "maxRanks": 1,
-            "type": "active",
-            "name": "Trueshot",
-            "spellId": 288613,
-            "icon": "ability_trueshot",
-            "index": 100
-          }
-        ]
-      },
-      {
-        "id": 104126,
-        "name": "Lethality",
-        "type": "single",
-        "posX": 13200,
-        "posY": 4500,
-        "reqPoints": 8,
-        "maxRanks": 2,
-        "next": [
-          103985
-        ],
-        "prev": [
-          103974
-        ],
-        "entries": [
-          {
-            "id": 128709,
-            "definitionId": 133511,
-            "maxRanks": 2,
             "type": "passive",
-            "name": "Lethality",
-            "spellId": 1259922,
-            "icon": "ability_hunter_blindingshot",
+            "name": "Light Ammo",
+            "spellId": 378913,
+            "icon": "ships_ability_armorpiercingammo",
             "index": 100
           }
         ]
@@ -52937,18 +53719,18 @@
         "id": 109490,
         "name": "Kill Shot",
         "type": "single",
-        "posX": 13800,
+        "posX": 11400,
         "posY": 4500,
         "reqPoints": 8,
         "maxRanks": 1,
         "next": [
-          103985,
-          103972,
-          109491
+          109491,
+          110688,
+          103985
         ],
         "prev": [
-          103974,
-          107288
+          103959,
+          110572
         ],
         "entries": [
           {
@@ -52964,50 +53746,120 @@
         ]
       },
       {
-        "id": 103968,
-        "name": "Target Acquisition",
+        "id": 103947,
+        "name": "Trueshot",
         "type": "single",
-        "posX": 10800,
-        "posY": 5100,
+        "posX": 12600,
+        "posY": 4500,
         "reqPoints": 8,
         "maxRanks": 1,
         "next": [
-          103950
+          103985,
+          103984,
+          103974
         ],
         "prev": [
-          103959
+          103964,
+          110572,
+          110575
         ],
         "entries": [
           {
-            "id": 128390,
-            "definitionId": 133196,
+            "id": 128367,
+            "definitionId": 133173,
             "maxRanks": 1,
-            "type": "passive",
-            "name": "Target Acquisition",
-            "spellId": 473379,
-            "icon": "ability_rogue_findweakness",
+            "type": "active",
+            "name": "Trueshot",
+            "spellId": 288613,
+            "icon": "ability_trueshot",
             "index": 100
           }
         ]
       },
       {
-        "id": 110208,
-        "name": "Critical Precision",
-        "type": "single",
-        "posX": 11400,
-        "posY": 5100,
+        "id": 110573,
+        "name": "Tactical Reload / Unstable Trigger",
+        "type": "choice",
+        "posX": 13200,
+        "posY": 4500,
         "reqPoints": 8,
         "maxRanks": 1,
         "next": [
-          103950
+          103974
         ],
         "prev": [
-          103959
+          110575
         ],
         "entries": [
           {
-            "id": 136741,
-            "definitionId": 141513,
+            "id": 137376,
+            "definitionId": 142136,
+            "maxRanks": 1,
+            "type": "passive",
+            "name": "Tactical Reload",
+            "spellId": 1301406,
+            "icon": "ability_ironmaidens_bombardment",
+            "index": 100
+          },
+          {
+            "id": 137635,
+            "definitionId": 142392,
+            "maxRanks": 1,
+            "type": "passive",
+            "name": "Unstable Trigger",
+            "spellId": 473520,
+            "icon": "spell_sandexplosion",
+            "index": 200
+          }
+        ]
+      },
+      {
+        "id": 110574,
+        "name": "Precision Detonation",
+        "type": "single",
+        "posX": 13800,
+        "posY": 4500,
+        "reqPoints": 8,
+        "maxRanks": 1,
+        "next": [
+          103974,
+          110691,
+          103978
+        ],
+        "prev": [
+          110575
+        ],
+        "entries": [
+          {
+            "id": 137377,
+            "definitionId": 142137,
+            "maxRanks": 1,
+            "type": "passive",
+            "name": "Precision Detonation",
+            "spellId": 471369,
+            "icon": "ability_hunter_explosiveshot",
+            "index": 100
+          }
+        ]
+      },
+      {
+        "id": 103955,
+        "name": "Critical Precision",
+        "type": "single",
+        "posX": 14400,
+        "posY": 4500,
+        "reqPoints": 8,
+        "maxRanks": 1,
+        "next": [
+          110691
+        ],
+        "prev": [
+          107288
+        ],
+        "entries": [
+          {
+            "id": 128375,
+            "definitionId": 133181,
             "maxRanks": 1,
             "type": "passive",
             "name": "Critical Precision",
@@ -53018,8 +53870,62 @@
         ]
       },
       {
-        "id": 103978,
-        "name": "No Scope",
+        "id": 109491,
+        "name": "Deathblow",
+        "type": "single",
+        "posX": 10800,
+        "posY": 5100,
+        "reqPoints": 8,
+        "maxRanks": 1,
+        "next": [
+          103950
+        ],
+        "prev": [
+          109490
+        ],
+        "entries": [
+          {
+            "id": 135714,
+            "definitionId": 140469,
+            "maxRanks": 1,
+            "type": "passive",
+            "name": "Deathblow",
+            "spellId": 343248,
+            "icon": "ability_hunter_runningshot",
+            "index": 100
+          }
+        ]
+      },
+      {
+        "id": 110688,
+        "name": "Deadeye",
+        "type": "single",
+        "posX": 11400,
+        "posY": 5100,
+        "reqPoints": 8,
+        "maxRanks": 1,
+        "next": [
+          103950
+        ],
+        "prev": [
+          109490
+        ],
+        "entries": [
+          {
+            "id": 128715,
+            "definitionId": 133517,
+            "maxRanks": 1,
+            "type": "passive",
+            "name": "Deadeye",
+            "spellId": 321460,
+            "icon": "spell_hunter_focusingshot",
+            "index": 100
+          }
+        ]
+      },
+      {
+        "id": 103985,
+        "name": "Bullseye",
         "type": "single",
         "posX": 12000,
         "posY": 5100,
@@ -53029,19 +53935,19 @@
           103950
         ],
         "prev": [
-          103947,
-          103955,
-          103959
+          109490,
+          110572,
+          103947
         ],
         "entries": [
           {
-            "id": 128400,
-            "definitionId": 133206,
+            "id": 128407,
+            "definitionId": 133213,
             "maxRanks": 1,
             "type": "passive",
-            "name": "No Scope",
-            "spellId": 473385,
-            "icon": "inv_eng_crowsnestscope",
+            "name": "Bullseye",
+            "spellId": 204089,
+            "icon": "ability_hunter_focusedaim",
             "index": 200
           }
         ]
@@ -53074,94 +53980,58 @@
         ]
       },
       {
-        "id": 103985,
-        "name": "Bullseye",
+        "id": 103974,
+        "name": "Master Marksman",
         "type": "single",
         "posX": 13200,
         "posY": 5100,
         "reqPoints": 8,
         "maxRanks": 1,
         "next": [
-          103973
+          103978
         ],
         "prev": [
-          109490,
-          104126,
-          103947
+          110573,
+          103947,
+          110574
         ],
         "entries": [
           {
-            "id": 128407,
-            "definitionId": 133213,
+            "id": 128396,
+            "definitionId": 133202,
             "maxRanks": 1,
             "type": "passive",
-            "name": "Bullseye",
-            "spellId": 204089,
-            "icon": "ability_hunter_focusedaim",
-            "index": 200
-          }
-        ]
-      },
-      {
-        "id": 103972,
-        "name": "Headshot / Deadeye",
-        "type": "choice",
-        "posX": 13800,
-        "posY": 5100,
-        "reqPoints": 8,
-        "maxRanks": 1,
-        "next": [
-          103973
-        ],
-        "prev": [
-          109490
-        ],
-        "entries": [
-          {
-            "id": 128394,
-            "definitionId": 133200,
-            "maxRanks": 1,
-            "type": "passive",
-            "name": "Headshot",
-            "spellId": 471363,
-            "icon": "ability_marksmanship",
+            "name": "Master Marksman",
+            "spellId": 260309,
+            "icon": "ability_hunter_mastermarksman",
             "index": 100
-          },
-          {
-            "id": 128715,
-            "definitionId": 133517,
-            "maxRanks": 1,
-            "type": "passive",
-            "name": "Deadeye",
-            "spellId": 321460,
-            "icon": "spell_hunter_focusingshot",
-            "index": 200
           }
         ]
       },
       {
-        "id": 109491,
-        "name": "Deathblow",
+        "id": 110691,
+        "name": "Eagle's Accuracy",
         "type": "single",
         "posX": 14400,
         "posY": 5100,
         "reqPoints": 8,
         "maxRanks": 1,
         "next": [
-          103973
+          103978
         ],
         "prev": [
-          109490
+          103955,
+          110574
         ],
         "entries": [
           {
-            "id": 135714,
-            "definitionId": 140469,
+            "id": 137506,
+            "definitionId": 142266,
             "maxRanks": 1,
             "type": "passive",
-            "name": "Deathblow",
-            "spellId": 343248,
-            "icon": "ability_hunter_runningshot",
+            "name": "Eagle's Accuracy",
+            "spellId": 473369,
+            "icon": "ability_hunter_silenthunter",
             "index": 100
           }
         ]
@@ -53179,9 +54049,9 @@
           103962
         ],
         "prev": [
-          103968,
-          110208,
-          103978
+          103985,
+          109491,
+          110688
         ],
         "entries": [
           {
@@ -53236,8 +54106,8 @@
         ]
       },
       {
-        "id": 103973,
-        "name": "Eagle's Accuracy",
+        "id": 103978,
+        "name": "Small Game Hunter",
         "type": "single",
         "posX": 13800,
         "posY": 5700,
@@ -53248,20 +54118,20 @@
           103979
         ],
         "prev": [
-          103972,
-          109491,
-          103985
+          103974,
+          110574,
+          110691
         ],
         "entries": [
           {
-            "id": 128395,
-            "definitionId": 133201,
+            "id": 128400,
+            "definitionId": 133206,
             "maxRanks": 2,
             "type": "passive",
-            "name": "Eagle's Accuracy",
-            "spellId": 473369,
-            "icon": "ability_hunter_silenthunter",
-            "index": 100
+            "name": "Small Game Hunter",
+            "spellId": 459802,
+            "icon": "inv_rabbit2_darkmoon",
+            "index": 200
           }
         ]
       },
@@ -53301,8 +54171,7 @@
         "reqPoints": 20,
         "maxRanks": 1,
         "next": [
-          107290,
-          109938
+          107290
         ],
         "prev": [
           103958,
@@ -53329,9 +54198,7 @@
         "posY": 6300,
         "reqPoints": 20,
         "maxRanks": 1,
-        "next": [
-          109938
-        ],
+        "next": [],
         "prev": [
           103958
         ],
@@ -53357,13 +54224,11 @@
         "reqPoints": 20,
         "maxRanks": 1,
         "next": [
-          109938,
-          103960,
-          103981
+          103960
         ],
         "prev": [
-          103973,
-          103958
+          103958,
+          103978
         ],
         "entries": [
           {
@@ -53390,7 +54255,7 @@
           104095
         ],
         "prev": [
-          103973
+          103978
         ],
         "entries": [
           {
@@ -53432,7 +54297,7 @@
       },
       {
         "id": 107290,
-        "name": "Incendiary Ammunition",
+        "name": "Accuracy By Volume",
         "type": "single",
         "posX": 12000,
         "posY": 6900,
@@ -53448,36 +54313,9 @@
             "definitionId": 136996,
             "maxRanks": 1,
             "type": "passive",
-            "name": "Incendiary Ammunition",
+            "name": "Accuracy By Volume",
             "spellId": 471428,
             "icon": "inv12_ability_hunter_fierymunitions",
-            "index": 200
-          }
-        ]
-      },
-      {
-        "id": 109938,
-        "name": "Double Tap",
-        "type": "single",
-        "posX": 12600,
-        "posY": 6900,
-        "reqPoints": 20,
-        "maxRanks": 1,
-        "next": [],
-        "prev": [
-          103966,
-          103956,
-          103962
-        ],
-        "entries": [
-          {
-            "id": 136232,
-            "definitionId": 141005,
-            "maxRanks": 1,
-            "type": "passive",
-            "name": "Double Tap",
-            "spellId": 473370,
-            "icon": "ability_hunter_crossfire",
             "index": 200
           }
         ]
@@ -53508,41 +54346,6 @@
         ]
       },
       {
-        "id": 103981,
-        "name": "Bullet Hell / Shrapnel Shot",
-        "type": "choice",
-        "posX": 13800,
-        "posY": 6900,
-        "reqPoints": 20,
-        "maxRanks": 1,
-        "next": [],
-        "prev": [
-          103956
-        ],
-        "entries": [
-          {
-            "id": 128403,
-            "definitionId": 133209,
-            "maxRanks": 1,
-            "type": "passive",
-            "name": "Bullet Hell",
-            "spellId": 473378,
-            "icon": "buff_epichunter",
-            "index": 100
-          },
-          {
-            "id": 135735,
-            "definitionId": 140490,
-            "maxRanks": 1,
-            "type": "passive",
-            "name": "Shrapnel Shot",
-            "spellId": 473520,
-            "icon": "spell_sandexplosion",
-            "index": 200
-          }
-        ]
-      },
-      {
         "id": 104095,
         "name": "Unload",
         "type": "single",
@@ -53566,6 +54369,64 @@
             "index": 100
           }
         ]
+      },
+      {
+        "id": 110430,
+        "name": "Take Aim / Take Aim / Take Aim",
+        "type": "tiered",
+        "posX": 12600,
+        "posY": 7650,
+        "reqPoints": 20,
+        "maxRanks": 4,
+        "rankLevels": [
+          {
+            "level": 81,
+            "maxRanks": 1
+          },
+          {
+            "level": 84,
+            "maxRanks": 3
+          },
+          {
+            "level": 90,
+            "maxRanks": 4
+          }
+        ],
+        "entryNode": true,
+        "next": [],
+        "prev": [],
+        "entries": [
+          {
+            "id": 137058,
+            "definitionId": 141821,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Take Aim",
+            "spellId": 1273132,
+            "icon": "inv12_apextalent_hunter_deadlyinsight",
+            "index": 100
+          },
+          {
+            "id": 137057,
+            "definitionId": 141820,
+            "maxRanks": 2,
+            "type": "tierrank",
+            "name": "Take Aim",
+            "spellId": 1273129,
+            "icon": "ability_hunter_wildquiver",
+            "index": 200
+          },
+          {
+            "id": 137056,
+            "definitionId": 141819,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Take Aim",
+            "spellId": 1273128,
+            "icon": "inv_spear_07",
+            "index": 300
+          }
+        ]
       }
     ],
     "heroNodes": [
@@ -53578,6 +54439,7 @@
         "maxRanks": 1,
         "entryNode": true,
         "subTreeId": 44,
+        "requiresNode": 109490,
         "next": [
           94961,
           94968,
@@ -53597,7 +54459,8 @@
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 94976,
@@ -53627,7 +54490,8 @@
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 94961,
@@ -53641,8 +54505,7 @@
           94986
         ],
         "prev": [
-          94987,
-          109961
+          94987
         ],
         "entries": [
           {
@@ -53669,8 +54532,7 @@
           94959
         ],
         "prev": [
-          94987,
-          109961
+          94987
         ],
         "entries": [
           {
@@ -53697,8 +54559,7 @@
           94960
         ],
         "prev": [
-          94987,
-          109961
+          94987
         ],
         "entries": [
           {
@@ -53725,8 +54586,7 @@
           109800
         ],
         "prev": [
-          94987,
-          109961
+          94987
         ],
         "entries": [
           {
@@ -54518,7 +55378,6 @@
       102336,
       102337,
       102338,
-      102339,
       102340,
       102341,
       102342,
@@ -54583,7 +55442,6 @@
       102424,
       102425,
       103947,
-      103948,
       103950,
       103952,
       103955,
@@ -54596,15 +55454,11 @@
       103962,
       103964,
       103966,
-      103968,
-      103972,
-      103973,
       103974,
       103975,
       103977,
       103978,
       103979,
-      103981,
       103982,
       103984,
       103985,
@@ -54613,7 +55467,6 @@
       103989,
       103990,
       104095,
-      104126,
       104127,
       104130,
       107285,
@@ -54655,7 +55508,6 @@
       109804,
       109805,
       109807,
-      109938,
       109961,
       110028,
       110152,
@@ -54671,7 +55523,16 @@
       110162,
       110163,
       110164,
-      110208
+      110428,
+      110429,
+      110430,
+      110572,
+      110573,
+      110574,
+      110575,
+      110688,
+      110691,
+      110692
     ]
   },
   {
@@ -55488,7 +56349,7 @@
         "type": "single",
         "posX": 2400,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           110153
@@ -55515,9 +56376,10 @@
         "type": "single",
         "posX": 3000,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
+          110153,
           102394,
           102416
         ],
@@ -55543,7 +56405,7 @@
         "type": "single",
         "posX": 3600,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           102416
@@ -55571,7 +56433,7 @@
         "type": "single",
         "posX": 4200,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           102416,
@@ -55599,7 +56461,7 @@
         "type": "single",
         "posX": 4800,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           102409
@@ -55627,7 +56489,7 @@
         "type": "single",
         "posX": 5400,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           102409,
@@ -55656,7 +56518,7 @@
         "type": "choice",
         "posX": 6000,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           102418
@@ -55693,13 +56555,14 @@
         "type": "single",
         "posX": 2400,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           102389
         ],
         "prev": [
-          110154
+          110154,
+          103989
         ],
         "entries": [
           {
@@ -55720,7 +56583,7 @@
         "type": "choice",
         "posX": 3000,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -55755,7 +56618,7 @@
         "type": "single",
         "posX": 3600,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "next": [
           102389,
@@ -55785,7 +56648,7 @@
         "type": "single",
         "posX": 4800,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "next": [
           110164,
@@ -55815,7 +56678,7 @@
         "type": "choice",
         "posX": 5400,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -55850,7 +56713,7 @@
         "type": "single",
         "posX": 6000,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           102387
@@ -55878,7 +56741,7 @@
         "type": "single",
         "posX": 3000,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -55904,7 +56767,7 @@
         "type": "choice",
         "posX": 4200,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -55940,7 +56803,7 @@
         "type": "single",
         "posX": 5400,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -56159,6 +57022,7 @@
         "maxRanks": 1,
         "next": [
           102279,
+          109305,
           110163
         ],
         "prev": [
@@ -56279,7 +57143,7 @@
         "reqPoints": 8,
         "maxRanks": 1,
         "next": [
-          109305
+          110159
         ],
         "prev": [
           109324,
@@ -56299,6 +57163,33 @@
         ]
       },
       {
+        "id": 109305,
+        "name": "Sic 'Em",
+        "type": "single",
+        "posX": 13800,
+        "posY": 3900,
+        "reqPoints": 8,
+        "maxRanks": 1,
+        "next": [
+          110159
+        ],
+        "prev": [
+          109321
+        ],
+        "entries": [
+          {
+            "id": 135496,
+            "definitionId": 140253,
+            "maxRanks": 1,
+            "type": "passive",
+            "name": "Sic 'Em",
+            "spellId": 1253137,
+            "icon": "ability_hunter_sickem",
+            "index": 100
+          }
+        ]
+      },
+      {
         "id": 110163,
         "name": "Two Against Many",
         "type": "single",
@@ -56307,7 +57198,7 @@
         "reqPoints": 8,
         "maxRanks": 1,
         "next": [
-          109305
+          110159
         ],
         "prev": [
           109321
@@ -56422,8 +57313,8 @@
         ]
       },
       {
-        "id": 109305,
-        "name": "Sic 'Em",
+        "id": 110159,
+        "name": "Primal Surge",
         "type": "single",
         "posX": 13800,
         "posY": 4500,
@@ -56431,22 +57322,22 @@
         "maxRanks": 1,
         "next": [
           102282,
-          109304,
           109306
         ],
         "prev": [
+          109305,
           110163,
           102279
         ],
         "entries": [
           {
-            "id": 135496,
-            "definitionId": 140253,
+            "id": 136680,
+            "definitionId": 141452,
             "maxRanks": 1,
             "type": "passive",
-            "name": "Sic 'Em",
-            "spellId": 1253137,
-            "icon": "ability_hunter_sickem",
+            "name": "Primal Surge",
+            "spellId": 1272154,
+            "icon": "ability_hunter_longevity",
             "index": 100
           }
         ]
@@ -56585,8 +57476,8 @@
           109312
         ],
         "prev": [
-          109305,
-          109319
+          109319,
+          110159
         ],
         "entries": [
           {
@@ -56612,33 +57503,6 @@
         ]
       },
       {
-        "id": 109304,
-        "name": "Shower of Blood",
-        "type": "single",
-        "posX": 13800,
-        "posY": 5100,
-        "reqPoints": 8,
-        "maxRanks": 2,
-        "next": [
-          109312
-        ],
-        "prev": [
-          109305
-        ],
-        "entries": [
-          {
-            "id": 135495,
-            "definitionId": 140252,
-            "maxRanks": 2,
-            "type": "passive",
-            "name": "Shower of Blood",
-            "spellId": 1253053,
-            "icon": "spell_druid_bloodythrash",
-            "index": 100
-          }
-        ]
-      },
-      {
         "id": 109306,
         "name": "Outland Venom",
         "type": "single",
@@ -56650,7 +57514,7 @@
           109312
         ],
         "prev": [
-          109305
+          110159
         ],
         "entries": [
           {
@@ -56660,7 +57524,7 @@
             "type": "passive",
             "name": "Outland Venom",
             "spellId": 459939,
-            "icon": "ability_creature_disease_04",
+            "icon": "ability_hunter_potentvenom",
             "index": 100
           }
         ]
@@ -56736,7 +57600,6 @@
           102268
         ],
         "prev": [
-          109304,
           109306,
           102282
         ],
@@ -56755,7 +57618,7 @@
       },
       {
         "id": 102252,
-        "name": "Flamefang Pitch",
+        "name": "Bombardier",
         "type": "single",
         "posX": 11400,
         "posY": 6300,
@@ -56773,10 +57636,10 @@
             "id": 126311,
             "definitionId": 131137,
             "maxRanks": 1,
-            "type": "active",
-            "name": "Flamefang Pitch",
-            "spellId": 1251592,
-            "icon": "inv_10_blacksmithing_craftedoptional_blacksmithdye_fire",
+            "type": "passive",
+            "name": "Bombardier",
+            "spellId": 1311963,
+            "icon": "inv_misc_blackironbomb",
             "index": 100
           }
         ]
@@ -56845,7 +57708,7 @@
         "maxRanks": 1,
         "next": [
           102257,
-          110159
+          109304
         ],
         "prev": [
           109312
@@ -56965,27 +57828,85 @@
         ]
       },
       {
-        "id": 110159,
-        "name": "Primal Surge",
+        "id": 109304,
+        "name": "Razor Edge",
         "type": "single",
         "posX": 14400,
         "posY": 6900,
         "reqPoints": 20,
-        "maxRanks": 1,
+        "maxRanks": 2,
         "next": [],
         "prev": [
           102268
         ],
         "entries": [
           {
-            "id": 136680,
-            "definitionId": 141452,
-            "maxRanks": 1,
+            "id": 135495,
+            "definitionId": 140252,
+            "maxRanks": 2,
             "type": "passive",
-            "name": "Primal Surge",
-            "spellId": 1272154,
-            "icon": "ability_hunter_longevity",
+            "name": "Razor Edge",
+            "spellId": 1253053,
+            "icon": "spell_druid_bloodythrash",
             "index": 100
+          }
+        ]
+      },
+      {
+        "id": 110429,
+        "name": "Raptor Swipe / Raptor Swipe / Raptor Swipe",
+        "type": "tiered",
+        "posX": 12600,
+        "posY": 7650,
+        "reqPoints": 20,
+        "maxRanks": 4,
+        "rankLevels": [
+          {
+            "level": 81,
+            "maxRanks": 1
+          },
+          {
+            "level": 84,
+            "maxRanks": 3
+          },
+          {
+            "level": 90,
+            "maxRanks": 4
+          }
+        ],
+        "entryNode": true,
+        "next": [],
+        "prev": [],
+        "entries": [
+          {
+            "id": 137055,
+            "definitionId": 141818,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Raptor Swipe",
+            "spellId": 1259003,
+            "icon": "inv12_apextalent_hunter_raptorswipe",
+            "index": 100
+          },
+          {
+            "id": 137054,
+            "definitionId": 141817,
+            "maxRanks": 2,
+            "type": "tierrank",
+            "name": "Raptor Swipe",
+            "spellId": 1259017,
+            "icon": "ability_hunter_raptorstrike",
+            "index": 200
+          },
+          {
+            "id": 137053,
+            "definitionId": 141816,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Raptor Swipe",
+            "spellId": 1259019,
+            "icon": "inv_raptortravelform",
+            "index": 300
           }
         ]
       }
@@ -57019,7 +57940,8 @@
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 94989,
@@ -57431,7 +58353,8 @@
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 94985,
@@ -57934,7 +58857,6 @@
       102336,
       102337,
       102338,
-      102339,
       102340,
       102341,
       102342,
@@ -57999,7 +58921,6 @@
       102424,
       102425,
       103947,
-      103948,
       103950,
       103952,
       103955,
@@ -58012,15 +58933,11 @@
       103962,
       103964,
       103966,
-      103968,
-      103972,
-      103973,
       103974,
       103975,
       103977,
       103978,
       103979,
-      103981,
       103982,
       103984,
       103985,
@@ -58029,7 +58946,6 @@
       103989,
       103990,
       104095,
-      104126,
       104127,
       104130,
       107285,
@@ -58071,7 +58987,6 @@
       109804,
       109805,
       109807,
-      109938,
       109961,
       110028,
       110152,
@@ -58087,7 +59002,16 @@
       110162,
       110163,
       110164,
-      110208
+      110428,
+      110429,
+      110430,
+      110572,
+      110573,
+      110574,
+      110575,
+      110688,
+      110691,
+      110692
     ]
   },
   {
@@ -58654,6 +59578,7 @@
         "maxRanks": 1,
         "next": [
           90743,
+          110576,
           94562
         ],
         "prev": [
@@ -58826,6 +59751,33 @@
         ]
       },
       {
+        "id": 110576,
+        "name": "Sanguine Vial",
+        "type": "single",
+        "posX": 3900,
+        "posY": 4500,
+        "reqPoints": 8,
+        "maxRanks": 1,
+        "next": [
+          90752
+        ],
+        "prev": [
+          90747
+        ],
+        "entries": [
+          {
+            "id": 137380,
+            "definitionId": 142140,
+            "maxRanks": 1,
+            "type": "passive",
+            "name": "Sanguine Vial",
+            "spellId": 1293135,
+            "icon": "inv_misc_potiona5",
+            "index": 100
+          }
+        ]
+      },
+      {
         "id": 94562,
         "name": "Deep Cuts",
         "type": "single",
@@ -58927,7 +59879,8 @@
         ],
         "prev": [
           90743,
-          94562
+          94562,
+          110576
         ],
         "entries": [
           {
@@ -58987,7 +59940,7 @@
         "type": "single",
         "posX": 2700,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           90759
@@ -59014,7 +59967,7 @@
         "type": "single",
         "posX": 3300,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "next": [
           90748
@@ -59042,7 +59995,7 @@
         "type": "single",
         "posX": 3900,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           90639
@@ -59069,7 +60022,7 @@
         "type": "single",
         "posX": 4500,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "next": [
           90750
@@ -59097,7 +60050,7 @@
         "type": "single",
         "posX": 5100,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           90688
@@ -59124,7 +60077,7 @@
         "type": "single",
         "posX": 2700,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "next": [
           90756
@@ -59151,7 +60104,7 @@
         "type": "single",
         "posX": 3900,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "requiresNode": 90770,
         "next": [
@@ -59179,7 +60132,7 @@
         "type": "single",
         "posX": 5100,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "next": [
           101713
@@ -59202,11 +60155,11 @@
       },
       {
         "id": 90756,
-        "name": "Thistle Tea",
-        "type": "single",
+        "name": "Thistle Tea / Thistle Tea",
+        "type": "choice",
         "posX": 2700,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -59223,6 +60176,16 @@
             "visibleSpellId": 381623,
             "icon": "inv_drink_milk_05",
             "index": 100
+          },
+          {
+            "id": 137464,
+            "definitionId": 142224,
+            "maxRanks": 1,
+            "type": "active",
+            "name": "Thistle Tea",
+            "spellId": 1298826,
+            "icon": "inv_drink_milk_05",
+            "index": 200
           }
         ]
       },
@@ -59232,7 +60195,7 @@
         "type": "single",
         "posX": 3300,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -59257,7 +60220,7 @@
         "type": "choice",
         "posX": 3900,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "requiresNode": 90770,
         "next": [],
@@ -59293,7 +60256,7 @@
         "type": "single",
         "posX": 4500,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -59318,7 +60281,7 @@
         "type": "single",
         "posX": 5100,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -59833,8 +60796,8 @@
       },
       {
         "id": 90626,
-        "name": "Finish the Job",
-        "type": "single",
+        "name": "Finish the Job / Negotiable Contract",
+        "type": "choice",
         "posX": 12300,
         "posY": 4500,
         "reqPoints": 8,
@@ -59855,6 +60818,16 @@
             "spellId": 1249809,
             "icon": "ability_revendreth_demonhunter",
             "index": 100
+          },
+          {
+            "id": 137379,
+            "definitionId": 142139,
+            "maxRanks": 1,
+            "type": "passive",
+            "name": "Negotiable Contract",
+            "spellId": 1292996,
+            "icon": "ability_revendreth_rogue",
+            "index": 200
           }
         ]
       },
@@ -59953,7 +60926,7 @@
       },
       {
         "id": 90771,
-        "name": "Systemic Failure",
+        "name": "Amplifying Poison",
         "type": "single",
         "posX": 11100,
         "posY": 5100,
@@ -59973,10 +60946,10 @@
             "id": 112664,
             "definitionId": 117669,
             "maxRanks": 1,
-            "type": "passive",
-            "name": "Systemic Failure",
-            "spellId": 381652,
-            "icon": "ability_skeer_bloodletting",
+            "type": "active",
+            "name": "Amplifying Poison",
+            "spellId": 381664,
+            "icon": "inv_misc_herb_fellotus",
             "index": 100
           }
         ]
@@ -60014,7 +60987,7 @@
       },
       {
         "id": 90777,
-        "name": "Amplifying Poison",
+        "name": "Systemic Failure",
         "type": "single",
         "posX": 13500,
         "posY": 5100,
@@ -60034,17 +61007,17 @@
             "id": 112670,
             "definitionId": 117675,
             "maxRanks": 1,
-            "type": "active",
-            "name": "Amplifying Poison",
-            "spellId": 381664,
-            "icon": "inv_misc_herb_fellotus",
+            "type": "passive",
+            "name": "Systemic Failure",
+            "spellId": 381652,
+            "icon": "ability_skeer_bloodletting",
             "index": 100
           }
         ]
       },
       {
         "id": 90786,
-        "name": "Blindside",
+        "name": "Dashing Scoundrel",
         "type": "single",
         "posX": 11100,
         "posY": 5700,
@@ -60062,9 +61035,9 @@
             "definitionId": 117684,
             "maxRanks": 1,
             "type": "passive",
-            "name": "Blindside",
-            "spellId": 328085,
-            "icon": "ability_rogue_focusedattacks",
+            "name": "Dashing Scoundrel",
+            "spellId": 381797,
+            "icon": "ability_rogue_venomouswounds",
             "index": 100
           }
         ]
@@ -60157,7 +61130,7 @@
       },
       {
         "id": 90622,
-        "name": "Avulsion",
+        "name": "Blindside",
         "type": "single",
         "posX": 13500,
         "posY": 5700,
@@ -60175,9 +61148,9 @@
             "definitionId": 117512,
             "maxRanks": 1,
             "type": "passive",
-            "name": "Avulsion",
-            "spellId": 1250358,
-            "icon": "inv_artifact_corruptedbloodofzakajz",
+            "name": "Blindside",
+            "spellId": 328085,
+            "icon": "ability_rogue_focusedattacks",
             "index": 100
           }
         ]
@@ -60274,7 +61247,7 @@
       },
       {
         "id": 90774,
-        "name": "Deadly Momentum",
+        "name": "Avulsion",
         "type": "single",
         "posX": 12900,
         "posY": 6300,
@@ -60291,9 +61264,9 @@
             "definitionId": 117672,
             "maxRanks": 1,
             "type": "passive",
-            "name": "Deadly Momentum",
-            "spellId": 1250271,
-            "icon": "ability_rogue_deadlymomentum",
+            "name": "Avulsion",
+            "spellId": 1250358,
+            "icon": "inv_artifact_corruptedbloodofzakajz",
             "index": 100
           }
         ]
@@ -60328,7 +61301,7 @@
       },
       {
         "id": 90784,
-        "name": "Dashing Scoundrel",
+        "name": "Unstable Toxin",
         "type": "single",
         "posX": 11100,
         "posY": 6900,
@@ -60344,9 +61317,9 @@
             "definitionId": 117682,
             "maxRanks": 1,
             "type": "passive",
-            "name": "Dashing Scoundrel",
-            "spellId": 381797,
-            "icon": "ability_rogue_venomouswounds",
+            "name": "Unstable Toxin",
+            "spellId": 1298812,
+            "icon": "rogue_venomzest",
             "index": 100
           }
         ]
@@ -60400,6 +61373,64 @@
             "index": 100
           }
         ]
+      },
+      {
+        "id": 110433,
+        "name": "Implacable / Implacable / Implacable",
+        "type": "tiered",
+        "posX": 12300,
+        "posY": 7650,
+        "reqPoints": 20,
+        "maxRanks": 4,
+        "rankLevels": [
+          {
+            "level": 81,
+            "maxRanks": 1
+          },
+          {
+            "level": 84,
+            "maxRanks": 3
+          },
+          {
+            "level": 90,
+            "maxRanks": 4
+          }
+        ],
+        "entryNode": true,
+        "next": [],
+        "prev": [],
+        "entries": [
+          {
+            "id": 137067,
+            "definitionId": 141831,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Implacable",
+            "spellId": 1265385,
+            "icon": "inv12_apextalent_rogue_implacable",
+            "index": 100
+          },
+          {
+            "id": 137066,
+            "definitionId": 141830,
+            "maxRanks": 2,
+            "type": "tierrank",
+            "name": "Implacable",
+            "spellId": 1265386,
+            "icon": "inv12_apextalent_rogue_implacable",
+            "index": 200
+          },
+          {
+            "id": 137065,
+            "definitionId": 141829,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Implacable",
+            "spellId": 1265387,
+            "icon": "inv12_apextalent_rogue_implacable",
+            "index": 300
+          }
+        ]
       }
     ],
     "heroNodes": [
@@ -60431,7 +61462,8 @@
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 95136,
@@ -60461,7 +61493,8 @@
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 95138,
@@ -61503,7 +62536,11 @@
       109768,
       110323,
       110324,
-      110325
+      110325,
+      110432,
+      110433,
+      110434,
+      110576
     ]
   },
   {
@@ -62070,6 +63107,7 @@
         "maxRanks": 1,
         "next": [
           90743,
+          110576,
           94562
         ],
         "prev": [
@@ -62242,6 +63280,33 @@
         ]
       },
       {
+        "id": 110576,
+        "name": "Sanguine Vial",
+        "type": "single",
+        "posX": 3900,
+        "posY": 4500,
+        "reqPoints": 8,
+        "maxRanks": 1,
+        "next": [
+          90752
+        ],
+        "prev": [
+          90747
+        ],
+        "entries": [
+          {
+            "id": 137380,
+            "definitionId": 142140,
+            "maxRanks": 1,
+            "type": "passive",
+            "name": "Sanguine Vial",
+            "spellId": 1293135,
+            "icon": "inv_misc_potiona5",
+            "index": 100
+          }
+        ]
+      },
+      {
         "id": 94562,
         "name": "Deep Cuts",
         "type": "single",
@@ -62343,7 +63408,8 @@
         ],
         "prev": [
           90743,
-          94562
+          94562,
+          110576
         ],
         "entries": [
           {
@@ -62403,7 +63469,7 @@
         "type": "single",
         "posX": 2700,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           90759
@@ -62430,7 +63496,7 @@
         "type": "single",
         "posX": 3300,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "next": [
           90748
@@ -62458,7 +63524,7 @@
         "type": "single",
         "posX": 3900,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           90639
@@ -62485,7 +63551,7 @@
         "type": "single",
         "posX": 4500,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "next": [
           90750
@@ -62513,7 +63579,7 @@
         "type": "single",
         "posX": 5100,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           90688
@@ -62540,7 +63606,7 @@
         "type": "single",
         "posX": 2700,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "next": [
           90756
@@ -62567,7 +63633,7 @@
         "type": "single",
         "posX": 3900,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "requiresNode": 90770,
         "next": [
@@ -62595,7 +63661,7 @@
         "type": "single",
         "posX": 5100,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "next": [
           101713
@@ -62618,11 +63684,11 @@
       },
       {
         "id": 90756,
-        "name": "Thistle Tea",
-        "type": "single",
+        "name": "Thistle Tea / Thistle Tea",
+        "type": "choice",
         "posX": 2700,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -62639,6 +63705,16 @@
             "visibleSpellId": 381623,
             "icon": "inv_drink_milk_05",
             "index": 100
+          },
+          {
+            "id": 137464,
+            "definitionId": 142224,
+            "maxRanks": 1,
+            "type": "active",
+            "name": "Thistle Tea",
+            "spellId": 1298826,
+            "icon": "inv_drink_milk_05",
+            "index": 200
           }
         ]
       },
@@ -62648,7 +63724,7 @@
         "type": "single",
         "posX": 3300,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -62673,7 +63749,7 @@
         "type": "choice",
         "posX": 3900,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "requiresNode": 90770,
         "next": [],
@@ -62709,7 +63785,7 @@
         "type": "single",
         "posX": 4500,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -62734,7 +63810,7 @@
         "type": "single",
         "posX": 5100,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -63141,7 +64217,8 @@
         "maxRanks": 1,
         "next": [
           90678,
-          90641
+          90641,
+          90677
         ],
         "prev": [
           90679
@@ -63279,7 +64356,8 @@
         "maxRanks": 1,
         "next": [
           90668,
-          90669
+          90669,
+          90667
         ],
         "prev": [
           90663
@@ -63463,7 +64541,8 @@
         ],
         "prev": [
           90641,
-          90678
+          90678,
+          90680
         ],
         "entries": [
           {
@@ -63586,7 +64665,8 @@
         ],
         "prev": [
           90669,
-          90668
+          90668,
+          90671
         ],
         "entries": [
           {
@@ -63816,6 +64896,64 @@
             "index": 100
           }
         ]
+      },
+      {
+        "id": 110434,
+        "name": "Gravedigger / Gravedigger / Gravedigger",
+        "type": "tiered",
+        "posX": 12300,
+        "posY": 7650,
+        "reqPoints": 20,
+        "maxRanks": 4,
+        "rankLevels": [
+          {
+            "level": 81,
+            "maxRanks": 1
+          },
+          {
+            "level": 84,
+            "maxRanks": 3
+          },
+          {
+            "level": 90,
+            "maxRanks": 4
+          }
+        ],
+        "entryNode": true,
+        "next": [],
+        "prev": [],
+        "entries": [
+          {
+            "id": 137070,
+            "definitionId": 141834,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Gravedigger",
+            "spellId": 1265861,
+            "icon": "inv12_apextalent_rogue_gravedigger",
+            "index": 100
+          },
+          {
+            "id": 137069,
+            "definitionId": 141833,
+            "maxRanks": 2,
+            "type": "tierrank",
+            "name": "Gravedigger",
+            "spellId": 1265862,
+            "icon": "inv12_apextalent_rogue_gravedigger",
+            "index": 200
+          },
+          {
+            "id": 137068,
+            "definitionId": 141832,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Gravedigger",
+            "spellId": 1265863,
+            "icon": "inv12_apextalent_rogue_gravedigger",
+            "index": 300
+          }
+        ]
       }
     ],
     "heroNodes": [
@@ -63847,7 +64985,8 @@
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 95138,
@@ -64260,7 +65399,8 @@
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 95121,
@@ -64425,7 +65565,6 @@
         "posY": 5400,
         "maxRanks": 1,
         "subTreeId": 51,
-        "requiresNode": 90715,
         "next": [
           95116
         ],
@@ -64517,7 +65656,6 @@
         "posY": 6000,
         "maxRanks": 1,
         "subTreeId": 51,
-        "requiresNode": 90715,
         "next": [
           95115
         ],
@@ -64921,7 +66059,11 @@
       109768,
       110323,
       110324,
-      110325
+      110325,
+      110432,
+      110433,
+      110434,
+      110576
     ]
   },
   {
@@ -65488,6 +66630,7 @@
         "maxRanks": 1,
         "next": [
           90743,
+          110576,
           94562
         ],
         "prev": [
@@ -65660,6 +66803,33 @@
         ]
       },
       {
+        "id": 110576,
+        "name": "Sanguine Vial",
+        "type": "single",
+        "posX": 3900,
+        "posY": 4500,
+        "reqPoints": 8,
+        "maxRanks": 1,
+        "next": [
+          90752
+        ],
+        "prev": [
+          90747
+        ],
+        "entries": [
+          {
+            "id": 137380,
+            "definitionId": 142140,
+            "maxRanks": 1,
+            "type": "passive",
+            "name": "Sanguine Vial",
+            "spellId": 1293135,
+            "icon": "inv_misc_potiona5",
+            "index": 100
+          }
+        ]
+      },
+      {
         "id": 94562,
         "name": "Deep Cuts",
         "type": "single",
@@ -65761,7 +66931,8 @@
         ],
         "prev": [
           90743,
-          94562
+          94562,
+          110576
         ],
         "entries": [
           {
@@ -65821,7 +66992,7 @@
         "type": "single",
         "posX": 2700,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           90759
@@ -65848,7 +67019,7 @@
         "type": "single",
         "posX": 3300,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "next": [
           90748
@@ -65876,7 +67047,7 @@
         "type": "single",
         "posX": 3900,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           90639
@@ -65903,7 +67074,7 @@
         "type": "single",
         "posX": 4500,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "next": [
           90750
@@ -65931,7 +67102,7 @@
         "type": "single",
         "posX": 5100,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           90688
@@ -65958,7 +67129,7 @@
         "type": "single",
         "posX": 2700,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "next": [
           90756
@@ -65985,7 +67156,7 @@
         "type": "single",
         "posX": 3900,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "requiresNode": 90770,
         "next": [
@@ -66013,7 +67184,7 @@
         "type": "single",
         "posX": 5100,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "next": [
           101713
@@ -66036,11 +67207,11 @@
       },
       {
         "id": 90756,
-        "name": "Thistle Tea",
-        "type": "single",
+        "name": "Thistle Tea / Thistle Tea",
+        "type": "choice",
         "posX": 2700,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -66057,6 +67228,16 @@
             "visibleSpellId": 381623,
             "icon": "inv_drink_milk_05",
             "index": 100
+          },
+          {
+            "id": 137464,
+            "definitionId": 142224,
+            "maxRanks": 1,
+            "type": "active",
+            "name": "Thistle Tea",
+            "spellId": 1298826,
+            "icon": "inv_drink_milk_05",
+            "index": 200
           }
         ]
       },
@@ -66066,7 +67247,7 @@
         "type": "single",
         "posX": 3300,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -66091,7 +67272,7 @@
         "type": "choice",
         "posX": 3900,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "requiresNode": 90770,
         "next": [],
@@ -66127,7 +67308,7 @@
         "type": "single",
         "posX": 4500,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -66152,7 +67333,7 @@
         "type": "single",
         "posX": 5100,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -66862,7 +68043,7 @@
       },
       {
         "id": 90735,
-        "name": "The First Dance",
+        "name": "Deepening Shadows",
         "type": "single",
         "posX": 11700,
         "posY": 5100,
@@ -66882,16 +68063,16 @@
             "definitionId": 117630,
             "maxRanks": 1,
             "type": "passive",
-            "name": "The First Dance",
-            "spellId": 382505,
-            "icon": "ability_rogue_shadowdance",
+            "name": "Deepening Shadows",
+            "spellId": 185314,
+            "icon": "spell_shadow_twilight",
             "index": 100
           }
         ]
       },
       {
         "id": 90724,
-        "name": "Deepening Shadows",
+        "name": "Goremaw's Bite",
         "type": "single",
         "posX": 12300,
         "posY": 5100,
@@ -66911,10 +68092,10 @@
             "id": 112612,
             "definitionId": 117617,
             "maxRanks": 1,
-            "type": "passive",
-            "name": "Deepening Shadows",
-            "spellId": 185314,
-            "icon": "spell_shadow_twilight",
+            "type": "active",
+            "name": "Goremaw's Bite",
+            "spellId": 426591,
+            "icon": "inv_knife_1h_artifactfangs_d_01",
             "index": 100
           }
         ]
@@ -67284,7 +68465,7 @@
       },
       {
         "id": 94581,
-        "name": "Goremaw's Bite",
+        "name": "The First Dance",
         "type": "single",
         "posX": 12900,
         "posY": 6900,
@@ -67300,10 +68481,10 @@
             "id": 117169,
             "definitionId": 122181,
             "maxRanks": 1,
-            "type": "active",
-            "name": "Goremaw's Bite",
-            "spellId": 426591,
-            "icon": "inv_knife_1h_artifactfangs_d_01",
+            "type": "passive",
+            "name": "The First Dance",
+            "spellId": 382505,
+            "icon": "ability_rogue_shadowdance",
             "index": 100
           }
         ]
@@ -67330,6 +68511,64 @@
             "spellId": 382504,
             "icon": "spell_nature_slowpoison",
             "index": 100
+          }
+        ]
+      },
+      {
+        "id": 110432,
+        "name": "Ancient Arts / Ancient Arts / Ancient Arts",
+        "type": "tiered",
+        "posX": 12300,
+        "posY": 7650,
+        "reqPoints": 20,
+        "maxRanks": 4,
+        "rankLevels": [
+          {
+            "level": 81,
+            "maxRanks": 1
+          },
+          {
+            "level": 84,
+            "maxRanks": 3
+          },
+          {
+            "level": 90,
+            "maxRanks": 4
+          }
+        ],
+        "entryNode": true,
+        "next": [],
+        "prev": [],
+        "entries": [
+          {
+            "id": 137064,
+            "definitionId": 141827,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Ancient Arts",
+            "spellId": 1268932,
+            "icon": "inv12_apextalent_rogue_ancientarts",
+            "index": 100
+          },
+          {
+            "id": 137063,
+            "definitionId": 141826,
+            "maxRanks": 2,
+            "type": "tierrank",
+            "name": "Ancient Arts",
+            "spellId": 1268936,
+            "icon": "inv12_apextalent_rogue_ancientarts",
+            "index": 200
+          },
+          {
+            "id": 137062,
+            "definitionId": 141825,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Ancient Arts",
+            "spellId": 1268939,
+            "icon": "inv12_apextalent_rogue_ancientarts",
+            "index": 300
           }
         ]
       }
@@ -67363,7 +68602,8 @@
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 95110,
@@ -67785,7 +69025,8 @@
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 95121,
@@ -67950,7 +69191,6 @@
         "posY": 5400,
         "maxRanks": 1,
         "subTreeId": 51,
-        "requiresNode": 90715,
         "next": [
           95116
         ],
@@ -68042,7 +69282,6 @@
         "posY": 6000,
         "maxRanks": 1,
         "subTreeId": 51,
-        "requiresNode": 90715,
         "next": [
           95115
         ],
@@ -68446,7 +69685,11 @@
       109768,
       110323,
       110324,
-      110325
+      110325,
+      110432,
+      110433,
+      110434,
+      110576
     ]
   },
   {
@@ -69472,7 +70715,7 @@
         "type": "single",
         "posX": 2700,
         "posY": 5400,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           103626
@@ -69500,7 +70743,7 @@
         "type": "single",
         "posX": 3900,
         "posY": 5400,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           103587
@@ -69528,7 +70771,7 @@
         "type": "single",
         "posX": 4500,
         "posY": 5400,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           103587,
@@ -69558,7 +70801,7 @@
         "type": "single",
         "posX": 5700,
         "posY": 5400,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           103593,
@@ -69588,7 +70831,7 @@
         "type": "choice",
         "posX": 2700,
         "posY": 6000,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           103620
@@ -69625,7 +70868,7 @@
         "type": "single",
         "posX": 3900,
         "posY": 6000,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           103620,
@@ -69654,7 +70897,7 @@
         "type": "choice",
         "posX": 4500,
         "posY": 6000,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           109388
@@ -69691,7 +70934,7 @@
         "type": "choice",
         "posX": 5100,
         "posY": 6000,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           109388,
@@ -69730,7 +70973,7 @@
         "type": "single",
         "posX": 6300,
         "posY": 6000,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           109387
@@ -69757,7 +71000,7 @@
         "type": "single",
         "posX": 3300,
         "posY": 6600,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -69783,7 +71026,7 @@
         "type": "single",
         "posX": 4500,
         "posY": 6600,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -69810,7 +71053,7 @@
         "type": "single",
         "posX": 5700,
         "posY": 6600,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -70720,7 +71963,7 @@
             "type": "active",
             "name": "Ascendance",
             "spellId": 114050,
-            "icon": "spell_fire_elementaldevastation",
+            "icon": "inv121_ability_shaman_ascendance_fire",
             "index": 100
           }
         ]
@@ -71027,6 +72270,64 @@
             "index": 100
           }
         ]
+      },
+      {
+        "id": 110402,
+        "name": "Feedback Loop / Feedback Loop / Feedback Loop",
+        "type": "tiered",
+        "posX": 12600,
+        "posY": 7350,
+        "reqPoints": 20,
+        "maxRanks": 4,
+        "rankLevels": [
+          {
+            "level": 81,
+            "maxRanks": 1
+          },
+          {
+            "level": 84,
+            "maxRanks": 3
+          },
+          {
+            "level": 90,
+            "maxRanks": 4
+          }
+        ],
+        "entryNode": true,
+        "next": [],
+        "prev": [],
+        "entries": [
+          {
+            "id": 136974,
+            "definitionId": 141737,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Feedback Loop",
+            "spellId": 1270061,
+            "icon": "inv12_apextalent_shaman_feedbackloop",
+            "index": 300
+          },
+          {
+            "id": 136973,
+            "definitionId": 141736,
+            "maxRanks": 2,
+            "type": "tierrank",
+            "name": "Feedback Loop",
+            "spellId": 1270062,
+            "icon": "inv12_apextalent_shaman_feedbackloop",
+            "index": 400
+          },
+          {
+            "id": 136972,
+            "definitionId": 141735,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Feedback Loop",
+            "spellId": 1270064,
+            "icon": "inv12_apextalent_shaman_feedbackloop",
+            "index": 500
+          }
+        ]
       }
     ],
     "heroNodes": [
@@ -71059,7 +72360,8 @@
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 94862,
@@ -71069,7 +72371,6 @@
         "posY": 1800,
         "maxRanks": 1,
         "subTreeId": 56,
-        "requiresNode": 80988,
         "next": [
           94887
         ],
@@ -71474,7 +72775,8 @@
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 94886,
@@ -71978,7 +73280,6 @@
       81015,
       81016,
       81018,
-      81019,
       81021,
       81022,
       81024,
@@ -72132,7 +73433,11 @@
       110083,
       110084,
       110085,
-      110186
+      110186,
+      110401,
+      110402,
+      110403,
+      113376
     ]
   },
   {
@@ -73158,7 +74463,7 @@
         "type": "single",
         "posX": 2700,
         "posY": 5400,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           103626
@@ -73186,7 +74491,7 @@
         "type": "single",
         "posX": 3900,
         "posY": 5400,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           103587
@@ -73214,7 +74519,7 @@
         "type": "single",
         "posX": 4500,
         "posY": 5400,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           103587,
@@ -73244,7 +74549,7 @@
         "type": "single",
         "posX": 5700,
         "posY": 5400,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           103593,
@@ -73274,7 +74579,7 @@
         "type": "choice",
         "posX": 2700,
         "posY": 6000,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           103620
@@ -73311,7 +74616,7 @@
         "type": "single",
         "posX": 3900,
         "posY": 6000,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           103620,
@@ -73340,7 +74645,7 @@
         "type": "choice",
         "posX": 4500,
         "posY": 6000,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           109388
@@ -73377,7 +74682,7 @@
         "type": "choice",
         "posX": 5100,
         "posY": 6000,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           109388,
@@ -73416,7 +74721,7 @@
         "type": "single",
         "posX": 6300,
         "posY": 6000,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           109387
@@ -73443,7 +74748,7 @@
         "type": "single",
         "posX": 3300,
         "posY": 6600,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -73469,7 +74774,7 @@
         "type": "single",
         "posX": 4500,
         "posY": 6600,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -73496,7 +74801,7 @@
         "type": "single",
         "posX": 5700,
         "posY": 6600,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -73708,7 +75013,7 @@
       },
       {
         "id": 80939,
-        "name": "Raging Maelstrom",
+        "name": "Overflowing Maelstrom",
         "type": "single",
         "posX": 12600,
         "posY": 3000,
@@ -73727,7 +75032,7 @@
             "definitionId": 106871,
             "maxRanks": 1,
             "type": "passive",
-            "name": "Raging Maelstrom",
+            "name": "Overflowing Maelstrom",
             "spellId": 384143,
             "icon": "inv_magic_swirl_color3",
             "index": 0
@@ -73821,7 +75126,7 @@
       },
       {
         "id": 80938,
-        "name": "Overflowing Maelstrom",
+        "name": "Raging Maelstrom",
         "type": "single",
         "posX": 12600,
         "posY": 3600,
@@ -73839,7 +75144,7 @@
             "definitionId": 106880,
             "maxRanks": 1,
             "type": "passive",
-            "name": "Overflowing Maelstrom",
+            "name": "Raging Maelstrom",
             "spellId": 384149,
             "icon": "spell_nature_elementalabsorption",
             "index": 0
@@ -74471,7 +75776,7 @@
             "type": "active",
             "name": "Ascendance",
             "spellId": 114051,
-            "icon": "spell_fire_elementaldevastation",
+            "icon": "inv121_ability_shaman_ascendance_air",
             "index": 200
           }
         ]
@@ -74525,6 +75830,64 @@
             "index": 100
           }
         ]
+      },
+      {
+        "id": 110401,
+        "name": "Storm Unleashed / Storm Unleashed / Storm Unleashed",
+        "type": "tiered",
+        "posX": 12600,
+        "posY": 7350,
+        "reqPoints": 20,
+        "maxRanks": 4,
+        "rankLevels": [
+          {
+            "level": 81,
+            "maxRanks": 1
+          },
+          {
+            "level": 84,
+            "maxRanks": 3
+          },
+          {
+            "level": 90,
+            "maxRanks": 4
+          }
+        ],
+        "entryNode": true,
+        "next": [],
+        "prev": [],
+        "entries": [
+          {
+            "id": 136971,
+            "definitionId": 141734,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Storm Unleashed",
+            "spellId": 1262713,
+            "icon": "inv12_apextalent_shaman_stormunleashed",
+            "index": 100
+          },
+          {
+            "id": 136970,
+            "definitionId": 141733,
+            "maxRanks": 2,
+            "type": "tierrank",
+            "name": "Storm Unleashed",
+            "spellId": 1262761,
+            "icon": "spell_druid_astralstorm",
+            "index": 200
+          },
+          {
+            "id": 136969,
+            "definitionId": 141732,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Storm Unleashed",
+            "spellId": 1252373,
+            "icon": "spell_druid_astralstorm",
+            "index": 300
+          }
+        ]
       }
     ],
     "heroNodes": [
@@ -74557,7 +75920,8 @@
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 94890,
@@ -74982,7 +76346,8 @@
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 94886,
@@ -75486,7 +76851,6 @@
       81015,
       81016,
       81018,
-      81019,
       81021,
       81022,
       81024,
@@ -75640,7 +77004,11 @@
       110083,
       110084,
       110085,
-      110186
+      110186,
+      110401,
+      110402,
+      110403,
+      113376
     ]
   },
   {
@@ -76666,7 +78034,7 @@
         "type": "single",
         "posX": 2700,
         "posY": 5400,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           103626
@@ -76694,7 +78062,7 @@
         "type": "single",
         "posX": 3900,
         "posY": 5400,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           103587
@@ -76722,7 +78090,7 @@
         "type": "single",
         "posX": 4500,
         "posY": 5400,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           103587,
@@ -76752,7 +78120,7 @@
         "type": "single",
         "posX": 5700,
         "posY": 5400,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           103593,
@@ -76782,7 +78150,7 @@
         "type": "choice",
         "posX": 2700,
         "posY": 6000,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           103620
@@ -76819,7 +78187,7 @@
         "type": "single",
         "posX": 3900,
         "posY": 6000,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           103620,
@@ -76848,7 +78216,7 @@
         "type": "choice",
         "posX": 4500,
         "posY": 6000,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           109388
@@ -76885,7 +78253,7 @@
         "type": "choice",
         "posX": 5100,
         "posY": 6000,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           109388,
@@ -76924,7 +78292,7 @@
         "type": "single",
         "posX": 6300,
         "posY": 6000,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           109387
@@ -76951,7 +78319,7 @@
         "type": "single",
         "posX": 3300,
         "posY": 6600,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -76977,7 +78345,7 @@
         "type": "single",
         "posX": 4500,
         "posY": 6600,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -77004,7 +78372,7 @@
         "type": "single",
         "posX": 5700,
         "posY": 6600,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -77187,7 +78555,7 @@
             "type": "active",
             "name": "Ascendance",
             "spellId": 114052,
-            "icon": "spell_fire_elementaldevastation",
+            "icon": "inv121_ability_shaman_ascendance_water",
             "index": 100
           },
           {
@@ -77329,7 +78697,7 @@
         "maxRanks": 1,
         "next": [
           81047,
-          81019
+          103427
         ],
         "prev": [
           81021,
@@ -77356,7 +78724,7 @@
         "posY": 3000,
         "maxRanks": 1,
         "next": [
-          81019,
+          103427,
           81048
         ],
         "prev": [
@@ -77437,13 +78805,13 @@
         ]
       },
       {
-        "id": 81019,
-        "name": "Calm Waters",
+        "id": 103427,
+        "name": "Wavespeaker's Blessing",
         "type": "single",
         "posX": 14400,
         "posY": 3600,
         "reqPoints": 8,
-        "maxRanks": 1,
+        "maxRanks": 2,
         "next": [
           81049,
           81046,
@@ -77455,14 +78823,14 @@
         ],
         "entries": [
           {
-            "id": 101896,
-            "definitionId": 106923,
-            "maxRanks": 1,
+            "id": 127671,
+            "definitionId": 132480,
+            "maxRanks": 2,
             "type": "passive",
-            "name": "Calm Waters",
-            "spellId": 1252841,
-            "icon": "inv_10_elementalshardfoozles_water",
-            "index": 300
+            "name": "Wavespeaker's Blessing",
+            "spellId": 381946,
+            "icon": "inv_alchemist_81_spiritedalchemiststone",
+            "index": 100
           }
         ]
       },
@@ -77621,7 +78989,7 @@
         ],
         "prev": [
           81047,
-          81019
+          103427
         ],
         "entries": [
           {
@@ -77650,7 +79018,7 @@
         ],
         "prev": [
           81048,
-          81019
+          103427
         ],
         "entries": [
           {
@@ -77724,7 +79092,7 @@
       },
       {
         "id": 81044,
-        "name": "Echo of the Elements",
+        "name": "Tidal Waves",
         "type": "single",
         "posX": 13200,
         "posY": 4800,
@@ -77745,9 +79113,9 @@
             "definitionId": 106941,
             "maxRanks": 1,
             "type": "passive",
-            "name": "Echo of the Elements",
-            "spellId": 333919,
-            "icon": "ability_shaman_echooftheelements",
+            "name": "Tidal Waves",
+            "spellId": 51564,
+            "icon": "spell_shaman_tidalwaves",
             "index": 100
           }
         ]
@@ -77793,8 +79161,8 @@
         ],
         "prev": [
           81046,
-          81019,
-          81049
+          81049,
+          103427
         ],
         "entries": [
           {
@@ -77850,7 +79218,7 @@
       },
       {
         "id": 81055,
-        "name": "Primal Tide Core",
+        "name": "Echo of the Elements",
         "type": "single",
         "posX": 12600,
         "posY": 5400,
@@ -77872,9 +79240,9 @@
             "definitionId": 106939,
             "maxRanks": 1,
             "type": "passive",
-            "name": "Primal Tide Core",
-            "spellId": 382045,
-            "icon": "ability_shaman_repulsiontotem",
+            "name": "Echo of the Elements",
+            "spellId": 333919,
+            "icon": "ability_shaman_echooftheelements",
             "index": 100
           }
         ]
@@ -77890,7 +79258,7 @@
         "next": [
           81052,
           103915,
-          103427
+          113376
         ],
         "prev": [
           81044,
@@ -77919,7 +79287,7 @@
         "reqPoints": 20,
         "maxRanks": 1,
         "next": [
-          103427,
+          113376,
           81051
         ],
         "prev": [
@@ -78078,13 +79446,13 @@
         ]
       },
       {
-        "id": 103427,
-        "name": "Wavespeaker's Blessing",
+        "id": 113376,
+        "name": "Swelling Tides",
         "type": "single",
         "posX": 14400,
         "posY": 6000,
         "reqPoints": 20,
-        "maxRanks": 2,
+        "maxRanks": 1,
         "next": [
           81042,
           81051
@@ -78095,13 +79463,13 @@
         ],
         "entries": [
           {
-            "id": 127671,
-            "definitionId": 132480,
-            "maxRanks": 2,
+            "id": 140663,
+            "definitionId": 145345,
+            "maxRanks": 1,
             "type": "passive",
-            "name": "Wavespeaker's Blessing",
-            "spellId": 381946,
-            "icon": "inv_alchemist_81_spiritedalchemiststone",
+            "name": "Swelling Tides",
+            "spellId": 1312843,
+            "icon": "ability_shaman_manatidetotem",
             "index": 100
           }
         ]
@@ -78126,14 +79494,14 @@
             "type": "passive",
             "name": "Double Dip",
             "spellId": 1252882,
-            "icon": "spell_shaman_tidalwaves",
+            "icon": "ability_mage_waterjet",
             "index": 100
           }
         ]
       },
       {
         "id": 80976,
-        "name": "Whispering Waves",
+        "name": "Primal Tide Core",
         "type": "single",
         "posX": 12600,
         "posY": 6600,
@@ -78151,9 +79519,9 @@
             "definitionId": 106901,
             "maxRanks": 1,
             "type": "passive",
-            "name": "Whispering Waves",
-            "spellId": 1217598,
-            "icon": "shaman_pvp_ripplingwaters",
+            "name": "Primal Tide Core",
+            "spellId": 382045,
+            "icon": "ability_shaman_repulsiontotem",
             "index": 100
           }
         ]
@@ -78169,8 +79537,8 @@
         "next": [],
         "prev": [
           103915,
-          103427,
-          81052
+          81052,
+          113376
         ],
         "entries": [
           {
@@ -78195,8 +79563,8 @@
         "maxRanks": 1,
         "next": [],
         "prev": [
-          103427,
-          103430
+          103430,
+          113376
         ],
         "entries": [
           {
@@ -78207,6 +79575,64 @@
             "name": "Deeply Rooted Elements",
             "spellId": 378270,
             "icon": "inv_misc_herb_liferoot_stem",
+            "index": 300
+          }
+        ]
+      },
+      {
+        "id": 110403,
+        "name": "Stormstream Totem / Stormstream Totem / Stormstream Totem",
+        "type": "tiered",
+        "posX": 13200,
+        "posY": 7350,
+        "reqPoints": 20,
+        "maxRanks": 4,
+        "rankLevels": [
+          {
+            "level": 81,
+            "maxRanks": 1
+          },
+          {
+            "level": 84,
+            "maxRanks": 3
+          },
+          {
+            "level": 90,
+            "maxRanks": 4
+          }
+        ],
+        "entryNode": true,
+        "next": [],
+        "prev": [],
+        "entries": [
+          {
+            "id": 136977,
+            "definitionId": 141740,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Stormstream Totem",
+            "spellId": 1267016,
+            "icon": "inv12_apextalent_shaman_stormstreamtotem",
+            "index": 100
+          },
+          {
+            "id": 136976,
+            "definitionId": 141739,
+            "maxRanks": 2,
+            "type": "tierrank",
+            "name": "Stormstream Totem",
+            "spellId": 1267093,
+            "icon": "inv12_apextalent_shaman_stormstreamtotem",
+            "index": 200
+          },
+          {
+            "id": 136975,
+            "definitionId": 141738,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Stormstream Totem",
+            "spellId": 1267120,
+            "icon": "inv12_apextalent_shaman_stormstreamtotem",
             "index": 300
           }
         ]
@@ -78242,7 +79668,8 @@
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 94877,
@@ -78273,7 +79700,8 @@
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 94862,
@@ -78283,7 +79711,6 @@
         "posY": 1800,
         "maxRanks": 1,
         "subTreeId": 56,
-        "requiresNode": 80988,
         "next": [
           94887
         ],
@@ -79175,7 +80602,6 @@
       81015,
       81016,
       81018,
-      81019,
       81021,
       81022,
       81024,
@@ -79329,7 +80755,11 @@
       110083,
       110084,
       110085,
-      110186
+      110186,
+      110401,
+      110402,
+      110403,
+      113376
     ]
   },
   {
@@ -80419,7 +81849,7 @@
         "type": "single",
         "posX": 3000,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           81495
@@ -80447,7 +81877,7 @@
         "type": "single",
         "posX": 3600,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           81495,
@@ -80477,7 +81907,7 @@
         "type": "choice",
         "posX": 4200,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           81621
@@ -80514,7 +81944,7 @@
         "type": "single",
         "posX": 4800,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           81621,
@@ -80543,7 +81973,7 @@
         "type": "single",
         "posX": 5400,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           103851
@@ -80571,7 +82001,7 @@
         "type": "single",
         "posX": 6000,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           103851,
@@ -80601,7 +82031,7 @@
         "type": "single",
         "posX": 6600,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           103856
@@ -80629,7 +82059,7 @@
         "type": "single",
         "posX": 3000,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           93357
@@ -80657,7 +82087,7 @@
         "type": "single",
         "posX": 3600,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           93357
@@ -80684,7 +82114,7 @@
         "type": "single",
         "posX": 4200,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "next": [
           93357,
@@ -80714,7 +82144,7 @@
         "type": "single",
         "posX": 5400,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "next": [
           103861,
@@ -80744,7 +82174,7 @@
         "type": "single",
         "posX": 6000,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           103863
@@ -80771,7 +82201,7 @@
         "type": "choice",
         "posX": 6600,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           103863
@@ -80809,7 +82239,7 @@
         "type": "single",
         "posX": 3600,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -80836,7 +82266,7 @@
         "type": "single",
         "posX": 4800,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -80862,7 +82292,7 @@
         "type": "single",
         "posX": 6000,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -82186,6 +83616,64 @@
             "index": 100
           }
         ]
+      },
+      {
+        "id": 110417,
+        "name": "Beacon of the Savior / Beacon of the Savior / Beacon of the Savior",
+        "type": "tiered",
+        "posX": 13200,
+        "posY": 7650,
+        "reqPoints": 20,
+        "maxRanks": 4,
+        "rankLevels": [
+          {
+            "level": 81,
+            "maxRanks": 1
+          },
+          {
+            "level": 84,
+            "maxRanks": 3
+          },
+          {
+            "level": 90,
+            "maxRanks": 4
+          }
+        ],
+        "entryNode": true,
+        "next": [],
+        "prev": [],
+        "entries": [
+          {
+            "id": 137019,
+            "definitionId": 141782,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Beacon of the Savior",
+            "spellId": 1244878,
+            "icon": "inv12_apextalent_paladin_beaconofthesavior",
+            "index": 100
+          },
+          {
+            "id": 137018,
+            "definitionId": 141781,
+            "maxRanks": 2,
+            "type": "tierrank",
+            "name": "Beacon of the Savior",
+            "spellId": 1245367,
+            "icon": "inv12_apextalent_paladin_beaconofthesavior",
+            "index": 200
+          },
+          {
+            "id": 137017,
+            "definitionId": 141780,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Beacon of the Savior",
+            "spellId": 1245368,
+            "icon": "inv12_apextalent_paladin_beaconofthesavior",
+            "index": 300
+          }
+        ]
       }
     ],
     "heroNodes": [
@@ -82218,7 +83706,8 @@
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 95073,
@@ -82629,12 +84118,14 @@
             "maxRanks": 1,
             "type": "active",
             "name": "Holy Armaments",
-            "spellId": 432459,
+            "spellId": 1289728,
+            "visibleSpellId": 432459,
             "icon": "inv_ability_lightsmithpaladin_holybulwark",
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 95233,
@@ -82648,7 +84139,6 @@
           95236
         ],
         "prev": [
-          95234,
           110257
         ],
         "entries": [
@@ -82686,7 +84176,6 @@
           95231
         ],
         "prev": [
-          95234,
           110257
         ],
         "entries": [
@@ -82714,7 +84203,6 @@
           95232
         ],
         "prev": [
-          95234,
           110257
         ],
         "entries": [
@@ -82752,7 +84240,6 @@
           109743
         ],
         "prev": [
-          95234,
           110257
         ],
         "entries": [
@@ -83100,10 +84587,7 @@
       81469,
       81470,
       81471,
-      81472,
-      81473,
       81474,
-      81475,
       81476,
       81477,
       81479,
@@ -83126,7 +84610,6 @@
       81497,
       81498,
       81499,
-      81500,
       81501,
       81502,
       81503,
@@ -83206,7 +84689,6 @@
       81618,
       81621,
       81628,
-      81629,
       81630,
       81631,
       81632,
@@ -83330,7 +84812,11 @@
       110091,
       110092,
       110093,
-      110257
+      110257,
+      110417,
+      110418,
+      110419,
+      110862
     ]
   },
   {
@@ -84431,7 +85917,7 @@
         "type": "single",
         "posX": 3000,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           81495
@@ -84459,7 +85945,7 @@
         "type": "single",
         "posX": 3600,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           81495,
@@ -84489,7 +85975,7 @@
         "type": "choice",
         "posX": 4200,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           81621
@@ -84526,7 +86012,7 @@
         "type": "single",
         "posX": 4800,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           81621,
@@ -84555,7 +86041,7 @@
         "type": "single",
         "posX": 5400,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           103851
@@ -84583,7 +86069,7 @@
         "type": "single",
         "posX": 6000,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           103851,
@@ -84613,7 +86099,7 @@
         "type": "single",
         "posX": 6600,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           103856
@@ -84641,7 +86127,7 @@
         "type": "single",
         "posX": 3000,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           93357
@@ -84669,7 +86155,7 @@
         "type": "single",
         "posX": 3600,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           93357
@@ -84696,7 +86182,7 @@
         "type": "single",
         "posX": 4200,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "next": [
           93357,
@@ -84726,7 +86212,7 @@
         "type": "single",
         "posX": 5400,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "next": [
           103861,
@@ -84756,7 +86242,7 @@
         "type": "single",
         "posX": 6000,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           103863
@@ -84783,7 +86269,7 @@
         "type": "choice",
         "posX": 6600,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           103863
@@ -84821,7 +86307,7 @@
         "type": "single",
         "posX": 3600,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -84848,7 +86334,7 @@
         "type": "single",
         "posX": 4800,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -84874,7 +86360,7 @@
         "type": "single",
         "posX": 6000,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -84932,7 +86418,7 @@
         "maxRanks": 1,
         "next": [
           81487,
-          81494
+          81476
         ],
         "prev": [
           81502
@@ -84959,7 +86445,7 @@
         "maxRanks": 1,
         "next": [
           81487,
-          81498
+          81494
         ],
         "prev": [
           81502
@@ -84988,18 +86474,84 @@
         ]
       },
       {
-        "id": 81494,
-        "name": "Imbued Shield / Redoubt",
+        "id": 81476,
+        "name": "Valiant Crusade / Blessed Word",
         "type": "choice",
         "posX": 12000,
         "posY": 2700,
         "maxRanks": 1,
         "next": [
-          81486,
-          81476
+          110862,
+          81486
         ],
         "prev": [
           81489
+        ],
+        "entries": [
+          {
+            "id": 102439,
+            "definitionId": 107444,
+            "maxRanks": 1,
+            "type": "passive",
+            "name": "Valiant Crusade",
+            "spellId": 1245979,
+            "icon": "ability_mount_alliancepvpmount",
+            "index": 100
+          },
+          {
+            "id": 137505,
+            "definitionId": 142265,
+            "maxRanks": 1,
+            "type": "passive",
+            "name": "Blessed Word",
+            "spellId": 1301732,
+            "icon": "spell_paladin_divinecircle",
+            "index": 200
+          }
+        ]
+      },
+      {
+        "id": 81487,
+        "name": "Grand Crusader",
+        "type": "single",
+        "posX": 13200,
+        "posY": 2700,
+        "maxRanks": 1,
+        "next": [
+          110862,
+          81501,
+          81481
+        ],
+        "prev": [
+          81489,
+          81469
+        ],
+        "entries": [
+          {
+            "id": 102453,
+            "definitionId": 107458,
+            "maxRanks": 1,
+            "type": "passive",
+            "name": "Grand Crusader",
+            "spellId": 85043,
+            "icon": "inv_helmet_74",
+            "index": 100
+          }
+        ]
+      },
+      {
+        "id": 81494,
+        "name": "Imbued Shield / Redoubt",
+        "type": "choice",
+        "posX": 14400,
+        "posY": 2700,
+        "maxRanks": 1,
+        "next": [
+          81501,
+          101927
+        ],
+        "prev": [
+          81469
         ],
         "entries": [
           {
@@ -85025,113 +86577,40 @@
         ]
       },
       {
-        "id": 81487,
-        "name": "Grand Crusader",
-        "type": "single",
-        "posX": 13200,
-        "posY": 2700,
-        "maxRanks": 1,
-        "next": [
-          81481,
-          81501,
-          81476
-        ],
-        "prev": [
-          81489,
-          81469
-        ],
-        "entries": [
-          {
-            "id": 102453,
-            "definitionId": 107458,
-            "maxRanks": 1,
-            "type": "passive",
-            "name": "Grand Crusader",
-            "spellId": 85043,
-            "icon": "inv_helmet_74",
-            "index": 100
-          }
-        ]
-      },
-      {
-        "id": 81498,
-        "name": "Seal of Charity",
-        "type": "single",
-        "posX": 14400,
-        "posY": 2700,
-        "maxRanks": 1,
-        "next": [
-          101927,
-          81501
-        ],
-        "prev": [
-          81469
-        ],
-        "entries": [
-          {
-            "id": 102467,
-            "definitionId": 107472,
-            "maxRanks": 1,
-            "type": "passive",
-            "name": "Seal of Charity",
-            "spellId": 384815,
-            "icon": "spell_priest_power_word",
-            "index": 100
-          }
-        ]
-      },
-      {
-        "id": 81486,
-        "name": "Refining Fire",
-        "type": "single",
-        "posX": 12000,
-        "posY": 3300,
-        "maxRanks": 1,
-        "next": [
-          81499,
-          81492,
-          81474
-        ],
-        "prev": [
-          81494
-        ],
-        "entries": [
-          {
-            "id": 102452,
-            "definitionId": 107457,
-            "maxRanks": 1,
-            "type": "passive",
-            "name": "Refining Fire",
-            "spellId": 469883,
-            "icon": "inv_everburningignition_yellow",
-            "index": 100
-          }
-        ]
-      },
-      {
-        "id": 81476,
-        "name": "Valiant Crusade",
-        "type": "single",
+        "id": 110862,
+        "name": "Blessing of Spellwarding / Uther's Counsel",
+        "type": "choice",
         "posX": 12600,
         "posY": 3300,
         "maxRanks": 1,
         "next": [
+          81486,
           81499
         ],
         "prev": [
           81487,
-          81494
+          81476
         ],
         "entries": [
           {
-            "id": 102439,
-            "definitionId": 107444,
+            "id": 111886,
+            "definitionId": 116891,
+            "maxRanks": 1,
+            "type": "active",
+            "name": "Blessing of Spellwarding",
+            "spellId": 204018,
+            "icon": "spell_holy_blessingofprotection",
+            "index": 100
+          },
+          {
+            "id": 137857,
+            "definitionId": 142611,
             "maxRanks": 1,
             "type": "passive",
-            "name": "Valiant Crusade",
-            "spellId": 1245979,
-            "icon": "ability_mount_alliancepvpmount",
-            "index": 100
+            "name": "Uther's Counsel",
+            "spellId": 378425,
+            "icon": "spell_holy_greaterblessingofsalvation",
+            "index": 200
           }
         ]
       },
@@ -85144,8 +86623,8 @@
         "maxRanks": 1,
         "next": [
           81499,
-          81503,
-          90062
+          81483,
+          81503
         ],
         "prev": [
           81487
@@ -85165,17 +86644,18 @@
       },
       {
         "id": 81501,
-        "name": "Searing Sunlight",
-        "type": "single",
+        "name": "Searing Sunlight / Hand of the Protector",
+        "type": "choice",
         "posX": 13800,
         "posY": 3300,
         "maxRanks": 1,
         "next": [
-          81503
+          81503,
+          101927
         ],
         "prev": [
-          81487,
-          81498
+          81494,
+          81487
         ],
         "entries": [
           {
@@ -85187,62 +86667,45 @@
             "spellId": 1244070,
             "icon": "ability_essence_reapingflames",
             "index": 100
-          }
-        ]
-      },
-      {
-        "id": 101927,
-        "name": "Solace",
-        "type": "single",
-        "posX": 14400,
-        "posY": 3300,
-        "maxRanks": 1,
-        "next": [
-          81503,
-          81470,
-          81485
-        ],
-        "prev": [
-          81498
-        ],
-        "entries": [
+          },
           {
-            "id": 102451,
-            "definitionId": 107456,
+            "id": 137854,
+            "definitionId": 142608,
             "maxRanks": 1,
             "type": "passive",
-            "name": "Solace",
-            "spellId": 1245891,
-            "icon": "spell_holy_prayerofmendingtga",
-            "index": 100
+            "name": "Hand of the Protector",
+            "spellId": 315924,
+            "icon": "ability_paladin_blessedhands",
+            "index": 200
           }
         ]
       },
       {
-        "id": 81492,
-        "name": "Undying Embers",
+        "id": 81486,
+        "name": "Refining Fire",
         "type": "single",
-        "posX": 11400,
+        "posX": 12000,
         "posY": 3900,
         "reqPoints": 8,
         "maxRanks": 1,
         "next": [
           81474,
-          101928
+          81492
         ],
         "prev": [
-          81486
+          110862,
+          81476
         ],
         "entries": [
           {
-            "id": 102459,
-            "definitionId": 107464,
+            "id": 102452,
+            "definitionId": 107457,
             "maxRanks": 1,
             "type": "passive",
-            "name": "Undying Embers",
-            "spellId": 1244019,
-            "icon": "inv_achievement_dungeon_darkflamecleft",
-            "index": 0
+            "name": "Refining Fire",
+            "spellId": 469883,
+            "icon": "inv_everburningignition_yellow",
+            "index": 100
           }
         ]
       },
@@ -85255,14 +86718,11 @@
         "reqPoints": 8,
         "maxRanks": 1,
         "next": [
-          81474,
-          81506,
-          81483
+          81506
         ],
         "prev": [
-          81476,
           81481,
-          81486
+          110862
         ],
         "entries": [
           {
@@ -85278,39 +86738,32 @@
         ]
       },
       {
-        "id": 90062,
-        "name": "Improved Ardent Defender / Blessing of Spellwarding",
-        "type": "choice",
+        "id": 81483,
+        "name": "Avenging Wrath",
+        "type": "single",
         "posX": 13200,
         "posY": 3900,
         "reqPoints": 8,
         "maxRanks": 1,
         "next": [
-          81483
+          81506,
+          90062,
+          81612
         ],
         "prev": [
           81481
         ],
         "entries": [
           {
-            "id": 111887,
-            "definitionId": 116892,
-            "maxRanks": 1,
-            "type": "passive",
-            "name": "Improved Ardent Defender",
-            "spellId": 393114,
-            "icon": "spell_holy_ardentdefender",
-            "index": 100
-          },
-          {
-            "id": 111886,
-            "definitionId": 116891,
+            "id": 102448,
+            "definitionId": 107453,
             "maxRanks": 1,
             "type": "active",
-            "name": "Blessing of Spellwarding",
-            "spellId": 204018,
-            "icon": "spell_holy_blessingofprotection",
-            "index": 200
+            "name": "Avenging Wrath",
+            "spellId": 31884,
+            "visibleSpellId": 31884,
+            "icon": "spell_holy_avenginewrath",
+            "index": 100
           }
         ]
       },
@@ -85323,14 +86776,12 @@
         "reqPoints": 8,
         "maxRanks": 1,
         "next": [
-          81485,
-          81483,
-          81612
+          81612,
+          81470
         ],
         "prev": [
           81501,
-          81481,
-          101927
+          81481
         ],
         "entries": [
           {
@@ -85356,30 +86807,41 @@
         ]
       },
       {
-        "id": 81470,
-        "name": "Vision of Sanctity",
-        "type": "single",
-        "posX": 15000,
+        "id": 101927,
+        "name": "Solace / Instrument of the Divine",
+        "type": "choice",
+        "posX": 14400,
         "posY": 3900,
         "reqPoints": 8,
         "maxRanks": 1,
         "next": [
-          81485,
-          81473
+          81470,
+          81485
         ],
         "prev": [
-          101927
+          81494,
+          81501
         ],
         "entries": [
           {
-            "id": 102432,
-            "definitionId": 107437,
+            "id": 102451,
+            "definitionId": 107456,
             "maxRanks": 1,
             "type": "passive",
-            "name": "Vision of Sanctity",
-            "spellId": 1245354,
-            "icon": "ability_racial_orbitalstrike",
+            "name": "Solace",
+            "spellId": 1245891,
+            "icon": "spell_holy_prayerofmendingtga",
             "index": 100
+          },
+          {
+            "id": 102454,
+            "definitionId": 107459,
+            "maxRanks": 1,
+            "type": "passive",
+            "name": "Instrument of the Divine",
+            "spellId": 1277162,
+            "icon": "ability_priest_archangel",
+            "index": 200
           }
         ]
       },
@@ -85387,18 +86849,15 @@
         "id": 81474,
         "name": "Tyr's Enforcer",
         "type": "single",
-        "posX": 12000,
+        "posX": 11400,
         "posY": 4500,
         "reqPoints": 8,
         "maxRanks": 2,
         "next": [
           101928,
-          81629,
-          81472
+          81493
         ],
         "prev": [
-          81499,
-          81492,
           81486
         ],
         "entries": [
@@ -85415,6 +86874,33 @@
         ]
       },
       {
+        "id": 81492,
+        "name": "Undying Embers",
+        "type": "single",
+        "posX": 12000,
+        "posY": 4500,
+        "reqPoints": 8,
+        "maxRanks": 1,
+        "next": [
+          101928
+        ],
+        "prev": [
+          81486
+        ],
+        "entries": [
+          {
+            "id": 102459,
+            "definitionId": 107464,
+            "maxRanks": 1,
+            "type": "passive",
+            "name": "Undying Embers",
+            "spellId": 1244019,
+            "icon": "inv_achievement_dungeon_darkflamecleft",
+            "index": 0
+          }
+        ]
+      },
+      {
         "id": 81506,
         "name": "Relentless Inquisitor",
         "type": "single",
@@ -85423,10 +86909,12 @@
         "reqPoints": 8,
         "maxRanks": 1,
         "next": [
-          81629
+          81490,
+          101928
         ],
         "prev": [
-          81499
+          81499,
+          81483
         ],
         "entries": [
           {
@@ -85442,44 +86930,38 @@
         ]
       },
       {
-        "id": 81483,
-        "name": "Avenging Wrath / Sentinel",
+        "id": 90062,
+        "name": "Improved Ardent Defender / Seal of Reprisal",
         "type": "choice",
         "posX": 13200,
         "posY": 4500,
         "reqPoints": 8,
         "maxRanks": 1,
         "next": [
-          81490,
-          81629,
-          81475
+          81490
         ],
         "prev": [
-          81503,
-          81499,
-          90062
+          81483
         ],
         "entries": [
           {
-            "id": 102448,
-            "definitionId": 107453,
+            "id": 111887,
+            "definitionId": 116892,
             "maxRanks": 1,
-            "type": "active",
-            "name": "Avenging Wrath",
-            "spellId": 31884,
-            "visibleSpellId": 31884,
-            "icon": "spell_holy_avenginewrath",
+            "type": "passive",
+            "name": "Improved Ardent Defender",
+            "spellId": 393114,
+            "icon": "spell_holy_ardentdefender",
             "index": 100
           },
           {
-            "id": 102447,
-            "definitionId": 107452,
+            "id": 137855,
+            "definitionId": 142609,
             "maxRanks": 1,
-            "type": "active",
-            "name": "Sentinel",
-            "spellId": 389539,
-            "visibleSpellId": 389539,
-            "icon": "spell_holy_holynova",
+            "type": "passive",
+            "name": "Seal of Reprisal",
+            "spellId": 377053,
+            "icon": "spell_holy_sealoffury",
             "index": 200
           }
         ]
@@ -85493,9 +86975,11 @@
         "reqPoints": 8,
         "maxRanks": 1,
         "next": [
-          81475
+          81490,
+          81488
         ],
         "prev": [
+          81483,
           81503
         ],
         "entries": [
@@ -85512,21 +86996,46 @@
         ]
       },
       {
-        "id": 81485,
-        "name": "Consecration in Flame",
+        "id": 81470,
+        "name": "Vision of Sanctity",
         "type": "single",
         "posX": 14400,
         "posY": 4500,
         "reqPoints": 8,
-        "maxRanks": 2,
+        "maxRanks": 1,
         "next": [
-          81475,
-          81473,
-          81500
+          81488
         ],
         "prev": [
-          81503,
-          81470,
+          101927,
+          81503
+        ],
+        "entries": [
+          {
+            "id": 102432,
+            "definitionId": 107437,
+            "maxRanks": 1,
+            "type": "passive",
+            "name": "Vision of Sanctity",
+            "spellId": 1245354,
+            "icon": "ability_racial_orbitalstrike",
+            "index": 100
+          }
+        ]
+      },
+      {
+        "id": 81485,
+        "name": "Consecration in Flame",
+        "type": "single",
+        "posX": 15000,
+        "posY": 4500,
+        "reqPoints": 8,
+        "maxRanks": 2,
+        "next": [
+          81488,
+          81498
+        ],
+        "prev": [
           101927
         ],
         "entries": [
@@ -85544,19 +87053,20 @@
       },
       {
         "id": 101928,
-        "name": "Soaring Shield",
-        "type": "single",
-        "posX": 11400,
+        "name": "Soaring Shield / Focused Enmity",
+        "type": "choice",
+        "posX": 12000,
         "posY": 5100,
         "reqPoints": 8,
         "maxRanks": 1,
         "next": [
-          81472,
-          81493
+          81493,
+          81482
         ],
         "prev": [
-          81474,
-          81492
+          81492,
+          81506,
+          81474
         ],
         "entries": [
           {
@@ -85568,35 +87078,16 @@
             "spellId": 378457,
             "icon": "spell_burningbladeshaman_lavaslash",
             "index": 100
-          }
-        ]
-      },
-      {
-        "id": 81629,
-        "name": "Seal of Reprisal",
-        "type": "single",
-        "posX": 12600,
-        "posY": 5100,
-        "reqPoints": 8,
-        "maxRanks": 1,
-        "next": [
-          81472
-        ],
-        "prev": [
-          81474,
-          81506,
-          81483
-        ],
-        "entries": [
+          },
           {
-            "id": 102621,
-            "definitionId": 107626,
+            "id": 137856,
+            "definitionId": 142610,
             "maxRanks": 1,
             "type": "passive",
-            "name": "Seal of Reprisal",
-            "spellId": 377053,
-            "icon": "spell_holy_sealoffury",
-            "index": 100
+            "name": "Focused Enmity",
+            "spellId": 378845,
+            "icon": "ability_priest_flashoflight",
+            "index": 200
           }
         ]
       },
@@ -85614,7 +87105,9 @@
           81497
         ],
         "prev": [
-          81483
+          90062,
+          81612,
+          81506
         ],
         "entries": [
           {
@@ -85630,54 +87123,26 @@
         ]
       },
       {
-        "id": 81475,
-        "name": "Hand of the Protector",
-        "type": "single",
-        "posX": 13800,
-        "posY": 5100,
-        "reqPoints": 8,
-        "maxRanks": 1,
-        "next": [
-          81500
-        ],
-        "prev": [
-          81485,
-          81612,
-          81483
-        ],
-        "entries": [
-          {
-            "id": 102438,
-            "definitionId": 107443,
-            "maxRanks": 1,
-            "type": "passive",
-            "name": "Hand of the Protector",
-            "spellId": 315924,
-            "icon": "ability_paladin_blessedhands",
-            "index": 100
-          }
-        ]
-      },
-      {
-        "id": 81473,
+        "id": 81488,
         "name": "Sanctuary",
         "type": "single",
-        "posX": 15000,
+        "posX": 14400,
         "posY": 5100,
         "reqPoints": 8,
         "maxRanks": 1,
         "next": [
-          81500,
-          81488
+          81498,
+          81471
         ],
         "prev": [
           81485,
-          81470
+          81470,
+          81612
         ],
         "entries": [
           {
-            "id": 102436,
-            "definitionId": 107441,
+            "id": 137858,
+            "definitionId": 142612,
             "maxRanks": 1,
             "type": "passive",
             "name": "Sanctuary",
@@ -85688,32 +87153,41 @@
         ]
       },
       {
-        "id": 81472,
-        "name": "Focused Enmity",
-        "type": "single",
-        "posX": 12000,
+        "id": 81493,
+        "name": "Strength in Adversity / Crusader's Resolve",
+        "type": "choice",
+        "posX": 11400,
         "posY": 5700,
         "reqPoints": 20,
         "maxRanks": 1,
         "next": [
-          81493,
-          81482
+          81482,
+          81505
         ],
         "prev": [
-          81474,
-          81629,
-          101928
+          101928,
+          81474
         ],
         "entries": [
           {
-            "id": 102435,
-            "definitionId": 107440,
+            "id": 102461,
+            "definitionId": 107466,
             "maxRanks": 1,
             "type": "passive",
-            "name": "Focused Enmity",
-            "spellId": 378845,
-            "icon": "ability_priest_flashoflight",
+            "name": "Strength in Adversity",
+            "spellId": 393071,
+            "icon": "spell_holy_weaponmastery",
             "index": 100
+          },
+          {
+            "id": 102460,
+            "definitionId": 107465,
+            "maxRanks": 1,
+            "type": "passive",
+            "name": "Crusader's Resolve",
+            "spellId": 380188,
+            "icon": "ability_priest_angelicbulwark",
+            "index": 200
           }
         ]
       },
@@ -85748,15 +87222,15 @@
       },
       {
         "id": 103877,
-        "name": "Sanctified Wrath",
+        "name": "Empyrean Authority",
         "type": "single",
         "posX": 13800,
         "posY": 5700,
         "reqPoints": 20,
         "maxRanks": 1,
         "next": [
-          81471,
           81497,
+          81471,
           81504
         ],
         "prev": [
@@ -85768,78 +87242,39 @@
             "definitionId": 133085,
             "maxRanks": 1,
             "type": "passive",
-            "name": "Sanctified Wrath",
-            "spellId": 53376,
-            "icon": "ability_paladin_judgementsofthejust",
+            "name": "Empyrean Authority",
+            "spellId": 1246481,
+            "icon": "ability_paladin_empoweredsealsrighteous",
             "index": 100
           }
         ]
       },
       {
-        "id": 81500,
-        "name": "Uther's Counsel",
+        "id": 81498,
+        "name": "Seal of Charity",
         "type": "single",
-        "posX": 14400,
+        "posX": 15000,
         "posY": 5700,
         "reqPoints": 20,
         "maxRanks": 1,
         "next": [
           81471,
-          81488
+          81477
         ],
         "prev": [
-          81473,
-          81475,
+          81488,
           81485
         ],
         "entries": [
           {
-            "id": 102469,
-            "definitionId": 107474,
+            "id": 102467,
+            "definitionId": 107472,
             "maxRanks": 1,
             "type": "passive",
-            "name": "Uther's Counsel",
-            "spellId": 378425,
-            "icon": "spell_holy_greaterblessingofsalvation",
+            "name": "Seal of Charity",
+            "spellId": 384815,
+            "icon": "spell_priest_power_word",
             "index": 100
-          }
-        ]
-      },
-      {
-        "id": 81493,
-        "name": "Strength in Adversity / Crusader's Resolve",
-        "type": "choice",
-        "posX": 11400,
-        "posY": 6300,
-        "reqPoints": 20,
-        "maxRanks": 1,
-        "next": [
-          81505
-        ],
-        "prev": [
-          81472,
-          101928
-        ],
-        "entries": [
-          {
-            "id": 102461,
-            "definitionId": 107466,
-            "maxRanks": 1,
-            "type": "passive",
-            "name": "Strength in Adversity",
-            "spellId": 393071,
-            "icon": "spell_holy_weaponmastery",
-            "index": 100
-          },
-          {
-            "id": 102460,
-            "definitionId": 107465,
-            "maxRanks": 1,
-            "type": "passive",
-            "name": "Crusader's Resolve",
-            "spellId": 380188,
-            "icon": "ability_priest_angelicbulwark",
-            "index": 200
           }
         ]
       },
@@ -85856,8 +87291,9 @@
           81491
         ],
         "prev": [
-          81472,
-          81484
+          81484,
+          101928,
+          81493
         ],
         "entries": [
           {
@@ -85874,7 +87310,7 @@
       },
       {
         "id": 81497,
-        "name": "Empyrean Authority",
+        "name": "Sentinel",
         "type": "single",
         "posX": 13200,
         "posY": 6300,
@@ -85886,18 +87322,18 @@
         ],
         "prev": [
           81490,
-          81484,
-          103877
+          103877,
+          81484
         ],
         "entries": [
           {
             "id": 102466,
             "definitionId": 107471,
             "maxRanks": 1,
-            "type": "passive",
-            "name": "Empyrean Authority",
-            "spellId": 1246481,
-            "icon": "ability_paladin_empoweredsealsrighteous",
+            "type": "active",
+            "name": "Sentinel",
+            "spellId": 389539,
+            "icon": "spell_holy_holynova",
             "index": 100
           }
         ]
@@ -85915,8 +87351,9 @@
           81477
         ],
         "prev": [
-          81500,
-          103877
+          103877,
+          81498,
+          81488
         ],
         "entries": [
           {
@@ -85927,34 +87364,6 @@
             "name": "Zealot's Paragon",
             "spellId": 391142,
             "icon": "ability_paladin_conviction",
-            "index": 100
-          }
-        ]
-      },
-      {
-        "id": 81488,
-        "name": "Instrument of the Divine",
-        "type": "single",
-        "posX": 15000,
-        "posY": 6300,
-        "reqPoints": 20,
-        "maxRanks": 1,
-        "next": [
-          81477
-        ],
-        "prev": [
-          81473,
-          81500
-        ],
-        "entries": [
-          {
-            "id": 102454,
-            "definitionId": 107459,
-            "maxRanks": 1,
-            "type": "passive",
-            "name": "Instrument of the Divine",
-            "spellId": 1277162,
-            "icon": "ability_priest_archangel",
             "index": 100
           }
         ]
@@ -86005,9 +87414,9 @@
         "maxRanks": 1,
         "next": [],
         "prev": [
-          81482,
+          81497,
           81484,
-          81497
+          81482
         ],
         "entries": [
           {
@@ -86060,7 +87469,7 @@
         "next": [],
         "prev": [
           81471,
-          81488
+          81498
         ],
         "entries": [
           {
@@ -86072,6 +87481,64 @@
             "spellId": 204074,
             "icon": "ability_paladin_shieldofthetemplar",
             "index": 100
+          }
+        ]
+      },
+      {
+        "id": 110418,
+        "name": "Glory of the Vanguard / Glory of the Vanguard / Glory of the Vanguard",
+        "type": "tiered",
+        "posX": 13200,
+        "posY": 7650,
+        "reqPoints": 20,
+        "maxRanks": 4,
+        "rankLevels": [
+          {
+            "level": 81,
+            "maxRanks": 1
+          },
+          {
+            "level": 84,
+            "maxRanks": 3
+          },
+          {
+            "level": 90,
+            "maxRanks": 4
+          }
+        ],
+        "entryNode": true,
+        "next": [],
+        "prev": [],
+        "entries": [
+          {
+            "id": 137022,
+            "definitionId": 141785,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Glory of the Vanguard",
+            "spellId": 1267203,
+            "icon": "inv12_apextalent_paladin_gloryofthevanguard",
+            "index": 0
+          },
+          {
+            "id": 137021,
+            "definitionId": 141784,
+            "maxRanks": 2,
+            "type": "tierrank",
+            "name": "Glory of the Vanguard",
+            "spellId": 1267211,
+            "icon": "inv12_apextalent_paladin_gloryofthevanguard",
+            "index": 100
+          },
+          {
+            "id": 137020,
+            "definitionId": 141783,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Glory of the Vanguard",
+            "spellId": 1267215,
+            "icon": "inv12_apextalent_paladin_gloryofthevanguard",
+            "index": 200
           }
         ]
       }
@@ -86106,7 +87573,8 @@
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 95183,
@@ -86524,7 +87992,8 @@
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 95233,
@@ -86538,8 +88007,7 @@
           95236
         ],
         "prev": [
-          95234,
-          110257
+          95234
         ],
         "entries": [
           {
@@ -86576,8 +88044,7 @@
           95231
         ],
         "prev": [
-          95234,
-          110257
+          95234
         ],
         "entries": [
           {
@@ -86604,8 +88071,7 @@
           95232
         ],
         "prev": [
-          95234,
-          110257
+          95234
         ],
         "entries": [
           {
@@ -86642,8 +88108,7 @@
           109743
         ],
         "prev": [
-          95234,
-          110257
+          95234
         ],
         "entries": [
           {
@@ -86990,10 +88455,7 @@
       81469,
       81470,
       81471,
-      81472,
-      81473,
       81474,
-      81475,
       81476,
       81477,
       81479,
@@ -87016,7 +88478,6 @@
       81497,
       81498,
       81499,
-      81500,
       81501,
       81502,
       81503,
@@ -87096,7 +88557,6 @@
       81618,
       81621,
       81628,
-      81629,
       81630,
       81631,
       81632,
@@ -87220,7 +88680,11 @@
       110091,
       110092,
       110093,
-      110257
+      110257,
+      110417,
+      110418,
+      110419,
+      110862
     ]
   },
   {
@@ -88360,7 +89824,7 @@
         "type": "single",
         "posX": 3000,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           81495
@@ -88388,7 +89852,7 @@
         "type": "single",
         "posX": 3600,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           81495,
@@ -88418,7 +89882,7 @@
         "type": "choice",
         "posX": 4200,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           81621
@@ -88455,7 +89919,7 @@
         "type": "single",
         "posX": 4800,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           81621,
@@ -88484,7 +89948,7 @@
         "type": "single",
         "posX": 5400,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           103851
@@ -88512,7 +89976,7 @@
         "type": "single",
         "posX": 6000,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           103851,
@@ -88542,7 +90006,7 @@
         "type": "single",
         "posX": 6600,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           103856
@@ -88570,7 +90034,7 @@
         "type": "single",
         "posX": 3000,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           93357
@@ -88598,7 +90062,7 @@
         "type": "single",
         "posX": 3600,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           93357
@@ -88625,7 +90089,7 @@
         "type": "single",
         "posX": 4200,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "next": [
           93357,
@@ -88655,7 +90119,7 @@
         "type": "single",
         "posX": 5400,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "next": [
           103861,
@@ -88685,7 +90149,7 @@
         "type": "single",
         "posX": 6000,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           103863
@@ -88712,7 +90176,7 @@
         "type": "choice",
         "posX": 6600,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           103863
@@ -88750,7 +90214,7 @@
         "type": "single",
         "posX": 3600,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -88777,7 +90241,7 @@
         "type": "single",
         "posX": 4800,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -88803,7 +90267,7 @@
         "type": "single",
         "posX": 6000,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -89792,6 +91256,64 @@
             "index": 100
           }
         ]
+      },
+      {
+        "id": 110419,
+        "name": "Light Within / Light Within / Light Within",
+        "type": "tiered",
+        "posX": 13200,
+        "posY": 7650,
+        "reqPoints": 20,
+        "maxRanks": 4,
+        "rankLevels": [
+          {
+            "level": 81,
+            "maxRanks": 1
+          },
+          {
+            "level": 84,
+            "maxRanks": 3
+          },
+          {
+            "level": 90,
+            "maxRanks": 4
+          }
+        ],
+        "entryNode": true,
+        "next": [],
+        "prev": [],
+        "entries": [
+          {
+            "id": 137025,
+            "definitionId": 141788,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Light Within",
+            "spellId": 1261113,
+            "icon": "inv12_apextalent_paladin_lightwithin",
+            "index": 100
+          },
+          {
+            "id": 137024,
+            "definitionId": 141787,
+            "maxRanks": 2,
+            "type": "tierrank",
+            "name": "Light Within",
+            "spellId": 1261111,
+            "icon": "inv_ability_holyfire_buff",
+            "index": 200
+          },
+          {
+            "id": 137023,
+            "definitionId": 141786,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Light Within",
+            "spellId": 1261159,
+            "icon": "inv_ability_holyfire_buff",
+            "index": 300
+          }
+        ]
       }
     ],
     "heroNodes": [
@@ -89824,7 +91346,8 @@
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 95099,
@@ -89855,7 +91378,8 @@
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 95183,
@@ -90697,10 +92221,7 @@
       81469,
       81470,
       81471,
-      81472,
-      81473,
       81474,
-      81475,
       81476,
       81477,
       81479,
@@ -90723,7 +92244,6 @@
       81497,
       81498,
       81499,
-      81500,
       81501,
       81502,
       81503,
@@ -90803,7 +92323,6 @@
       81618,
       81621,
       81628,
-      81629,
       81630,
       81631,
       81632,
@@ -90927,7 +92446,11 @@
       110091,
       110092,
       110093,
-      110257
+      110257,
+      110417,
+      110418,
+      110419,
+      110862
     ]
   },
   {
@@ -91475,6 +92998,7 @@
         "maxRanks": 1,
         "next": [
           62127,
+          110597,
           62098
         ],
         "prev": [
@@ -91649,6 +93173,33 @@
         ]
       },
       {
+        "id": 110597,
+        "name": "Improved Warding",
+        "type": "single",
+        "posX": 3900,
+        "posY": 5100,
+        "reqPoints": 8,
+        "maxRanks": 1,
+        "next": [
+          62096
+        ],
+        "prev": [
+          108661
+        ],
+        "entries": [
+          {
+            "id": 137410,
+            "definitionId": 142170,
+            "maxRanks": 1,
+            "type": "passive",
+            "name": "Improved Warding",
+            "spellId": 1297073,
+            "icon": "inv_cloth_raidmage_p_01helm",
+            "index": 100
+          }
+        ]
+      },
+      {
         "id": 62098,
         "name": "Tome of Antonidas",
         "type": "single",
@@ -91806,7 +93357,8 @@
         ],
         "prev": [
           62098,
-          62127
+          62127,
+          110597
         ],
         "entries": [
           {
@@ -92221,8 +93773,8 @@
         "posY": 2100,
         "maxRanks": 1,
         "next": [
-          102473,
-          102445
+          102445,
+          110850
         ],
         "prev": [
           102467
@@ -92248,7 +93800,7 @@
         "posY": 2100,
         "maxRanks": 1,
         "next": [
-          102445,
+          110850,
           102471
         ],
         "prev": [
@@ -92268,8 +93820,8 @@
         ]
       },
       {
-        "id": 102473,
-        "name": "Amplification",
+        "id": 102445,
+        "name": "Improved Clearcasting",
         "type": "single",
         "posX": 11100,
         "posY": 2700,
@@ -92282,20 +93834,20 @@
         ],
         "entries": [
           {
-            "id": 126543,
-            "definitionId": 131369,
+            "id": 126515,
+            "definitionId": 131341,
             "maxRanks": 1,
             "type": "passive",
-            "name": "Amplification",
-            "spellId": 236628,
-            "icon": "spell_arcane_invocation",
+            "name": "Improved Clearcasting",
+            "spellId": 321420,
+            "icon": "spell_shadow_manaburn",
             "index": 100
           }
         ]
       },
       {
-        "id": 102445,
-        "name": "Improved Clearcasting",
+        "id": 110850,
+        "name": "Refractive Images",
         "type": "single",
         "posX": 12300,
         "posY": 2700,
@@ -92304,18 +93856,18 @@
           102449
         ],
         "prev": [
-          108538,
-          108539
+          108539,
+          108538
         ],
         "entries": [
           {
-            "id": 126515,
-            "definitionId": 131341,
+            "id": 137842,
+            "definitionId": 142596,
             "maxRanks": 1,
             "type": "passive",
-            "name": "Improved Clearcasting",
-            "spellId": 321420,
-            "icon": "spell_shadow_manaburn",
+            "name": "Refractive Images",
+            "spellId": 1309497,
+            "icon": "inv_112_arcane_buff",
             "index": 100
           }
         ]
@@ -92358,7 +93910,7 @@
           102460
         ],
         "prev": [
-          102473
+          102445
         ],
         "entries": [
           {
@@ -92386,7 +93938,7 @@
           102469
         ],
         "prev": [
-          102445
+          110850
         ],
         "entries": [
           {
@@ -92465,6 +94017,7 @@
         "maxRanks": 1,
         "next": [
           102446,
+          110849,
           102468
         ],
         "prev": [
@@ -92586,7 +94139,7 @@
         "maxRanks": 1,
         "next": [
           108536,
-          110441,
+          110442,
           108535
         ],
         "prev": [
@@ -92602,6 +94155,31 @@
             "name": "Intuition",
             "spellId": 1223798,
             "icon": "spell_shadow_brainwash",
+            "index": 100
+          }
+        ]
+      },
+      {
+        "id": 110849,
+        "name": "Amplification",
+        "type": "single",
+        "posX": 11700,
+        "posY": 4500,
+        "reqPoints": 8,
+        "maxRanks": 1,
+        "next": [],
+        "prev": [
+          102460
+        ],
+        "entries": [
+          {
+            "id": 137841,
+            "definitionId": 142595,
+            "maxRanks": 1,
+            "type": "passive",
+            "name": "Amplification",
+            "spellId": 236628,
+            "icon": "spell_arcane_invocation",
             "index": 100
           }
         ]
@@ -92720,7 +94298,7 @@
         ]
       },
       {
-        "id": 110441,
+        "id": 110442,
         "name": "Arcane Tempo",
         "type": "single",
         "posX": 11100,
@@ -92735,8 +94313,8 @@
         ],
         "entries": [
           {
-            "id": 137083,
-            "definitionId": 141847,
+            "id": 137084,
+            "definitionId": 141848,
             "maxRanks": 1,
             "type": "passive",
             "name": "Arcane Tempo",
@@ -92884,7 +94462,7 @@
         "prev": [
           108535,
           108536,
-          110441
+          110442
         ],
         "entries": [
           {
@@ -93215,6 +94793,64 @@
             "index": 100
           }
         ]
+      },
+      {
+        "id": 110420,
+        "name": "Prismatic Bolt / Prismatic Bolt / Prismatic Bolt",
+        "type": "tiered",
+        "posX": 12300,
+        "posY": 7650,
+        "reqPoints": 20,
+        "maxRanks": 4,
+        "rankLevels": [
+          {
+            "level": 81,
+            "maxRanks": 1
+          },
+          {
+            "level": 84,
+            "maxRanks": 3
+          },
+          {
+            "level": 90,
+            "maxRanks": 4
+          }
+        ],
+        "entryNode": true,
+        "next": [],
+        "prev": [],
+        "entries": [
+          {
+            "id": 137028,
+            "definitionId": 141791,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Prismatic Bolt",
+            "spellId": 1295923,
+            "icon": "inv12_apextalent_mage_touchofthearchmage",
+            "index": 100
+          },
+          {
+            "id": 137027,
+            "definitionId": 141790,
+            "maxRanks": 2,
+            "type": "tierrank",
+            "name": "Prismatic Bolt",
+            "spellId": 1295944,
+            "icon": "inv12_apextalent_mage_touchofthearchmage",
+            "index": 200
+          },
+          {
+            "id": 137026,
+            "definitionId": 141789,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Prismatic Bolt",
+            "spellId": 1295946,
+            "icon": "inv12_apextalent_mage_touchofthearchmage",
+            "index": 300
+          }
+        ]
       }
     ],
     "heroNodes": [
@@ -93246,7 +94882,8 @@
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 94662,
@@ -93659,7 +95296,8 @@
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 94653,
@@ -94229,7 +95867,6 @@
       102470,
       102471,
       102472,
-      102473,
       102474,
       102475,
       102476,
@@ -94312,7 +95949,13 @@
       110283,
       110321,
       110322,
-      110441
+      110420,
+      110422,
+      110423,
+      110442,
+      110597,
+      110849,
+      110850
     ]
   },
   {
@@ -94860,6 +96503,7 @@
         "maxRanks": 1,
         "next": [
           62127,
+          110597,
           62098
         ],
         "prev": [
@@ -95034,6 +96678,33 @@
         ]
       },
       {
+        "id": 110597,
+        "name": "Improved Warding",
+        "type": "single",
+        "posX": 3900,
+        "posY": 5100,
+        "reqPoints": 8,
+        "maxRanks": 1,
+        "next": [
+          62096
+        ],
+        "prev": [
+          108661
+        ],
+        "entries": [
+          {
+            "id": 137410,
+            "definitionId": 142170,
+            "maxRanks": 1,
+            "type": "passive",
+            "name": "Improved Warding",
+            "spellId": 1297073,
+            "icon": "inv_cloth_raidmage_p_01helm",
+            "index": 100
+          }
+        ]
+      },
+      {
         "id": 62098,
         "name": "Tome of Antonidas",
         "type": "single",
@@ -95191,7 +96862,8 @@
         ],
         "prev": [
           62098,
-          62127
+          62127,
+          110597
         ],
         "entries": [
           {
@@ -96637,39 +98309,67 @@
             "index": 100
           }
         ]
-      }
-    ],
-    "heroNodes": [
+      },
       {
-        "id": 94636,
-        "name": "Frostfire Bolt",
-        "type": "single",
-        "posX": 15000,
-        "posY": 1500,
-        "maxRanks": 1,
-        "entryNode": true,
-        "subTreeId": 41,
-        "next": [
-          94642,
-          94641,
-          94633,
-          109672
+        "id": 110423,
+        "name": "Fired Up / Fired Up / Fired Up",
+        "type": "tiered",
+        "posX": 12300,
+        "posY": 7650,
+        "reqPoints": 20,
+        "maxRanks": 4,
+        "rankLevels": [
+          {
+            "level": 81,
+            "maxRanks": 1
+          },
+          {
+            "level": 84,
+            "maxRanks": 3
+          },
+          {
+            "level": 90,
+            "maxRanks": 4
+          }
         ],
+        "entryNode": true,
+        "next": [],
         "prev": [],
         "entries": [
           {
-            "id": 117239,
-            "definitionId": 122251,
+            "id": 137037,
+            "definitionId": 141800,
             "maxRanks": 1,
-            "type": "active",
-            "name": "Frostfire Bolt",
-            "spellId": 431044,
-            "icon": "inv_ability_frostfiremage_frostfirebolt",
+            "type": "tierrank",
+            "name": "Fired Up",
+            "spellId": 1257343,
+            "icon": "inv12_apextalent_mage_firedup",
             "index": 100
+          },
+          {
+            "id": 137036,
+            "definitionId": 141799,
+            "maxRanks": 2,
+            "type": "tierrank",
+            "name": "Fired Up",
+            "spellId": 1257349,
+            "icon": "ability_warlock_backdraft",
+            "index": 200
+          },
+          {
+            "id": 137035,
+            "definitionId": 141798,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Fired Up",
+            "spellId": 1257348,
+            "icon": "ability_warlock_burningembers",
+            "index": 300
           }
-        ],
-        "freeNode": true
-      },
+        ]
+      }
+    ],
+    "heroNodes": [
       {
         "id": 109956,
         "name": "Frostfire Bolt",
@@ -96698,7 +98398,8 @@
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 94642,
@@ -96712,7 +98413,6 @@
           94638
         ],
         "prev": [
-          94636,
           109956
         ],
         "entries": [
@@ -96750,7 +98450,6 @@
           94640
         ],
         "prev": [
-          94636,
           109956
         ],
         "entries": [
@@ -96778,7 +98477,6 @@
           94634
         ],
         "prev": [
-          94636,
           109956
         ],
         "entries": [
@@ -96816,7 +98514,6 @@
           109671
         ],
         "prev": [
-          94636,
           109956
         ],
         "entries": [
@@ -97115,7 +98812,8 @@
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 94653,
@@ -97686,7 +99384,6 @@
       102470,
       102471,
       102472,
-      102473,
       102474,
       102475,
       102476,
@@ -97769,7 +99466,13 @@
       110283,
       110321,
       110322,
-      110441
+      110420,
+      110422,
+      110423,
+      110442,
+      110597,
+      110849,
+      110850
     ]
   },
   {
@@ -98317,6 +100020,7 @@
         "maxRanks": 1,
         "next": [
           62127,
+          110597,
           62098
         ],
         "prev": [
@@ -98491,6 +100195,33 @@
         ]
       },
       {
+        "id": 110597,
+        "name": "Improved Warding",
+        "type": "single",
+        "posX": 3900,
+        "posY": 5100,
+        "reqPoints": 8,
+        "maxRanks": 1,
+        "next": [
+          62096
+        ],
+        "prev": [
+          108661
+        ],
+        "entries": [
+          {
+            "id": 137410,
+            "definitionId": 142170,
+            "maxRanks": 1,
+            "type": "passive",
+            "name": "Improved Warding",
+            "spellId": 1297073,
+            "icon": "inv_cloth_raidmage_p_01helm",
+            "index": 100
+          }
+        ]
+      },
+      {
         "id": 62098,
         "name": "Tome of Antonidas",
         "type": "single",
@@ -98648,7 +100379,8 @@
         ],
         "prev": [
           62098,
-          62127
+          62127,
+          110597
         ],
         "entries": [
           {
@@ -100114,6 +101846,64 @@
             "index": 100
           }
         ]
+      },
+      {
+        "id": 110422,
+        "name": "Hand of Frost / Hand of Frost / Hand of Frost",
+        "type": "tiered",
+        "posX": 12300,
+        "posY": 7650,
+        "reqPoints": 20,
+        "maxRanks": 4,
+        "rankLevels": [
+          {
+            "level": 81,
+            "maxRanks": 1
+          },
+          {
+            "level": 84,
+            "maxRanks": 3
+          },
+          {
+            "level": 90,
+            "maxRanks": 4
+          }
+        ],
+        "entryNode": true,
+        "next": [],
+        "prev": [],
+        "entries": [
+          {
+            "id": 137034,
+            "definitionId": 141797,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Hand of Frost",
+            "spellId": 1262935,
+            "icon": "inv12_apextalent_mage_handoffrost",
+            "index": 100
+          },
+          {
+            "id": 137033,
+            "definitionId": 141796,
+            "maxRanks": 2,
+            "type": "tierrank",
+            "name": "Hand of Frost",
+            "spellId": 1262981,
+            "icon": "spell_frost_piercing_chill",
+            "index": 200
+          },
+          {
+            "id": 137032,
+            "definitionId": 141795,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Hand of Frost",
+            "spellId": 1263249,
+            "icon": "ability_mage_rayoffrost",
+            "index": 300
+          }
+        ]
       }
     ],
     "heroNodes": [
@@ -100145,37 +101935,8 @@
             "index": 100
           }
         ],
-        "freeNode": true
-      },
-      {
-        "id": 109956,
-        "name": "Frostfire Bolt",
-        "type": "single",
-        "posX": 15000,
-        "posY": 1500,
-        "maxRanks": 1,
-        "entryNode": true,
-        "subTreeId": 41,
-        "next": [
-          94642,
-          94641,
-          94633,
-          109672
-        ],
-        "prev": [],
-        "entries": [
-          {
-            "id": 136441,
-            "definitionId": 141214,
-            "maxRanks": 1,
-            "type": "active",
-            "name": "Frostfire Bolt",
-            "spellId": 431044,
-            "icon": "inv_ability_frostfiremage_frostfirebolt",
-            "index": 100
-          }
-        ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 94664,
@@ -100205,7 +101966,8 @@
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 94642,
@@ -100219,8 +101981,7 @@
           94638
         ],
         "prev": [
-          94636,
-          109956
+          94636
         ],
         "entries": [
           {
@@ -100257,8 +102018,7 @@
           94640
         ],
         "prev": [
-          94636,
-          109956
+          94636
         ],
         "entries": [
           {
@@ -100285,8 +102045,7 @@
           94634
         ],
         "prev": [
-          94636,
-          109956
+          94636
         ],
         "entries": [
           {
@@ -100323,8 +102082,7 @@
           109671
         ],
         "prev": [
-          94636,
-          109956
+          94636
         ],
         "entries": [
           {
@@ -101161,7 +102919,6 @@
       102470,
       102471,
       102472,
-      102473,
       102474,
       102475,
       102476,
@@ -101244,7 +103001,13 @@
       110283,
       110321,
       110322,
-      110441
+      110420,
+      110422,
+      110423,
+      110442,
+      110597,
+      110849,
+      110850
     ]
   },
   {
@@ -101681,7 +103444,7 @@
         "entries": [
           {
             "id": 134217,
-            "definitionId": 117191,
+            "definitionId": 141828,
             "maxRanks": 1,
             "type": "active",
             "name": "Intervene",
@@ -102101,7 +103864,7 @@
         "type": "single",
         "posX": 1800,
         "posY": 5100,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           90381
@@ -102128,7 +103891,7 @@
         "type": "single",
         "posX": 3000,
         "posY": 5100,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           90381,
@@ -102146,7 +103909,7 @@
             "type": "passive",
             "name": "Javelineer",
             "spellId": 1271948,
-            "icon": "inv_spear_01",
+            "icon": "inv121_ability_warrior_javelineer",
             "index": 100
           }
         ]
@@ -102157,7 +103920,7 @@
         "type": "single",
         "posX": 4200,
         "posY": 5100,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           90322,
@@ -102186,7 +103949,7 @@
         "type": "single",
         "posX": 5400,
         "posY": 5100,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           90360
@@ -102213,7 +103976,7 @@
         "type": "single",
         "posX": 2400,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "next": [
           108543,
@@ -102242,7 +104005,7 @@
         "type": "single",
         "posX": 3600,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "next": [
           90380,
@@ -102271,7 +104034,7 @@
         "type": "single",
         "posX": 4800,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "next": [
           108542,
@@ -102300,7 +104063,7 @@
         "type": "single",
         "posX": 1800,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -102325,7 +104088,7 @@
         "type": "single",
         "posX": 3000,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -102351,7 +104114,7 @@
         "type": "single",
         "posX": 4200,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -102377,7 +104140,7 @@
         "type": "single",
         "posX": 5400,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -102775,8 +104538,8 @@
       },
       {
         "id": 92614,
-        "name": "Overpowering Finish",
-        "type": "single",
+        "name": "Overpowering Finish / Mass Execution",
+        "type": "choice",
         "posX": 10800,
         "posY": 3900,
         "reqPoints": 8,
@@ -102798,6 +104561,16 @@
             "spellId": 400205,
             "icon": "ability_warrior_punishingblow",
             "index": 200
+          },
+          {
+            "id": 137473,
+            "definitionId": 142233,
+            "maxRanks": 1,
+            "type": "passive",
+            "name": "Mass Execution",
+            "spellId": 1273075,
+            "icon": "warrior_talent_icon_mastercleaver",
+            "index": 300
           }
         ]
       },
@@ -102877,7 +104650,7 @@
         "maxRanks": 2,
         "next": [
           90291,
-          110175
+          109682
         ],
         "prev": [
           90292,
@@ -102905,7 +104678,6 @@
         "reqPoints": 8,
         "maxRanks": 1,
         "next": [
-          110175,
           109682
         ],
         "prev": [
@@ -102926,8 +104698,8 @@
       },
       {
         "id": 92536,
-        "name": "Improved Sweeping Strikes / Powerful Momentum",
-        "type": "choice",
+        "name": "Powerful Momentum",
+        "type": "single",
         "posX": 13800,
         "posY": 3900,
         "reqPoints": 8,
@@ -102939,16 +104711,6 @@
           90292
         ],
         "entries": [
-          {
-            "id": 114641,
-            "definitionId": 119647,
-            "maxRanks": 1,
-            "type": "passive",
-            "name": "Improved Sweeping Strikes",
-            "spellId": 383155,
-            "icon": "ability_rogue_slicedice",
-            "index": 100
-          },
           {
             "id": 114739,
             "definitionId": 119746,
@@ -103111,8 +104873,8 @@
         ]
       },
       {
-        "id": 110175,
-        "name": "Mass Execution",
+        "id": 109682,
+        "name": "Collateral Damage",
         "type": "single",
         "posX": 13200,
         "posY": 4500,
@@ -103122,36 +104884,9 @@
           90444
         ],
         "prev": [
-          90447,
-          90293
-        ],
-        "entries": [
-          {
-            "id": 136700,
-            "definitionId": 141472,
-            "maxRanks": 1,
-            "type": "passive",
-            "name": "Mass Execution",
-            "spellId": 1273075,
-            "icon": "warrior_talent_icon_mastercleaver",
-            "index": 100
-          }
-        ]
-      },
-      {
-        "id": 109682,
-        "name": "Collateral Damage",
-        "type": "single",
-        "posX": 13800,
-        "posY": 4500,
-        "reqPoints": 8,
-        "maxRanks": 1,
-        "next": [
-          90444
-        ],
-        "prev": [
           92536,
-          90293
+          90293,
+          90447
         ],
         "entries": [
           {
@@ -103249,7 +104984,6 @@
           90439
         ],
         "prev": [
-          110175,
           90291,
           109682
         ],
@@ -103268,7 +105002,7 @@
       },
       {
         "id": 92615,
-        "name": "Battlelord",
+        "name": "Master Tactician",
         "type": "single",
         "posX": 10200,
         "posY": 5700,
@@ -103286,9 +105020,9 @@
             "definitionId": 119747,
             "maxRanks": 1,
             "type": "passive",
-            "name": "Battlelord",
-            "spellId": 386630,
-            "icon": "ability_pvp_hardiness",
+            "name": "Master Tactician",
+            "spellId": 1261057,
+            "icon": "ability_warrior_revenge",
             "index": 0
           }
         ]
@@ -103380,7 +105114,7 @@
       },
       {
         "id": 109679,
-        "name": "Master Tactician",
+        "name": "Battlelord",
         "type": "single",
         "posX": 10800,
         "posY": 6300,
@@ -103397,9 +105131,9 @@
             "definitionId": 140688,
             "maxRanks": 1,
             "type": "passive",
-            "name": "Master Tactician",
-            "spellId": 1261057,
-            "icon": "ability_warrior_revenge",
+            "name": "Battlelord",
+            "spellId": 386630,
+            "icon": "ability_pvp_hardiness",
             "index": 100
           }
         ]
@@ -103455,6 +105189,64 @@
             "index": 100
           }
         ]
+      },
+      {
+        "id": 110407,
+        "name": "Master of Warfare / Master of Warfare / Master of Warfare",
+        "type": "tiered",
+        "posX": 12000,
+        "posY": 7050,
+        "reqPoints": 20,
+        "maxRanks": 4,
+        "rankLevels": [
+          {
+            "level": 81,
+            "maxRanks": 1
+          },
+          {
+            "level": 84,
+            "maxRanks": 3
+          },
+          {
+            "level": 90,
+            "maxRanks": 4
+          }
+        ],
+        "entryNode": true,
+        "next": [],
+        "prev": [],
+        "entries": [
+          {
+            "id": 136989,
+            "definitionId": 141752,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Master of Warfare",
+            "spellId": 1269314,
+            "icon": "inv12_apextalent_warrior_masterofwarfare",
+            "index": 100
+          },
+          {
+            "id": 136988,
+            "definitionId": 141751,
+            "maxRanks": 2,
+            "type": "tierrank",
+            "name": "Master of Warfare",
+            "spellId": 1269306,
+            "icon": "inv12_apextalent_warrior_masterofwarfare",
+            "index": 200
+          },
+          {
+            "id": 136987,
+            "definitionId": 141750,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Master of Warfare",
+            "spellId": 1269307,
+            "icon": "inv12_apextalent_warrior_masterofwarfare",
+            "index": 300
+          }
+        ]
       }
     ],
     "heroNodes": [
@@ -103486,7 +105278,8 @@
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 94788,
@@ -103902,7 +105695,8 @@
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 94812,
@@ -104552,10 +106346,14 @@
       109969,
       110118,
       110119,
-      110175,
       110176,
       110203,
-      110329
+      110330,
+      110407,
+      110411,
+      110412,
+      110653,
+      110654
     ]
   },
   {
@@ -104628,7 +106426,7 @@
         "maxRanks": 1,
         "next": [
           90326,
-          109391
+          110654
         ],
         "prev": [
           90325
@@ -104737,7 +106535,7 @@
         "posY": 2100,
         "maxRanks": 1,
         "next": [
-          109391,
+          110654,
           90332,
           90352
         ],
@@ -104840,8 +106638,8 @@
         ]
       },
       {
-        "id": 109391,
-        "name": "Rend",
+        "id": 110654,
+        "name": "Storm of Blood",
         "type": "single",
         "posX": 1800,
         "posY": 2700,
@@ -104851,18 +106649,18 @@
           90351
         ],
         "prev": [
-          90344,
-          90326
+          90326,
+          90344
         ],
         "entries": [
           {
-            "id": 135597,
-            "definitionId": 140353,
+            "id": 137472,
+            "definitionId": 142232,
             "maxRanks": 1,
-            "type": "active",
-            "name": "Rend",
-            "spellId": 772,
-            "icon": "ability_gouge",
+            "type": "passive",
+            "name": "Storm of Blood",
+            "spellId": 1299025,
+            "icon": "ability_ironmaidens_whirlofblood",
             "index": 100
           }
         ]
@@ -105026,8 +106824,8 @@
           90348
         ],
         "prev": [
-          109391,
-          90352
+          90352,
+          110654
         ],
         "entries": [
           {
@@ -105163,7 +106961,7 @@
         ],
         "prev": [
           90375,
-          109391
+          110654
         ],
         "entries": [
           {
@@ -105412,7 +107210,7 @@
         "type": "single",
         "posX": 1800,
         "posY": 5100,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           90381
@@ -105439,7 +107237,7 @@
         "type": "single",
         "posX": 3000,
         "posY": 5100,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           90381,
@@ -105457,7 +107255,7 @@
             "type": "passive",
             "name": "Javelineer",
             "spellId": 1271948,
-            "icon": "inv_spear_01",
+            "icon": "inv121_ability_warrior_javelineer",
             "index": 100
           }
         ]
@@ -105468,7 +107266,7 @@
         "type": "single",
         "posX": 4200,
         "posY": 5100,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           90373,
@@ -105497,7 +107295,7 @@
         "type": "single",
         "posX": 5400,
         "posY": 5100,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           90360
@@ -105524,7 +107322,7 @@
         "type": "single",
         "posX": 2400,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "next": [
           108543,
@@ -105553,7 +107351,7 @@
         "type": "single",
         "posX": 3600,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "next": [
           90380,
@@ -105582,7 +107380,7 @@
         "type": "single",
         "posX": 4800,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "next": [
           108542,
@@ -105611,7 +107409,7 @@
         "type": "single",
         "posX": 1800,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -105636,7 +107434,7 @@
         "type": "single",
         "posX": 3000,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -105662,7 +107460,7 @@
         "type": "single",
         "posX": 4200,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -105688,7 +107486,7 @@
         "type": "single",
         "posX": 5400,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -105889,7 +107687,7 @@
         "maxRanks": 1,
         "next": [
           90399,
-          110329,
+          110330,
           90408
         ],
         "prev": [
@@ -106021,7 +107819,7 @@
         ]
       },
       {
-        "id": 110329,
+        "id": 110330,
         "name": "Invigorating Fury",
         "type": "single",
         "posX": 11400,
@@ -106034,8 +107832,8 @@
         ],
         "entries": [
           {
-            "id": 136889,
-            "definitionId": 141652,
+            "id": 136890,
+            "definitionId": 141653,
             "maxRanks": 1,
             "type": "passive",
             "name": "Invigorating Fury",
@@ -106298,16 +108096,16 @@
       },
       {
         "id": 109967,
-        "name": "Meat Cleaver",
-        "type": "single",
+        "name": "Meat Cleaver / Carving Blades",
+        "type": "choice",
         "posX": 13800,
         "posY": 3900,
         "reqPoints": 8,
         "maxRanks": 1,
         "next": [],
         "prev": [
-          90390,
-          90391
+          90391,
+          90390
         ],
         "entries": [
           {
@@ -106319,6 +108117,16 @@
             "spellId": 280392,
             "icon": "warrior_talent_icon_mastercleaver",
             "index": 100
+          },
+          {
+            "id": 137487,
+            "definitionId": 142247,
+            "maxRanks": 1,
+            "type": "passive",
+            "name": "Carving Blades",
+            "spellId": 1300463,
+            "icon": "inv_knife_1h_goblinrogue_c_01",
+            "index": 200
           }
         ]
       },
@@ -106362,8 +108170,8 @@
           90406
         ],
         "prev": [
-          109969,
-          90397
+          90397,
+          109969
         ],
         "entries": [
           {
@@ -106476,8 +108284,8 @@
           110203
         ],
         "prev": [
-          109962,
-          90402
+          90402,
+          109962
         ],
         "entries": [
           {
@@ -106535,8 +108343,8 @@
           109964
         ],
         "prev": [
-          90405,
-          90387
+          90387,
+          90405
         ],
         "entries": [
           {
@@ -106750,6 +108558,64 @@
             "index": 200
           }
         ]
+      },
+      {
+        "id": 110412,
+        "name": "Rampaging Berserker / Rampaging Berserker / Rampaging Berserker",
+        "type": "tiered",
+        "posX": 12000,
+        "posY": 7050,
+        "reqPoints": 20,
+        "maxRanks": 4,
+        "rankLevels": [
+          {
+            "level": 81,
+            "maxRanks": 1
+          },
+          {
+            "level": 84,
+            "maxRanks": 3
+          },
+          {
+            "level": 90,
+            "maxRanks": 4
+          }
+        ],
+        "entryNode": true,
+        "next": [],
+        "prev": [],
+        "entries": [
+          {
+            "id": 137004,
+            "definitionId": 141767,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Rampaging Berserker",
+            "spellId": 1269308,
+            "icon": "inv12_apextalent_warrior_rampagingberserker2",
+            "index": 100
+          },
+          {
+            "id": 137003,
+            "definitionId": 141766,
+            "maxRanks": 2,
+            "type": "tierrank",
+            "name": "Rampaging Berserker",
+            "spellId": 1269309,
+            "icon": "inv12_apextalent_warrior_rampagingberserker2",
+            "index": 200
+          },
+          {
+            "id": 137002,
+            "definitionId": 141765,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Rampaging Berserker",
+            "spellId": 1269310,
+            "icon": "inv12_apextalent_warrior_rampagingberserker2",
+            "index": 300
+          }
+        ]
       }
     ],
     "heroNodes": [
@@ -106781,7 +108647,8 @@
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 94816,
@@ -106920,7 +108787,8 @@
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 94785,
@@ -107859,10 +109727,14 @@
       109969,
       110118,
       110119,
-      110175,
       110176,
       110203,
-      110329
+      110330,
+      110407,
+      110411,
+      110412,
+      110653,
+      110654
     ]
   },
   {
@@ -107935,7 +109807,7 @@
         "maxRanks": 1,
         "next": [
           90326,
-          109391
+          110653
         ],
         "prev": [
           90261
@@ -108044,7 +109916,7 @@
         "posY": 2100,
         "maxRanks": 1,
         "next": [
-          109391,
+          110653,
           90332,
           90352
         ],
@@ -108147,8 +110019,8 @@
         ]
       },
       {
-        "id": 109391,
-        "name": "Rend",
+        "id": 110653,
+        "name": "Blood and Thunder",
         "type": "single",
         "posX": 1800,
         "posY": 2700,
@@ -108158,18 +110030,18 @@
           90351
         ],
         "prev": [
-          90344,
-          90326
+          90326,
+          90344
         ],
         "entries": [
           {
-            "id": 135597,
-            "definitionId": 140353,
+            "id": 137471,
+            "definitionId": 142231,
             "maxRanks": 1,
-            "type": "active",
-            "name": "Rend",
-            "spellId": 772,
-            "icon": "ability_gouge",
+            "type": "passive",
+            "name": "Blood and Thunder",
+            "spellId": 384277,
+            "icon": "warrior_talent_icon_bloodandthunder",
             "index": 100
           }
         ]
@@ -108323,8 +110195,8 @@
           90348
         ],
         "prev": [
-          109391,
-          90352
+          90352,
+          110653
         ],
         "entries": [
           {
@@ -108460,7 +110332,7 @@
         ],
         "prev": [
           90375,
-          109391
+          110653
         ],
         "entries": [
           {
@@ -108709,7 +110581,7 @@
         "type": "single",
         "posX": 1800,
         "posY": 5100,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           90381
@@ -108736,7 +110608,7 @@
         "type": "single",
         "posX": 3000,
         "posY": 5100,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           90381,
@@ -108754,7 +110626,7 @@
             "type": "passive",
             "name": "Javelineer",
             "spellId": 1271948,
-            "icon": "inv_spear_01",
+            "icon": "inv121_ability_warrior_javelineer",
             "index": 100
           }
         ]
@@ -108765,7 +110637,7 @@
         "type": "single",
         "posX": 4200,
         "posY": 5100,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           90324,
@@ -108794,7 +110666,7 @@
         "type": "single",
         "posX": 5400,
         "posY": 5100,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           90360
@@ -108821,7 +110693,7 @@
         "type": "single",
         "posX": 2400,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "next": [
           108543,
@@ -108850,7 +110722,7 @@
         "type": "single",
         "posX": 3600,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "next": [
           90380,
@@ -108879,7 +110751,7 @@
         "type": "single",
         "posX": 4800,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "next": [
           108542,
@@ -108908,7 +110780,7 @@
         "type": "single",
         "posX": 1800,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -108933,7 +110805,7 @@
         "type": "single",
         "posX": 3000,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -108959,7 +110831,7 @@
         "type": "single",
         "posX": 4200,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -108985,7 +110857,7 @@
         "type": "single",
         "posX": 5400,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -110097,6 +111969,64 @@
             "index": 300
           }
         ]
+      },
+      {
+        "id": 110411,
+        "name": "Phalanx / Phalanx / Phalanx",
+        "type": "tiered",
+        "posX": 12000,
+        "posY": 7050,
+        "reqPoints": 20,
+        "maxRanks": 4,
+        "rankLevels": [
+          {
+            "level": 81,
+            "maxRanks": 1
+          },
+          {
+            "level": 84,
+            "maxRanks": 3
+          },
+          {
+            "level": 90,
+            "maxRanks": 4
+          }
+        ],
+        "entryNode": true,
+        "next": [],
+        "prev": [],
+        "entries": [
+          {
+            "id": 137001,
+            "definitionId": 141764,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Phalanx",
+            "spellId": 1269311,
+            "icon": "inv12_apextalent_warrior_phalanx",
+            "index": 100
+          },
+          {
+            "id": 137000,
+            "definitionId": 141763,
+            "maxRanks": 2,
+            "type": "tierrank",
+            "name": "Phalanx",
+            "spellId": 1269312,
+            "icon": "inv12_apextalent_warrior_phalanx",
+            "index": 200
+          },
+          {
+            "id": 136999,
+            "definitionId": 141762,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Phalanx",
+            "spellId": 1269313,
+            "icon": "inv12_apextalent_warrior_phalanx",
+            "index": 300
+          }
+        ]
       }
     ],
     "heroNodes": [
@@ -110128,7 +112058,8 @@
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 94816,
@@ -110553,7 +112484,8 @@
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 94812,
@@ -111203,10 +113135,14 @@
       109969,
       110118,
       110119,
-      110175,
       110176,
       110203,
-      110329
+      110330,
+      110407,
+      110411,
+      110412,
+      110653,
+      110654
     ]
   },
   {
@@ -111262,12 +113198,13 @@
             "maxRanks": 1,
             "type": "passive",
             "name": "Soul Leech",
-            "spellId": 108370,
+            "spellId": 1311653,
             "icon": "warlock_siphonlife",
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 10
       },
       {
         "id": 71949,
@@ -112104,7 +114041,7 @@
         "type": "choice",
         "posX": 3000,
         "posY": 5400,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           71918,
@@ -112143,7 +114080,7 @@
         "type": "single",
         "posX": 4200,
         "posY": 5400,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           109842,
@@ -112173,7 +114110,7 @@
         "type": "choice",
         "posX": 5400,
         "posY": 5400,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           71924,
@@ -112213,7 +114150,7 @@
         "type": "single",
         "posX": 2400,
         "posY": 6000,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           71926
@@ -112240,7 +114177,7 @@
         "type": "single",
         "posX": 3600,
         "posY": 6000,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "next": [
           71926,
@@ -112269,7 +114206,7 @@
         "type": "single",
         "posX": 4200,
         "posY": 6000,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           71957
@@ -112296,7 +114233,7 @@
         "type": "single",
         "posX": 4800,
         "posY": 6000,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "next": [
           71957,
@@ -112325,7 +114262,7 @@
         "type": "single",
         "posX": 6000,
         "posY": 6000,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           109848
@@ -112352,7 +114289,7 @@
         "type": "single",
         "posX": 3000,
         "posY": 6600,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -112378,7 +114315,7 @@
         "type": "single",
         "posX": 4200,
         "posY": 6600,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -112405,7 +114342,7 @@
         "type": "choice",
         "posX": 5400,
         "posY": 6600,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -113219,7 +115156,7 @@
       },
       {
         "id": 109851,
-        "name": "Nocturnal Yield",
+        "name": "Impetuous Wrath",
         "type": "single",
         "posX": 14400,
         "posY": 5400,
@@ -113238,9 +115175,9 @@
             "definitionId": 140866,
             "maxRanks": 1,
             "type": "passive",
-            "name": "Nocturnal Yield",
-            "spellId": 1260271,
-            "icon": "inv_nulllotus_shadow",
+            "name": "Impetuous Wrath",
+            "spellId": 1312998,
+            "icon": "spell_shadow_manaburn",
             "index": 100
           }
         ]
@@ -113408,7 +115345,7 @@
       },
       {
         "id": 109853,
-        "name": "Patient Zero",
+        "name": "Hedonic Gorging",
         "type": "single",
         "posX": 13200,
         "posY": 6600,
@@ -113424,9 +115361,9 @@
             "definitionId": 140868,
             "maxRanks": 1,
             "type": "passive",
-            "name": "Patient Zero",
-            "spellId": 1260285,
-            "icon": "ability_warlock_soulswap",
+            "name": "Hedonic Gorging",
+            "spellId": 1311969,
+            "icon": "ability_soulrenderdormazain_hellscream",
             "index": 100
           }
         ]
@@ -113453,6 +115390,64 @@
             "spellId": 196226,
             "icon": "spell_shadow_seedofdestruction",
             "index": 100
+          }
+        ]
+      },
+      {
+        "id": 110405,
+        "name": "Shadow of Nathreza / Shadow of Nathreza / Shadow of Nathreza",
+        "type": "tiered",
+        "posX": 12600,
+        "posY": 7350,
+        "reqPoints": 20,
+        "maxRanks": 4,
+        "rankLevels": [
+          {
+            "level": 81,
+            "maxRanks": 1
+          },
+          {
+            "level": 84,
+            "maxRanks": 3
+          },
+          {
+            "level": 90,
+            "maxRanks": 4
+          }
+        ],
+        "entryNode": true,
+        "next": [],
+        "prev": [],
+        "entries": [
+          {
+            "id": 136983,
+            "definitionId": 141746,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Shadow of Nathreza",
+            "spellId": 1261984,
+            "icon": "inv12_apextalent_warlock_shadowsofnathreza",
+            "index": 100
+          },
+          {
+            "id": 136982,
+            "definitionId": 141745,
+            "maxRanks": 2,
+            "type": "tierrank",
+            "name": "Shadow of Nathreza",
+            "spellId": 1261990,
+            "icon": "inv12_apextalent_warlock_shadowsofnathreza",
+            "index": 200
+          },
+          {
+            "id": 136981,
+            "definitionId": 141744,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Shadow of Nathreza",
+            "spellId": 1261992,
+            "icon": "inv12_apextalent_warlock_shadowsofnathreza",
+            "index": 300
           }
         ]
       }
@@ -113487,7 +115482,8 @@
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 94853,
@@ -113625,7 +115621,8 @@
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 94825,
@@ -114549,7 +116546,10 @@
       110270,
       110280,
       110281,
-      110282
+      110282,
+      110404,
+      110405,
+      110406
     ]
   },
   {
@@ -114605,12 +116605,13 @@
             "maxRanks": 1,
             "type": "passive",
             "name": "Soul Leech",
-            "spellId": 108370,
+            "spellId": 1311653,
             "icon": "warlock_siphonlife",
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 10
       },
       {
         "id": 71949,
@@ -115447,7 +117448,7 @@
         "type": "choice",
         "posX": 3000,
         "posY": 5400,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           71918,
@@ -115486,7 +117487,7 @@
         "type": "single",
         "posX": 4200,
         "posY": 5400,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           109842,
@@ -115516,7 +117517,7 @@
         "type": "choice",
         "posX": 5400,
         "posY": 5400,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           71924,
@@ -115556,7 +117557,7 @@
         "type": "single",
         "posX": 2400,
         "posY": 6000,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           71926
@@ -115583,7 +117584,7 @@
         "type": "single",
         "posX": 3600,
         "posY": 6000,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "next": [
           71926,
@@ -115612,7 +117613,7 @@
         "type": "single",
         "posX": 4200,
         "posY": 6000,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           71957
@@ -115639,7 +117640,7 @@
         "type": "single",
         "posX": 4800,
         "posY": 6000,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "next": [
           71957,
@@ -115668,7 +117669,7 @@
         "type": "single",
         "posX": 6000,
         "posY": 6000,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           109848
@@ -115695,7 +117696,7 @@
         "type": "single",
         "posX": 3000,
         "posY": 6600,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -115721,7 +117722,7 @@
         "type": "single",
         "posX": 4200,
         "posY": 6600,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -115748,7 +117749,7 @@
         "type": "choice",
         "posX": 5400,
         "posY": 6600,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -116860,6 +118861,64 @@
             "index": 200
           }
         ]
+      },
+      {
+        "id": 110404,
+        "name": "Dominion of Argus / Dominion of Argus / Dominion of Argus",
+        "type": "tiered",
+        "posX": 12600,
+        "posY": 7350,
+        "reqPoints": 20,
+        "maxRanks": 4,
+        "rankLevels": [
+          {
+            "level": 81,
+            "maxRanks": 1
+          },
+          {
+            "level": 84,
+            "maxRanks": 3
+          },
+          {
+            "level": 90,
+            "maxRanks": 4
+          }
+        ],
+        "entryNode": true,
+        "next": [],
+        "prev": [],
+        "entries": [
+          {
+            "id": 136980,
+            "definitionId": 141743,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Dominion of Argus",
+            "spellId": 1276163,
+            "icon": "inv12_apextalent_warlock_dominionofargus",
+            "index": 100
+          },
+          {
+            "id": 136979,
+            "definitionId": 141742,
+            "maxRanks": 2,
+            "type": "tierrank",
+            "name": "Dominion of Argus",
+            "spellId": 1276190,
+            "icon": "inv12_apextalent_warlock_dominionofargus",
+            "index": 200
+          },
+          {
+            "id": 136978,
+            "definitionId": 141741,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Dominion of Argus",
+            "spellId": 1276222,
+            "icon": "inv12_apextalent_warlock_dominionofargus",
+            "index": 300
+          }
+        ]
       }
     ],
     "heroNodes": [
@@ -116891,7 +118950,8 @@
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 94825,
@@ -117306,7 +119366,8 @@
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 94849,
@@ -117954,7 +120015,10 @@
       110270,
       110280,
       110281,
-      110282
+      110282,
+      110404,
+      110405,
+      110406
     ]
   },
   {
@@ -118010,12 +120074,13 @@
             "maxRanks": 1,
             "type": "passive",
             "name": "Soul Leech",
-            "spellId": 108370,
+            "spellId": 1311653,
             "icon": "warlock_siphonlife",
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 10
       },
       {
         "id": 71949,
@@ -118852,7 +120917,7 @@
         "type": "choice",
         "posX": 3000,
         "posY": 5400,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           71918,
@@ -118891,7 +120956,7 @@
         "type": "single",
         "posX": 4200,
         "posY": 5400,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           109842,
@@ -118921,7 +120986,7 @@
         "type": "choice",
         "posX": 5400,
         "posY": 5400,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           71924,
@@ -118961,7 +121026,7 @@
         "type": "single",
         "posX": 2400,
         "posY": 6000,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           71926
@@ -118988,7 +121053,7 @@
         "type": "single",
         "posX": 3600,
         "posY": 6000,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "next": [
           71926,
@@ -119017,7 +121082,7 @@
         "type": "single",
         "posX": 4200,
         "posY": 6000,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           71957
@@ -119044,7 +121109,7 @@
         "type": "single",
         "posX": 4800,
         "posY": 6000,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "next": [
           71957,
@@ -119073,7 +121138,7 @@
         "type": "single",
         "posX": 6000,
         "posY": 6000,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           109848
@@ -119100,7 +121165,7 @@
         "type": "single",
         "posX": 3000,
         "posY": 6600,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -119126,7 +121191,7 @@
         "type": "single",
         "posX": 4200,
         "posY": 6600,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -119153,7 +121218,7 @@
         "type": "choice",
         "posX": 5400,
         "posY": 6600,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -119941,7 +122006,7 @@
         "maxRanks": 2,
         "next": [
           108681,
-          71975
+          71966
         ],
         "prev": [
           71980
@@ -119968,7 +122033,7 @@
         "reqPoints": 20,
         "maxRanks": 1,
         "next": [
-          71975,
+          71966,
           71965
         ],
         "prev": [
@@ -120083,15 +122148,15 @@
         ]
       },
       {
-        "id": 71975,
-        "name": "Inferno",
+        "id": 71966,
+        "name": "Chaos Incarnate",
         "type": "single",
         "posX": 12000,
         "posY": 6000,
         "reqPoints": 20,
         "maxRanks": 1,
         "next": [
-          71966
+          71975
         ],
         "prev": [
           72066,
@@ -120099,13 +122164,13 @@
         ],
         "entries": [
           {
-            "id": 91489,
-            "definitionId": 96491,
+            "id": 91479,
+            "definitionId": 96481,
             "maxRanks": 1,
             "type": "passive",
-            "name": "Inferno",
-            "spellId": 1280483,
-            "icon": "warlock_pvp_burninglegion",
+            "name": "Chaos Incarnate",
+            "spellId": 387275,
+            "icon": "spell_fire_felflamering",
             "index": 100
           }
         ]
@@ -120131,7 +122196,7 @@
             "type": "passive",
             "name": "Conflagration of Chaos",
             "spellId": 387108,
-            "icon": "spell_shadow_scourgebuild",
+            "icon": "inv_shadowflame_buff",
             "index": 100
           }
         ]
@@ -120227,8 +122292,8 @@
         ]
       },
       {
-        "id": 71966,
-        "name": "Chaos Incarnate",
+        "id": 71975,
+        "name": "Inferno",
         "type": "single",
         "posX": 12000,
         "posY": 6600,
@@ -120236,17 +122301,17 @@
         "maxRanks": 1,
         "next": [],
         "prev": [
-          71975
+          71966
         ],
         "entries": [
           {
-            "id": 91479,
-            "definitionId": 96481,
+            "id": 91489,
+            "definitionId": 96491,
             "maxRanks": 1,
             "type": "passive",
-            "name": "Chaos Incarnate",
-            "spellId": 387275,
-            "icon": "spell_fire_felflamering",
+            "name": "Inferno",
+            "spellId": 1280483,
+            "icon": "warlock_pvp_burninglegion",
             "index": 100
           }
         ]
@@ -120300,6 +122365,64 @@
             "index": 100
           }
         ]
+      },
+      {
+        "id": 110406,
+        "name": "Embers of Nihilam / Embers of Nihilam / Embers of Nihilam",
+        "type": "tiered",
+        "posX": 12600,
+        "posY": 7350,
+        "reqPoints": 20,
+        "maxRanks": 4,
+        "rankLevels": [
+          {
+            "level": 81,
+            "maxRanks": 1
+          },
+          {
+            "level": 84,
+            "maxRanks": 3
+          },
+          {
+            "level": 90,
+            "maxRanks": 4
+          }
+        ],
+        "entryNode": true,
+        "next": [],
+        "prev": [],
+        "entries": [
+          {
+            "id": 136986,
+            "definitionId": 141749,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Embers of Nihilam",
+            "spellId": 1265770,
+            "icon": "inv12_apextalent_warlock_embersofnihilam",
+            "index": 100
+          },
+          {
+            "id": 136985,
+            "definitionId": 141748,
+            "maxRanks": 2,
+            "type": "tierrank",
+            "name": "Embers of Nihilam",
+            "spellId": 1265772,
+            "icon": "inv12_apextalent_warlock_embersofnihilam",
+            "index": 200
+          },
+          {
+            "id": 136984,
+            "definitionId": 141747,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Embers of Nihilam",
+            "spellId": 1265774,
+            "icon": "inv12_apextalent_warlock_embersofnihilam",
+            "index": 300
+          }
+        ]
       }
     ],
     "heroNodes": [
@@ -120332,7 +122455,8 @@
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 94853,
@@ -120745,7 +122869,8 @@
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 94849,
@@ -121393,7 +123518,10 @@
       110270,
       110280,
       110281,
-      110282
+      110282,
+      110404,
+      110405,
+      110406
     ]
   },
   {
@@ -121474,7 +123602,7 @@
             "id": 136086,
             "definitionId": 140841,
             "maxRanks": 1,
-            "type": "passive",
+            "type": "active",
             "name": "Stagger",
             "spellId": 115069,
             "icon": "monk_stance_drunkenox",
@@ -122446,7 +124574,7 @@
         "type": "single",
         "posX": 2400,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           101169
@@ -122474,7 +124602,7 @@
         "type": "single",
         "posX": 3000,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           101169
@@ -122502,7 +124630,7 @@
         "type": "choice",
         "posX": 3600,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           101169,
@@ -122541,7 +124669,7 @@
         "type": "single",
         "posX": 4200,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           101175
@@ -122570,7 +124698,7 @@
         "type": "choice",
         "posX": 4800,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           101175,
@@ -122609,7 +124737,7 @@
         "type": "single",
         "posX": 5400,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -122634,7 +124762,7 @@
         "type": "single",
         "posX": 6000,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           101179
@@ -122662,7 +124790,7 @@
         "type": "single",
         "posX": 3000,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "next": [
           101168,
@@ -122692,7 +124820,7 @@
         "type": "single",
         "posX": 3600,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           101170,
@@ -122720,7 +124848,7 @@
         "type": "single",
         "posX": 4200,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           101176
@@ -122749,7 +124877,7 @@
         "type": "single",
         "posX": 4800,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           101176,
@@ -122777,7 +124905,7 @@
         "type": "single",
         "posX": 5400,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "next": [
           101178,
@@ -122806,7 +124934,7 @@
         "type": "single",
         "posX": 2400,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -122831,7 +124959,7 @@
         "type": "single",
         "posX": 3600,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -122857,7 +124985,7 @@
         "type": "choice",
         "posX": 4200,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -122894,7 +125022,7 @@
         "type": "single",
         "posX": 4800,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -122920,7 +125048,7 @@
         "type": "single",
         "posX": 6000,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -124263,6 +126391,64 @@
             "index": 100
           }
         ]
+      },
+      {
+        "id": 110435,
+        "name": "Bring Me Another / Bring Me Another / Bring Me Another",
+        "type": "tiered",
+        "posX": 12600,
+        "posY": 7650,
+        "reqPoints": 20,
+        "maxRanks": 4,
+        "rankLevels": [
+          {
+            "level": 81,
+            "maxRanks": 1
+          },
+          {
+            "level": 84,
+            "maxRanks": 3
+          },
+          {
+            "level": 90,
+            "maxRanks": 4
+          }
+        ],
+        "entryNode": true,
+        "next": [],
+        "prev": [],
+        "entries": [
+          {
+            "id": 137075,
+            "definitionId": 141839,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Bring Me Another",
+            "spellId": 1265129,
+            "icon": "inv12_apextalent_monk_bringmeanother",
+            "index": 200
+          },
+          {
+            "id": 137074,
+            "definitionId": 141838,
+            "maxRanks": 2,
+            "type": "tierrank",
+            "name": "Bring Me Another",
+            "spellId": 1265138,
+            "icon": "inv12_apextalent_monk_bringmeanother",
+            "index": 300
+          },
+          {
+            "id": 137073,
+            "definitionId": 141837,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Bring Me Another",
+            "spellId": 1265141,
+            "icon": "inv12_apextalent_monk_bringmeanother",
+            "index": 400
+          }
+        ]
       }
     ],
     "heroNodes": [
@@ -124294,7 +126480,8 @@
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 101247,
@@ -124707,7 +126894,8 @@
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 101222,
@@ -125386,6 +127574,7 @@
       104129,
       108540,
       108946,
+      109516,
       109694,
       109695,
       109696,
@@ -125415,7 +127604,9 @@
       110211,
       110218,
       110220,
-      110221
+      110221,
+      110435,
+      110436
     ]
   },
   {
@@ -126458,7 +128649,7 @@
         "type": "single",
         "posX": 2400,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           101169
@@ -126486,7 +128677,7 @@
         "type": "single",
         "posX": 3000,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           101169
@@ -126514,7 +128705,7 @@
         "type": "choice",
         "posX": 3600,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           101169,
@@ -126553,7 +128744,7 @@
         "type": "single",
         "posX": 4200,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           101175
@@ -126582,7 +128773,7 @@
         "type": "choice",
         "posX": 4800,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           101175,
@@ -126621,7 +128812,7 @@
         "type": "single",
         "posX": 5400,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -126646,7 +128837,7 @@
         "type": "single",
         "posX": 6000,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           101179
@@ -126674,7 +128865,7 @@
         "type": "single",
         "posX": 3000,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "next": [
           101168,
@@ -126704,7 +128895,7 @@
         "type": "single",
         "posX": 3600,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           101170,
@@ -126732,7 +128923,7 @@
         "type": "single",
         "posX": 4200,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           101176
@@ -126761,7 +128952,7 @@
         "type": "single",
         "posX": 4800,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           101176,
@@ -126789,7 +128980,7 @@
         "type": "single",
         "posX": 5400,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "next": [
           101178,
@@ -126818,7 +129009,7 @@
         "type": "single",
         "posX": 2400,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -126843,7 +129034,7 @@
         "type": "single",
         "posX": 3600,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -126869,7 +129060,7 @@
         "type": "choice",
         "posX": 4200,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -126906,7 +129097,7 @@
         "type": "single",
         "posX": 4800,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -126932,7 +129123,7 @@
         "type": "single",
         "posX": 6000,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -128277,6 +130468,64 @@
             "index": 200
           }
         ]
+      },
+      {
+        "id": 110436,
+        "name": "Tigereye Brew / Tigereye Brew / Tigereye Brew",
+        "type": "tiered",
+        "posX": 12600,
+        "posY": 7650,
+        "reqPoints": 20,
+        "maxRanks": 4,
+        "rankLevels": [
+          {
+            "level": 81,
+            "maxRanks": 1
+          },
+          {
+            "level": 84,
+            "maxRanks": 3
+          },
+          {
+            "level": 90,
+            "maxRanks": 4
+          }
+        ],
+        "entryNode": true,
+        "next": [],
+        "prev": [],
+        "entries": [
+          {
+            "id": 137076,
+            "definitionId": 141840,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Tigereye Brew",
+            "spellId": 1261703,
+            "icon": "inv12_apextalent_monk_tigereyebrew",
+            "index": 200
+          },
+          {
+            "id": 137077,
+            "definitionId": 141841,
+            "maxRanks": 2,
+            "type": "tierrank",
+            "name": "Tigereye Brew",
+            "spellId": 1261844,
+            "icon": "inv12_apextalent_monk_tigereyebrew",
+            "index": 300
+          },
+          {
+            "id": 137078,
+            "definitionId": 141842,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Tigereye Brew",
+            "spellId": 1261849,
+            "icon": "inv12_apextalent_monk_tigereyebrew",
+            "index": 400
+          }
+        ]
       }
     ],
     "heroNodes": [
@@ -128308,7 +130557,8 @@
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 101243,
@@ -128338,7 +130588,8 @@
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 101247,
@@ -128470,7 +130721,6 @@
           101237
         ],
         "prev": [
-          110067,
           101243
         ],
         "entries": [
@@ -128508,7 +130758,6 @@
           110211
         ],
         "prev": [
-          110067,
           101243
         ],
         "entries": [
@@ -128573,7 +130822,6 @@
           110218
         ],
         "prev": [
-          110067,
           101243
         ],
         "entries": [
@@ -128753,7 +131001,6 @@
         "maxRanks": 1,
         "subTreeId": 64,
         "next": [
-          101240,
           110220
         ],
         "prev": [
@@ -128784,7 +131031,6 @@
           101235
         ],
         "prev": [
-          101233,
           110221
         ],
         "entries": [
@@ -129094,7 +131340,6 @@
         "prev": [
           109700,
           101235,
-          101240,
           101238,
           110220
         ],
@@ -129398,6 +131643,7 @@
       104129,
       108540,
       108946,
+      109516,
       109694,
       109695,
       109696,
@@ -129427,7 +131673,9 @@
       110211,
       110218,
       110220,
-      110221
+      110221,
+      110435,
+      110436
     ]
   },
   {
@@ -130451,7 +132699,7 @@
         "type": "single",
         "posX": 2400,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           101169
@@ -130479,7 +132727,7 @@
         "type": "single",
         "posX": 3000,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           101169
@@ -130507,7 +132755,7 @@
         "type": "single",
         "posX": 3600,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           101169,
@@ -130536,7 +132784,7 @@
         "type": "choice",
         "posX": 4200,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           101175
@@ -130575,7 +132823,7 @@
         "type": "choice",
         "posX": 4800,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           101175,
@@ -130614,7 +132862,7 @@
         "type": "single",
         "posX": 5400,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -130639,7 +132887,7 @@
         "type": "single",
         "posX": 6000,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           101179
@@ -130667,7 +132915,7 @@
         "type": "single",
         "posX": 3000,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "next": [
           101168,
@@ -130697,7 +132945,7 @@
         "type": "single",
         "posX": 3600,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           101170,
@@ -130725,7 +132973,7 @@
         "type": "single",
         "posX": 4200,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           101176
@@ -130754,7 +133002,7 @@
         "type": "single",
         "posX": 4800,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           101176,
@@ -130782,7 +133030,7 @@
         "type": "single",
         "posX": 5400,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "next": [
           101178,
@@ -130811,7 +133059,7 @@
         "type": "single",
         "posX": 2400,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -130836,7 +133084,7 @@
         "type": "single",
         "posX": 3600,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -130862,7 +133110,7 @@
         "type": "choice",
         "posX": 4200,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -130899,7 +133147,7 @@
         "type": "single",
         "posX": 4800,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -130925,7 +133173,7 @@
         "type": "single",
         "posX": 6000,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -131644,8 +133892,8 @@
       },
       {
         "id": 101112,
-        "name": "Dancing Mists",
-        "type": "single",
+        "name": "Dancing Mists / Vital Expenditure",
+        "type": "choice",
         "posX": 13200,
         "posY": 5100,
         "reqPoints": 8,
@@ -131668,6 +133916,16 @@
             "spellId": 388701,
             "icon": "ability_monk_serenity",
             "index": 100
+          },
+          {
+            "id": 137474,
+            "definitionId": 142234,
+            "maxRanks": 1,
+            "type": "passive",
+            "name": "Vital Expenditure",
+            "spellId": 1299572,
+            "icon": "ability_monk_soothingmists",
+            "index": 200
           }
         ]
       },
@@ -132234,6 +134492,64 @@
             "index": 200
           }
         ]
+      },
+      {
+        "id": 109516,
+        "name": "Spiritfont / Spiritfont / Spiritfont",
+        "type": "tiered",
+        "posX": 12600,
+        "posY": 7650,
+        "reqPoints": 20,
+        "maxRanks": 4,
+        "rankLevels": [
+          {
+            "level": 81,
+            "maxRanks": 1
+          },
+          {
+            "level": 84,
+            "maxRanks": 3
+          },
+          {
+            "level": 90,
+            "maxRanks": 4
+          }
+        ],
+        "entryNode": true,
+        "next": [],
+        "prev": [],
+        "entries": [
+          {
+            "id": 135749,
+            "definitionId": 140504,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Spiritfont",
+            "spellId": 1260511,
+            "icon": "inv12_apextalent_monk_spiritfont",
+            "index": 200
+          },
+          {
+            "id": 137072,
+            "definitionId": 141836,
+            "maxRanks": 2,
+            "type": "tierrank",
+            "name": "Spiritfont",
+            "spellId": 1260677,
+            "icon": "inv12_apextalent_monk_spiritfont",
+            "index": 300
+          },
+          {
+            "id": 137071,
+            "definitionId": 141835,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Spiritfont",
+            "spellId": 1260680,
+            "icon": "inv12_apextalent_monk_spiritfont",
+            "index": 400
+          }
+        ]
       }
     ],
     "heroNodes": [
@@ -132265,7 +134581,8 @@
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 101236,
@@ -132279,8 +134596,7 @@
           101237
         ],
         "prev": [
-          110067,
-          101243
+          110067
         ],
         "entries": [
           {
@@ -132317,8 +134633,7 @@
           110211
         ],
         "prev": [
-          110067,
-          101243
+          110067
         ],
         "entries": [
           {
@@ -132382,8 +134697,7 @@
           110218
         ],
         "prev": [
-          110067,
-          101243
+          110067
         ],
         "entries": [
           {
@@ -132434,8 +134748,7 @@
         "maxRanks": 1,
         "subTreeId": 64,
         "next": [
-          101240,
-          110220
+          101240
         ],
         "prev": [
           101242
@@ -132465,8 +134778,7 @@
           101235
         ],
         "prev": [
-          101233,
-          110221
+          101233
         ],
         "entries": [
           {
@@ -132640,8 +134952,7 @@
           109700,
           101235,
           101240,
-          101238,
-          110220
+          101238
         ],
         "entries": [
           {
@@ -132685,7 +134996,8 @@
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 101222,
@@ -133367,6 +135679,7 @@
       104129,
       108540,
       108946,
+      109516,
       109694,
       109695,
       109696,
@@ -133396,7 +135709,9 @@
       110211,
       110218,
       110220,
-      110221
+      110221,
+      110435,
+      110436
     ]
   },
   {
@@ -133920,9 +136235,7 @@
         "posY": 3900,
         "reqPoints": 8,
         "maxRanks": 1,
-        "next": [
-          91004
-        ],
+        "next": [],
         "prev": [
           91006
         ],
@@ -134094,9 +136407,8 @@
           91000
         ],
         "prev": [
-          91005,
-          95150,
-          90933
+          90933,
+          95150
         ],
         "entries": [
           {
@@ -134219,8 +136531,8 @@
         ],
         "prev": [
           90936,
-          91004,
-          90939
+          90939,
+          91004
         ],
         "entries": [
           {
@@ -134248,9 +136560,9 @@
           95149
         ],
         "prev": [
-          91004,
           90947,
-          90927
+          90927,
+          91004
         ],
         "entries": [
           {
@@ -134271,7 +136583,7 @@
         "type": "single",
         "posX": 2700,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           90996
@@ -134298,7 +136610,7 @@
         "type": "single",
         "posX": 3300,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           110011,
@@ -134327,7 +136639,7 @@
         "type": "single",
         "posX": 4500,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           91002,
@@ -134356,7 +136668,7 @@
         "type": "single",
         "posX": 5100,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           90949
@@ -134383,7 +136695,7 @@
         "type": "single",
         "posX": 2700,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "next": [
           110010
@@ -134410,7 +136722,7 @@
         "type": "single",
         "posX": 3300,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -134435,7 +136747,7 @@
         "type": "single",
         "posX": 3900,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           91001
@@ -134463,7 +136775,7 @@
         "type": "single",
         "posX": 4500,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -134488,7 +136800,7 @@
         "type": "single",
         "posX": 5100,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "next": [
           90997
@@ -134515,7 +136827,7 @@
         "type": "single",
         "posX": 2700,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -134540,7 +136852,7 @@
         "type": "choice",
         "posX": 3900,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -134575,7 +136887,7 @@
         "type": "single",
         "posX": 5100,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -134693,7 +137005,7 @@
       },
       {
         "id": 93014,
-        "name": "Dash of Chaos",
+        "name": "Never Say Die",
         "type": "single",
         "posX": 10500,
         "posY": 2700,
@@ -134710,9 +137022,9 @@
             "definitionId": 120257,
             "maxRanks": 1,
             "type": "passive",
-            "name": "Dash of Chaos",
+            "name": "Never Say Die",
             "spellId": 427794,
-            "icon": "inv_boots_cloth_35v3",
+            "icon": "inv_misc_food_legion_goosaporange_drop",
             "index": 100
           }
         ]
@@ -135358,8 +137670,8 @@
       },
       {
         "id": 91035,
-        "name": "Chaos Theory",
-        "type": "single",
+        "name": "Chaos Theory / Inner Demon",
+        "type": "choice",
         "posX": 11400,
         "posY": 5700,
         "reqPoints": 20,
@@ -135382,13 +137694,23 @@
             "spellId": 389687,
             "icon": "inv_glaive_1h_artifactaldrochi_d_03dual",
             "index": 100
+          },
+          {
+            "id": 137827,
+            "definitionId": 142581,
+            "maxRanks": 1,
+            "type": "passive",
+            "name": "Inner Demon",
+            "spellId": 389693,
+            "icon": "ability_demonhunter_glide",
+            "index": 200
           }
         ]
       },
       {
         "id": 91024,
-        "name": "Inner Demon / Chaotic Transformation",
-        "type": "choice",
+        "name": "Chaotic Transformation",
+        "type": "single",
         "posX": 12300,
         "posY": 5700,
         "reqPoints": 20,
@@ -135407,20 +137729,10 @@
             "definitionId": 117952,
             "maxRanks": 1,
             "type": "passive",
-            "name": "Inner Demon",
-            "spellId": 389693,
-            "icon": "ability_demonhunter_glide",
-            "index": 100
-          },
-          {
-            "id": 117765,
-            "definitionId": 122777,
-            "maxRanks": 1,
-            "type": "passive",
             "name": "Chaotic Transformation",
             "spellId": 388112,
             "icon": "ability_demonhunter_glide",
-            "index": 200
+            "index": 100
           }
         ]
       },
@@ -135715,6 +138027,64 @@
             "index": 100
           }
         ]
+      },
+      {
+        "id": 110427,
+        "name": "Eternal Hunt / Eternal Hunt / Eternal Hunt",
+        "type": "tiered",
+        "posX": 12300,
+        "posY": 7650,
+        "reqPoints": 20,
+        "maxRanks": 4,
+        "rankLevels": [
+          {
+            "level": 81,
+            "maxRanks": 1
+          },
+          {
+            "level": 84,
+            "maxRanks": 3
+          },
+          {
+            "level": 90,
+            "maxRanks": 4
+          }
+        ],
+        "entryNode": true,
+        "next": [],
+        "prev": [],
+        "entries": [
+          {
+            "id": 137049,
+            "definitionId": 141812,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Eternal Hunt",
+            "spellId": 1270898,
+            "icon": "inv12_apextalent_demonhunter_eternalhunt",
+            "index": 100
+          },
+          {
+            "id": 137048,
+            "definitionId": 141811,
+            "maxRanks": 2,
+            "type": "tierrank",
+            "name": "Eternal Hunt",
+            "spellId": 1270900,
+            "icon": "inv12_apextalent_demonhunter_eternalhunt",
+            "index": 200
+          },
+          {
+            "id": 137047,
+            "definitionId": 141810,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Eternal Hunt",
+            "spellId": 1270901,
+            "icon": "inv12_apextalent_demonhunter_eternalhunt",
+            "index": 300
+          }
+        ]
       }
     ],
     "heroNodes": [
@@ -135746,7 +138116,8 @@
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 94898,
@@ -136141,10 +138512,10 @@
         "entryNode": true,
         "subTreeId": 34,
         "next": [
-          109773,
           94913,
           94918,
-          94899
+          94899,
+          109773
         ],
         "prev": [],
         "entries": [
@@ -136159,41 +138530,15 @@
             "index": 100
           }
         ],
-        "freeNode": true
-      },
-      {
-        "id": 109773,
-        "name": "Blind Focus",
-        "type": "single",
-        "posX": 9000,
-        "posY": 4800,
-        "maxRanks": 1,
-        "subTreeId": 34,
-        "next": [
-          109774
-        ],
-        "prev": [
-          94917
-        ],
-        "entries": [
-          {
-            "id": 136031,
-            "definitionId": 140786,
-            "maxRanks": 1,
-            "type": "passive",
-            "name": "Blind Focus",
-            "spellId": 1272364,
-            "icon": "inv_belt_leather_raiddemonhunter_r_01",
-            "index": 100
-          }
-        ]
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 94913,
         "name": "Wave of Debilitation / Pursuit of Angriness",
         "type": "choice",
-        "posX": 7250,
-        "posY": 4850,
+        "posX": 7200,
+        "posY": 4800,
         "maxRanks": 1,
         "subTreeId": 34,
         "next": [
@@ -136229,8 +138574,8 @@
         "id": 94918,
         "name": "Focused Hatred",
         "type": "single",
-        "posX": 7850,
-        "posY": 4850,
+        "posX": 7800,
+        "posY": 4800,
         "maxRanks": 1,
         "subTreeId": 34,
         "next": [
@@ -136256,8 +138601,8 @@
         "id": 94899,
         "name": "Set Fire to the Pain / Improved Soul Rending",
         "type": "choice",
-        "posX": 8450,
-        "posY": 4850,
+        "posX": 8400,
+        "posY": 4800,
         "maxRanks": 1,
         "subTreeId": 34,
         "next": [
@@ -136290,6 +138635,114 @@
         ]
       },
       {
+        "id": 109773,
+        "name": "Blind Focus",
+        "type": "single",
+        "posX": 9000,
+        "posY": 4800,
+        "maxRanks": 1,
+        "subTreeId": 34,
+        "next": [
+          109774
+        ],
+        "prev": [
+          94917
+        ],
+        "entries": [
+          {
+            "id": 136031,
+            "definitionId": 140786,
+            "maxRanks": 1,
+            "type": "passive",
+            "name": "Blind Focus",
+            "spellId": 1272364,
+            "icon": "inv_belt_leather_raiddemonhunter_r_01",
+            "index": 100
+          }
+        ]
+      },
+      {
+        "id": 94905,
+        "name": "Burning Blades",
+        "type": "single",
+        "posX": 7200,
+        "posY": 5400,
+        "maxRanks": 1,
+        "subTreeId": 34,
+        "next": [
+          94904
+        ],
+        "prev": [
+          94913
+        ],
+        "entries": [
+          {
+            "id": 117502,
+            "definitionId": 122514,
+            "maxRanks": 1,
+            "type": "passive",
+            "name": "Burning Blades",
+            "spellId": 452408,
+            "icon": "inv_glaive_1h_artifactazgalor_d_02dual",
+            "index": 100
+          }
+        ]
+      },
+      {
+        "id": 94912,
+        "name": "Violent Transformation",
+        "type": "single",
+        "posX": 7800,
+        "posY": 5400,
+        "maxRanks": 1,
+        "subTreeId": 34,
+        "next": [
+          94902
+        ],
+        "prev": [
+          94918
+        ],
+        "entries": [
+          {
+            "id": 117509,
+            "definitionId": 122521,
+            "maxRanks": 1,
+            "type": "passive",
+            "name": "Violent Transformation",
+            "spellId": 452409,
+            "icon": "spell_shadow_demoniccirclesummon",
+            "index": 100
+          }
+        ]
+      },
+      {
+        "id": 94916,
+        "name": "Enduring Torment",
+        "type": "single",
+        "posX": 8400,
+        "posY": 5400,
+        "maxRanks": 1,
+        "subTreeId": 34,
+        "next": [
+          94909
+        ],
+        "prev": [
+          94899
+        ],
+        "entries": [
+          {
+            "id": 117513,
+            "definitionId": 122525,
+            "maxRanks": 1,
+            "type": "passive",
+            "name": "Enduring Torment",
+            "spellId": 452410,
+            "icon": "spell_fire_felimmolation",
+            "index": 100
+          }
+        ]
+      },
+      {
         "id": 109774,
         "name": "Undying Embers",
         "type": "single",
@@ -136317,119 +138770,11 @@
         ]
       },
       {
-        "id": 94905,
-        "name": "Burning Blades",
-        "type": "single",
-        "posX": 7250,
-        "posY": 5450,
-        "maxRanks": 1,
-        "subTreeId": 34,
-        "next": [
-          94904
-        ],
-        "prev": [
-          94913
-        ],
-        "entries": [
-          {
-            "id": 117502,
-            "definitionId": 122514,
-            "maxRanks": 1,
-            "type": "passive",
-            "name": "Burning Blades",
-            "spellId": 452408,
-            "icon": "inv_glaive_1h_artifactazgalor_d_02dual",
-            "index": 100
-          }
-        ]
-      },
-      {
-        "id": 94912,
-        "name": "Violent Transformation",
-        "type": "single",
-        "posX": 7850,
-        "posY": 5450,
-        "maxRanks": 1,
-        "subTreeId": 34,
-        "next": [
-          94902
-        ],
-        "prev": [
-          94918
-        ],
-        "entries": [
-          {
-            "id": 117509,
-            "definitionId": 122521,
-            "maxRanks": 1,
-            "type": "passive",
-            "name": "Violent Transformation",
-            "spellId": 452409,
-            "icon": "spell_shadow_demoniccirclesummon",
-            "index": 100
-          }
-        ]
-      },
-      {
-        "id": 94916,
-        "name": "Enduring Torment",
-        "type": "single",
-        "posX": 8450,
-        "posY": 5450,
-        "maxRanks": 1,
-        "subTreeId": 34,
-        "next": [
-          94909
-        ],
-        "prev": [
-          94899
-        ],
-        "entries": [
-          {
-            "id": 117513,
-            "definitionId": 122525,
-            "maxRanks": 1,
-            "type": "passive",
-            "name": "Enduring Torment",
-            "spellId": 452410,
-            "icon": "spell_fire_felimmolation",
-            "index": 100
-          }
-        ]
-      },
-      {
-        "id": 109772,
-        "name": "Volatile Instinct",
-        "type": "single",
-        "posX": 9000,
-        "posY": 6000,
-        "maxRanks": 1,
-        "subTreeId": 34,
-        "next": [
-          94901
-        ],
-        "prev": [
-          109774
-        ],
-        "entries": [
-          {
-            "id": 136030,
-            "definitionId": 140785,
-            "maxRanks": 1,
-            "type": "passive",
-            "name": "Volatile Instinct",
-            "spellId": 1272453,
-            "icon": "inv_nature_nova",
-            "index": 100
-          }
-        ]
-      },
-      {
         "id": 94904,
         "name": "Untethered Fury",
         "type": "single",
-        "posX": 7250,
-        "posY": 6050,
+        "posX": 7200,
+        "posY": 6000,
         "maxRanks": 1,
         "subTreeId": 34,
         "next": [
@@ -136455,8 +138800,8 @@
         "id": 94902,
         "name": "Student of Suffering / Flamebound",
         "type": "choice",
-        "posX": 7850,
-        "posY": 6050,
+        "posX": 7800,
+        "posY": 6000,
         "maxRanks": 1,
         "subTreeId": 34,
         "next": [
@@ -136492,8 +138837,8 @@
         "id": 94909,
         "name": "Monster Rising",
         "type": "single",
-        "posX": 8450,
-        "posY": 6050,
+        "posX": 8400,
+        "posY": 6000,
         "maxRanks": 1,
         "subTreeId": 34,
         "next": [
@@ -136511,6 +138856,33 @@
             "name": "Monster Rising",
             "spellId": 452414,
             "icon": "ability_warlock_demonicpower",
+            "index": 100
+          }
+        ]
+      },
+      {
+        "id": 109772,
+        "name": "Volatile Instinct",
+        "type": "single",
+        "posX": 9000,
+        "posY": 6000,
+        "maxRanks": 1,
+        "subTreeId": 34,
+        "next": [
+          94901
+        ],
+        "prev": [
+          109774
+        ],
+        "entries": [
+          {
+            "id": 136030,
+            "definitionId": 140785,
+            "maxRanks": 1,
+            "type": "passive",
+            "name": "Volatile Instinct",
+            "spellId": 1272453,
+            "icon": "inv_nature_nova",
             "index": 100
           }
         ]
@@ -136588,18 +138960,18 @@
             "atlasMemberName": "talents-heroclass-demonhunter-felscarred",
             "nodes": [
               94917,
-              109773,
               94913,
               94918,
               94899,
-              109774,
+              109773,
               94905,
               94912,
               94916,
-              109772,
+              109774,
               94904,
               94902,
               94909,
+              109772,
               94901
             ]
           }
@@ -136830,7 +139202,10 @@
       110171,
       110172,
       110173,
-      110174
+      110174,
+      110416,
+      110425,
+      110427
     ]
   },
   {
@@ -137352,9 +139727,7 @@
         "posY": 3900,
         "reqPoints": 8,
         "maxRanks": 1,
-        "next": [
-          91004
-        ],
+        "next": [],
         "prev": [
           91006
         ],
@@ -137526,9 +139899,8 @@
           91000
         ],
         "prev": [
-          91005,
-          95150,
-          90933
+          90933,
+          95150
         ],
         "entries": [
           {
@@ -137651,8 +140023,8 @@
         ],
         "prev": [
           90936,
-          91004,
-          90939
+          90939,
+          91004
         ],
         "entries": [
           {
@@ -137680,9 +140052,9 @@
           95149
         ],
         "prev": [
-          91004,
           90947,
-          90927
+          90927,
+          91004
         ],
         "entries": [
           {
@@ -137703,7 +140075,7 @@
         "type": "single",
         "posX": 2700,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           90996
@@ -137730,7 +140102,7 @@
         "type": "single",
         "posX": 3300,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           110011,
@@ -137759,7 +140131,7 @@
         "type": "single",
         "posX": 4500,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           91002,
@@ -137788,7 +140160,7 @@
         "type": "single",
         "posX": 5100,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           90949
@@ -137815,7 +140187,7 @@
         "type": "single",
         "posX": 2700,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "next": [
           110010
@@ -137842,7 +140214,7 @@
         "type": "single",
         "posX": 3300,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -137867,7 +140239,7 @@
         "type": "single",
         "posX": 3900,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           91001
@@ -137895,7 +140267,7 @@
         "type": "single",
         "posX": 4500,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -137920,7 +140292,7 @@
         "type": "single",
         "posX": 5100,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "next": [
           90997
@@ -137947,7 +140319,7 @@
         "type": "single",
         "posX": 2700,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -137972,7 +140344,7 @@
         "type": "choice",
         "posX": 3900,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -138007,7 +140379,7 @@
         "type": "single",
         "posX": 5100,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -138257,8 +140629,8 @@
       },
       {
         "id": 90988,
-        "name": "Roaring Fire / Sigil of Silence",
-        "type": "choice",
+        "name": "Feed the Demon",
+        "type": "single",
         "posX": 12300,
         "posY": 3300,
         "maxRanks": 1,
@@ -138276,20 +140648,10 @@
             "definitionId": 117910,
             "maxRanks": 1,
             "type": "passive",
-            "name": "Roaring Fire",
-            "spellId": 391178,
-            "icon": "spell_fire_felflamering",
+            "name": "Feed the Demon",
+            "spellId": 218612,
+            "icon": "spell_warlock_demonicempowerment",
             "index": 100
-          },
-          {
-            "id": 112904,
-            "definitionId": 117909,
-            "maxRanks": 1,
-            "type": "active",
-            "name": "Sigil of Silence",
-            "spellId": 202137,
-            "icon": "ability_demonhunter_sigilofsilence",
-            "index": 200
           }
         ]
       },
@@ -138406,7 +140768,7 @@
       },
       {
         "id": 90966,
-        "name": "Feed the Demon",
+        "name": "Sigil of Silence",
         "type": "single",
         "posX": 12300,
         "posY": 3900,
@@ -138425,10 +140787,10 @@
             "id": 112881,
             "definitionId": 117886,
             "maxRanks": 1,
-            "type": "passive",
-            "name": "Feed the Demon",
-            "spellId": 218612,
-            "icon": "spell_warlock_demonicempowerment",
+            "type": "active",
+            "name": "Sigil of Silence",
+            "spellId": 202137,
+            "icon": "ability_demonhunter_sigilofsilence",
             "index": 100
           }
         ]
@@ -138758,7 +141120,7 @@
       },
       {
         "id": 90954,
-        "name": "Sigil of Chains",
+        "name": "Roaring Fire",
         "type": "single",
         "posX": 12300,
         "posY": 5100,
@@ -138777,10 +141139,10 @@
             "id": 112867,
             "definitionId": 117872,
             "maxRanks": 1,
-            "type": "active",
-            "name": "Sigil of Chains",
-            "spellId": 202138,
-            "icon": "ability_demonhunter_sigilofchains",
+            "type": "passive",
+            "name": "Roaring Fire",
+            "spellId": 391178,
+            "icon": "spell_fire_felflamering",
             "index": 100
           }
         ]
@@ -139199,6 +141561,64 @@
             "index": 200
           }
         ]
+      },
+      {
+        "id": 110425,
+        "name": "Untethered Rage / Untethered Rage / Untethered Rage",
+        "type": "tiered",
+        "posX": 12300,
+        "posY": 7650,
+        "reqPoints": 20,
+        "maxRanks": 4,
+        "rankLevels": [
+          {
+            "level": 81,
+            "maxRanks": 1
+          },
+          {
+            "level": 84,
+            "maxRanks": 3
+          },
+          {
+            "level": 90,
+            "maxRanks": 4
+          }
+        ],
+        "entryNode": true,
+        "next": [],
+        "prev": [],
+        "entries": [
+          {
+            "id": 137043,
+            "definitionId": 141806,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Untethered Rage",
+            "spellId": 1270444,
+            "icon": "inv12_apextalent_demonhunter__untetheredrage",
+            "index": 100
+          },
+          {
+            "id": 137042,
+            "definitionId": 141805,
+            "maxRanks": 2,
+            "type": "tierrank",
+            "name": "Untethered Rage",
+            "spellId": 1270448,
+            "icon": "inv12_apextalent_demonhunter__untetheredrage",
+            "index": 200
+          },
+          {
+            "id": 137041,
+            "definitionId": 141804,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Untethered Rage",
+            "spellId": 1270449,
+            "icon": "inv12_apextalent_demonhunter__untetheredrage",
+            "index": 300
+          }
+        ]
       }
     ],
     "heroNodes": [
@@ -139230,7 +141650,8 @@
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 94898,
@@ -139642,7 +142063,8 @@
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 109454,
@@ -140303,7 +142725,10 @@
       110171,
       110172,
       110173,
-      110174
+      110174,
+      110416,
+      110425,
+      110427
     ]
   },
   {
@@ -140827,9 +143252,7 @@
         "posY": 3900,
         "reqPoints": 8,
         "maxRanks": 1,
-        "next": [
-          91004
-        ],
+        "next": [],
         "prev": [
           91006
         ],
@@ -140997,13 +143420,12 @@
         "reqPoints": 8,
         "maxRanks": 2,
         "next": [
+          107346,
           91000
         ],
         "prev": [
-          91005,
-          95150,
           90933,
-          107346
+          95150
         ],
         "entries": [
           {
@@ -141121,13 +143543,13 @@
         "reqPoints": 8,
         "maxRanks": 1,
         "next": [
-          91004,
           95152,
           90929
         ],
         "prev": [
           90936,
-          90939
+          90939,
+          91004
         ],
         "entries": [
           {
@@ -141155,9 +143577,9 @@
           95149
         ],
         "prev": [
-          91004,
           90947,
-          90927
+          90927,
+          91004
         ],
         "entries": [
           {
@@ -141178,7 +143600,7 @@
         "type": "single",
         "posX": 2700,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           90996
@@ -141205,7 +143627,7 @@
         "type": "single",
         "posX": 3300,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           110011,
@@ -141234,7 +143656,7 @@
         "type": "single",
         "posX": 4500,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           91002,
@@ -141263,7 +143685,7 @@
         "type": "single",
         "posX": 5100,
         "posY": 5700,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           90949
@@ -141290,7 +143712,7 @@
         "type": "single",
         "posX": 2700,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "next": [
           110010
@@ -141317,7 +143739,7 @@
         "type": "single",
         "posX": 3300,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -141342,7 +143764,7 @@
         "type": "single",
         "posX": 3900,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [
           91001
@@ -141370,7 +143792,7 @@
         "type": "single",
         "posX": 4500,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -141395,7 +143817,7 @@
         "type": "single",
         "posX": 5100,
         "posY": 6300,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 2,
         "next": [
           90997
@@ -141422,7 +143844,7 @@
         "type": "single",
         "posX": 2700,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -141447,7 +143869,7 @@
         "type": "choice",
         "posX": 3900,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -141482,7 +143904,7 @@
         "type": "single",
         "posX": 5100,
         "posY": 6900,
-        "reqPoints": 20,
+        "reqPoints": 23,
         "maxRanks": 1,
         "next": [],
         "prev": [
@@ -142562,6 +144984,64 @@
             "index": 100
           }
         ]
+      },
+      {
+        "id": 110416,
+        "name": "Midnight / Midnight / Midnight",
+        "type": "tiered",
+        "posX": 12300,
+        "posY": 7650,
+        "reqPoints": 20,
+        "maxRanks": 4,
+        "rankLevels": [
+          {
+            "level": 81,
+            "maxRanks": 1
+          },
+          {
+            "level": 84,
+            "maxRanks": 3
+          },
+          {
+            "level": 90,
+            "maxRanks": 4
+          }
+        ],
+        "entryNode": true,
+        "next": [],
+        "prev": [],
+        "entries": [
+          {
+            "id": 137016,
+            "definitionId": 141779,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Midnight",
+            "spellId": 1242486,
+            "icon": "inv12_apextalent_demonhunter_midnight",
+            "index": 100
+          },
+          {
+            "id": 137015,
+            "definitionId": 141778,
+            "maxRanks": 2,
+            "type": "tierrank",
+            "name": "Midnight",
+            "spellId": 1250088,
+            "icon": "inv_ability_voidweaverpriest_entropicrift",
+            "index": 200
+          },
+          {
+            "id": 137014,
+            "definitionId": 141777,
+            "maxRanks": 1,
+            "type": "tierrank",
+            "name": "Midnight",
+            "spellId": 1250094,
+            "icon": "ability_argus_edgeofobliteration",
+            "index": 300
+          }
+        ]
       }
     ],
     "heroNodes": [
@@ -142593,7 +145073,8 @@
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 110114,
@@ -143005,7 +145486,8 @@
             "index": 100
           }
         ],
-        "freeNode": true
+        "freeNode": true,
+        "freeLevel": 71
       },
       {
         "id": 109454,
@@ -143666,7 +146148,10 @@
       110171,
       110172,
       110173,
-      110174
+      110174,
+      110416,
+      110425,
+      110427
     ]
   }
 ]

--- a/packages/web/components/Settings/RecordingSettings.tsx
+++ b/packages/web/components/Settings/RecordingSettings.tsx
@@ -152,6 +152,7 @@ const RecordingSettings = () => {
   const [pendingBitrate, setPendingBitrate] = useState<number | null>(null);
   const [pendingCqp, setPendingCqp] = useState<number | null>(null);
   const [pendingCrf, setPendingCrf] = useState<number | null>(null);
+  const [pendingMaxStorage, setPendingMaxStorage] = useState<number | null>(null);
   const audioLevels = useAudioLevels();
 
   async function checkAudioDevices() {
@@ -171,6 +172,7 @@ const RecordingSettings = () => {
     setPendingBitrate(recordingConfig.obsKBitRate ?? null);
     setPendingCqp(recordingConfig.obsCQP ?? null);
     setPendingCrf(recordingConfig.obsCRF ?? null);
+    setPendingMaxStorage(recordingConfig.maxStorage ?? null);
   }, [recordingConfig]);
 
   useEffect(() => {
@@ -212,6 +214,16 @@ const RecordingSettings = () => {
     }, 300);
     return () => clearTimeout(handle);
   }, [pendingCrf, recordingConfig?.obsCRF]);
+
+  useEffect(() => {
+    if (pendingMaxStorage === null) return;
+    const handle = setTimeout(() => {
+      if (pendingMaxStorage !== recordingConfig?.maxStorage) {
+        window.wowarenalogs.obs?.setConfig?.('maxStorage', pendingMaxStorage);
+      }
+    }, 300);
+    return () => clearTimeout(handle);
+  }, [pendingMaxStorage, recordingConfig?.maxStorage]);
 
   const engineStarted = !!appConfig.enableVideoRecording;
 
@@ -388,6 +400,33 @@ const RecordingSettings = () => {
                 >
                   Set VOD Directory
                 </button>
+              </div>
+              <div className="flex flex-row gap-2 items-center">
+                <label className="form-control">
+                  <div className="label">
+                    <span className="label-text">Max video storage (GB, 0 = unlimited)</span>
+                  </div>
+                  <input
+                    type="number"
+                    min={0}
+                    step={1}
+                    className="input input-sm input-bordered w-40"
+                    value={pendingMaxStorage ?? ''}
+                    onChange={(e) => {
+                      const raw = e.target.value;
+                      if (raw === '') {
+                        setPendingMaxStorage(null);
+                        return;
+                      }
+                      const next = Math.max(0, Math.round(Number(raw)));
+                      if (!Number.isFinite(next)) return;
+                      setPendingMaxStorage(next);
+                    }}
+                  />
+                </label>
+                <span className="text-sm opacity-70 mt-6">
+                  Oldest videos are deleted automatically to stay under this limit. Recording never stops.
+                </span>
               </div>
               <div>
                 <div className="flex flex-row gap-4">


### PR DESCRIPTION
## Summary
- `writeLoadoutContent` only wrote the entry-index bit for `type === "choice" | "subtree"`, but tiered nodes (e.g. Stormstream Totem) with multiple rank entries need one too - Blizzard's encoding keys this on `entries.length > 1`, not on node type. Skipping it desynced the bitstream for every node after it, which is why unrelated talents also appeared missing.
- `isChoiceNode` now triggers on `entries.length > 1` instead of type.
- `ranksPurchased` sums `talentsPicked` entries per node id for tiered nodes, since each rank purchase comes through as a separate entry.
- Invalid entry index now throws instead of silently writing a bad value.
- Refreshed `talentIdMap.json` - the old data predated tiered nodes like Stormstream Totem entirely, so this bug was unreachable until the data caught up.
