### PR TITLE
Disable match search API and strip match ids from partner webhooks

### DIFF
--- a/packages/cloud/WEBHOOKS.md
+++ b/packages/cloud/WEBHOOKS.md
@@ -23,7 +23,7 @@ One webhook per match, **after** the match stub is written to Firestore, for:
     elapses, then dropped.
 - **Duplicates are expected** — retries (and at-least-once delivery) mean the same
   match may arrive more than once. **Deduplicate on `x-idempotency-key`** (equals
-  the payload `id`); it is stable across attempts.
+  the payload `idempotencyKey`); it is stable across attempts.
 - **Timeout** — each POST is aborted after ~10s (`ENV_WEBHOOK_TIMEOUT_MS`,
   default `10000`).
 
@@ -34,7 +34,7 @@ One webhook per match, **after** the match stub is written to Firestore, for:
 | Header              | Value                                                      |
 | ------------------- | ---------------------------------------------------------- |
 | `content-type`      | `application/json`                                         |
-| `x-idempotency-key` | The match `id` — use this to dedupe re-deliveries.         |
+| `x-idempotency-key` | The payload `idempotencyKey` — use this to dedupe re-deliveries. |
 | `x-signature`       | `sha256=<hex>` HMAC-SHA256 of the raw body (see below).    |
 
 `x-signature` is present only when `ENV_WEBHOOK_SECRET` is configured; an unsigned
@@ -42,13 +42,17 @@ delivery is logged as a warning on our side.
 
 ## Payload
 
+The payload deliberately carries **no match id and no match URL**. The match id is
+also the storage object name of the raw combat log, so either field would let a
+receiver fetch the log itself. `idempotencyKey` is an opaque one-way digest of the
+match id: stable across retries, unique per match, and not reversible.
+
 ```jsonc
 {
-  "version": 1,                       // payload schema version; branch on this
+  "version": 2,                       // payload schema version; branch on this
   "dataType": "ArenaMatch",           // "ArenaMatch" | "ShuffleMatch"
-  "id": "string",                     // match id (also the idempotency key)
+  "idempotencyKey": "string",         // opaque per-match key (also sent as x-idempotency-key)
   "wowVersion": "retail",             // "retail" | "classic"
-  "link": "https://wowarenalogs.com/match?id=...",  // string; string[] for shuffle (one per round)
   "startInfo": {
     "timestamp": 0,                   // epoch ms
     "zoneId": "string",
@@ -108,8 +112,14 @@ delivery is logged as a warning on our side.
 
 Note: for **shuffle**, `combatants` (and each `combatants[].teamId`, `dps`, `hps`,
 `deaths`, `hasAdvancedLogging`, `playerTeamRating`) is taken from **round 1** only —
-teams are re-drawn each round, so `teamId` is not stable across the match. For
-per-round detail across the whole shuffle, query the GraphQL API by match `id`.
+teams are re-drawn each round, so `teamId` is not stable across the match.
+`roundResults` gives the per-round outcome for the whole shuffle.
+
+### Version history
+
+- **2** — removed `id` and `link`; added `idempotencyKey`. `x-idempotency-key` now
+  carries `idempotencyKey` instead of the match id.
+- **1** — initial payload.
 
 ## Verifying the signature
 
@@ -134,8 +144,8 @@ function verify(rawBody, headers, secret) {
 
 The signature covers the body alone, so it is stable across retries of the same
 match. There is no timestamp binding, so the signature on its own does not protect
-against replay — rely on `x-idempotency-key` (the match `id`) to collapse duplicate
-and replayed deliveries.
+against replay — rely on `x-idempotency-key` (the payload `idempotencyKey`) to
+collapse duplicate and replayed deliveries.
 
 ## Configuration (deployer)
 

--- a/packages/cloud/WEBHOOKS.md
+++ b/packages/cloud/WEBHOOKS.md
@@ -23,7 +23,7 @@ One webhook per match, **after** the match stub is written to Firestore, for:
     elapses, then dropped.
 - **Duplicates are expected** — retries (and at-least-once delivery) mean the same
   match may arrive more than once. **Deduplicate on `x-idempotency-key`** (equals
-  the payload `idempotencyKey`); it is stable across attempts.
+  the payload `id`); it is stable across attempts.
 - **Timeout** — each POST is aborted after ~10s (`ENV_WEBHOOK_TIMEOUT_MS`,
   default `10000`).
 
@@ -34,7 +34,7 @@ One webhook per match, **after** the match stub is written to Firestore, for:
 | Header              | Value                                                      |
 | ------------------- | ---------------------------------------------------------- |
 | `content-type`      | `application/json`                                         |
-| `x-idempotency-key` | The payload `idempotencyKey` — use this to dedupe re-deliveries. |
+| `x-idempotency-key` | The match `id` — use this to dedupe re-deliveries.         |
 | `x-signature`       | `sha256=<hex>` HMAC-SHA256 of the raw body (see below).    |
 
 `x-signature` is present only when `ENV_WEBHOOK_SECRET` is configured; an unsigned
@@ -42,17 +42,13 @@ delivery is logged as a warning on our side.
 
 ## Payload
 
-The payload deliberately carries **no match id and no match URL**. The match id is
-also the storage object name of the raw combat log, so either field would let a
-receiver fetch the log itself. `idempotencyKey` is an opaque one-way digest of the
-match id: stable across retries, unique per match, and not reversible.
-
 ```jsonc
 {
-  "version": 2,                       // payload schema version; branch on this
+  "version": 1,                       // payload schema version; branch on this
   "dataType": "ArenaMatch",           // "ArenaMatch" | "ShuffleMatch"
-  "idempotencyKey": "string",         // opaque per-match key (also sent as x-idempotency-key)
+  "id": "string",                     // opaque per-match key (also the idempotency key); see note below
   "wowVersion": "retail",             // "retail" | "classic"
+  "link": "https://wowarenalogs.com/match?id=<id>",  // string; string[] for shuffle (one per round)
   "startInfo": {
     "timestamp": 0,                   // epoch ms
     "zoneId": "string",
@@ -110,16 +106,15 @@ match id: stable across retries, unique per match, and not reversible.
 }
 ```
 
+Note: `id` is an opaque, one-way key derived from the match — stable across
+retries and unique per match, which is all deduplication needs — and is **not**
+the internal match id. The internal id doubles as the raw log's storage object
+name and is never included. `link` is built from the same key.
+
 Note: for **shuffle**, `combatants` (and each `combatants[].teamId`, `dps`, `hps`,
 `deaths`, `hasAdvancedLogging`, `playerTeamRating`) is taken from **round 1** only —
 teams are re-drawn each round, so `teamId` is not stable across the match.
 `roundResults` gives the per-round outcome for the whole shuffle.
-
-### Version history
-
-- **2** — removed `id` and `link`; added `idempotencyKey`. `x-idempotency-key` now
-  carries `idempotencyKey` instead of the match id.
-- **1** — initial payload.
 
 ## Verifying the signature
 
@@ -144,8 +139,8 @@ function verify(rawBody, headers, secret) {
 
 The signature covers the body alone, so it is stable across retries of the same
 match. There is no timestamp binding, so the signature on its own does not protect
-against replay — rely on `x-idempotency-key` (the payload `idempotencyKey`) to
-collapse duplicate and replayed deliveries.
+against replay — rely on `x-idempotency-key` (the match `id`) to collapse duplicate
+and replayed deliveries.
 
 ## Configuration (deployer)
 

--- a/packages/cloud/src/deliverWebhookHandler.ts
+++ b/packages/cloud/src/deliverWebhookHandler.ts
@@ -9,7 +9,7 @@ export async function handler(
 ) {
   try {
     const stub = JSON.parse(Buffer.from(message.data ?? '', 'base64').toString('utf8')) as WebhookStub;
-    if (!stub || !stub.id || !stub.dataType) {
+    if (!stub || !stub.idempotencyKey || !stub.dataType) {
       // Drop malformed payloads — they will never become valid on retry.
       console.error('deliverWebhook: dropping invalid stub', stub);
       callback();
@@ -22,7 +22,7 @@ export async function handler(
     logWebhookEvent({
       event: 'webhook_attempt',
       dataType: stub.dataType,
-      matchId: stub.id,
+      idempotencyKey: stub.idempotencyKey,
       messageId: message.messageId,
       deliveryAttempt: message.deliveryAttempt,
     });
@@ -35,7 +35,7 @@ export async function handler(
       event: 'webhook_outcome',
       level: outcome === 'failed_transient' || outcome === 'failed_permanent' ? 'error' : 'info',
       dataType: stub.dataType,
-      matchId: stub.id,
+      idempotencyKey: stub.idempotencyKey,
       messageId: message.messageId,
       deliveryAttempt: message.deliveryAttempt,
       outcome,
@@ -43,7 +43,7 @@ export async function handler(
     });
 
     if (outcome === 'failed_transient') {
-      callback(new Error(`webhook delivery failed for match ${stub.id}`));
+      callback(new Error(`webhook delivery failed for idempotencyKey ${stub.idempotencyKey}`));
       return;
     }
     callback();

--- a/packages/cloud/src/deliverWebhookHandler.ts
+++ b/packages/cloud/src/deliverWebhookHandler.ts
@@ -9,7 +9,7 @@ export async function handler(
 ) {
   try {
     const stub = JSON.parse(Buffer.from(message.data ?? '', 'base64').toString('utf8')) as WebhookStub;
-    if (!stub || !stub.idempotencyKey || !stub.dataType) {
+    if (!stub || !stub.id || !stub.dataType) {
       // Drop malformed payloads — they will never become valid on retry.
       console.error('deliverWebhook: dropping invalid stub', stub);
       callback();
@@ -22,7 +22,7 @@ export async function handler(
     logWebhookEvent({
       event: 'webhook_attempt',
       dataType: stub.dataType,
-      idempotencyKey: stub.idempotencyKey,
+      matchId: stub.id,
       messageId: message.messageId,
       deliveryAttempt: message.deliveryAttempt,
     });
@@ -35,7 +35,7 @@ export async function handler(
       event: 'webhook_outcome',
       level: outcome === 'failed_transient' || outcome === 'failed_permanent' ? 'error' : 'info',
       dataType: stub.dataType,
-      idempotencyKey: stub.idempotencyKey,
+      matchId: stub.id,
       messageId: message.messageId,
       deliveryAttempt: message.deliveryAttempt,
       outcome,
@@ -43,7 +43,7 @@ export async function handler(
     });
 
     if (outcome === 'failed_transient') {
-      callback(new Error(`webhook delivery failed for idempotencyKey ${stub.idempotencyKey}`));
+      callback(new Error(`webhook delivery failed for match ${stub.id}`));
       return;
     }
     callback();

--- a/packages/cloud/src/webhookPublisher.ts
+++ b/packages/cloud/src/webhookPublisher.ts
@@ -13,19 +13,29 @@ const pubsub = new PubSub({ credentials: gcpCredentials });
 
 // Never throws — a publish failure is logged and swallowed so match processing
 // is unaffected.
-export const publishWebhookStubAsync = async (stub: WebhookStub): Promise<void> => {
+//
+// `matchId` is only logged here, never published: this is the one place that
+// ties a partner-visible idempotencyKey back to a match id for debugging.
+export const publishWebhookStubAsync = async (stub: WebhookStub, matchId: string): Promise<void> => {
   const topic = process.env.ENV_WEBHOOK_TOPIC;
   if (!topic) {
     return;
   }
   try {
     await pubsub.topic(topic).publishMessage({ json: stub });
+    logWebhookEvent({
+      event: 'webhook_published',
+      dataType: stub.dataType,
+      matchId,
+      idempotencyKey: stub.idempotencyKey,
+    });
   } catch (e) {
     logWebhookEvent({
       event: 'webhook_publish_failed',
       level: 'error',
       dataType: stub.dataType,
-      matchId: stub.id,
+      matchId,
+      idempotencyKey: stub.idempotencyKey,
       error: e instanceof Error ? e.message : String(e),
     });
   }

--- a/packages/cloud/src/webhookPublisher.ts
+++ b/packages/cloud/src/webhookPublisher.ts
@@ -14,8 +14,8 @@ const pubsub = new PubSub({ credentials: gcpCredentials });
 // Never throws — a publish failure is logged and swallowed so match processing
 // is unaffected.
 //
-// `matchId` is only logged here, never published: this is the one place that
-// ties a partner-visible idempotencyKey back to a match id for debugging.
+// `stub.id` is the partner-facing key, not the match id. `matchId` is only
+// logged here, never published: this is the one place that ties the two together.
 export const publishWebhookStubAsync = async (stub: WebhookStub, matchId: string): Promise<void> => {
   const topic = process.env.ENV_WEBHOOK_TOPIC;
   if (!topic) {
@@ -27,7 +27,7 @@ export const publishWebhookStubAsync = async (stub: WebhookStub, matchId: string
       event: 'webhook_published',
       dataType: stub.dataType,
       matchId,
-      idempotencyKey: stub.idempotencyKey,
+      webhookId: stub.id,
     });
   } catch (e) {
     logWebhookEvent({
@@ -35,7 +35,7 @@ export const publishWebhookStubAsync = async (stub: WebhookStub, matchId: string
       level: 'error',
       dataType: stub.dataType,
       matchId,
-      idempotencyKey: stub.idempotencyKey,
+      webhookId: stub.id,
       error: e instanceof Error ? e.message : String(e),
     });
   }

--- a/packages/cloud/src/webhooks.ts
+++ b/packages/cloud/src/webhooks.ts
@@ -15,10 +15,7 @@ import {
 } from '../../parser/dist/index';
 import { realmIdToRegion } from '../../shared/src/utils/realms';
 
-// v2: dropped `id` and `link`. The match id is also the raw log's object name,
-// so exposing it (directly or via the match URL) hands out the log file itself.
-// `idempotencyKey` replaces `id` as the per-match dedupe handle.
-const WEBHOOK_PAYLOAD_VERSION = 2;
+const WEBHOOK_PAYLOAD_VERSION = 1;
 const WEBHOOK_DEFAULT_TIMEOUT_MS = 10000;
 
 export type WebhookCombatantStats = {
@@ -67,8 +64,9 @@ export type WebhookCombatant = {
 export type WebhookStub = {
   version: number;
   dataType: 'ArenaMatch' | 'ShuffleMatch';
-  idempotencyKey: string; // opaque, stable per match; NOT the match id
+  id: string; // opaque per-match key (see toWebhookMatchKey), NOT the internal match id
   wowVersion: WowVersion;
+  link: string | string[]; // string for match, string[] for shuffle; built from `id` above
   startInfo: {
     timestamp: number;
     zoneId: string;
@@ -100,7 +98,7 @@ type WebhookStubBase = Pick<
   WebhookStub,
   | 'version'
   | 'dataType'
-  | 'idempotencyKey'
+  | 'id'
   | 'wowVersion'
   | 'result'
   | 'resultName'
@@ -122,10 +120,11 @@ export const logWebhookEvent = (fields: Record<string, unknown>) => {
   console.log(JSON.stringify(fields));
 };
 
-// One-way key a partner can dedupe on without learning the match id (which
-// doubles as the raw log's storage object name). Match ids are md5 digests, so
-// the preimage is not enumerable.
-export const toIdempotencyKey = (matchId: string): string => crypto.createHash('sha256').update(matchId).digest('hex');
+// The internal match id doubles as the raw log's storage object name, so it is
+// never sent to partners. This one-way digest stands in for it everywhere the
+// payload used to carry the id: stable per match across retries, unique, and
+// not reversible (match ids are md5 digests, so the preimage is not enumerable).
+export const toWebhookMatchKey = (matchId: string): string => crypto.createHash('sha256').update(matchId).digest('hex');
 
 // Player GUIDs are `Player-<realmId>-<hex>`; undefined for any malformed id.
 const parseRealmId = (guid: string): number | undefined => {
@@ -206,7 +205,7 @@ const mapCombatants = (units: Record<string, ICombatUnit>, effectiveDuration: nu
 const buildStubBase = (match: IArenaMatch | IShuffleMatch, atomic: AtomicArenaCombat): WebhookStubBase => ({
   version: WEBHOOK_PAYLOAD_VERSION,
   dataType: match.dataType,
-  idempotencyKey: toIdempotencyKey(match.id),
+  id: toWebhookMatchKey(match.id),
   wowVersion: match.wowVersion,
   result: match.result,
   resultName: (CombatResult[match.result] ?? 'unknown').toLowerCase(),
@@ -229,11 +228,13 @@ const buildStubBase = (match: IArenaMatch | IShuffleMatch, atomic: AtomicArenaCo
 
 export const createWebhookStubFromArenaMatch = (match: IArenaMatch): WebhookStub => {
   const effectiveDuration = getEffectiveCombatDuration(match);
+  const base = buildStubBase(match, match);
   return {
-    ...buildStubBase(match, match),
+    ...base,
     playerId: match.playerId,
     playerTeamId: match.playerTeamId,
     region: playerRegion(match.playerId),
+    link: `https://wowarenalogs.com/match?id=${base.id}&viewerIsOwner=false&source=webhook`,
     combatants: mapCombatants(match.units, effectiveDuration),
   };
 };
@@ -243,11 +244,15 @@ export const createWebhookStubFromShuffleMatch = (match: IShuffleMatch): Webhook
   // taken from round 1; see WEBHOOKS.md.
   const round0 = match.rounds[0];
   const effectiveDuration = getEffectiveCombatDuration(round0);
+  const base = buildStubBase(match, round0);
   return {
-    ...buildStubBase(match, round0),
+    ...base,
     playerId: round0.playerId,
     playerTeamId: round0.playerTeamId,
     region: playerRegion(round0.playerId),
+    link: match.rounds.map(
+      (_r, idx) => `https://wowarenalogs.com/match?id=${base.id}&viewerIsOwner=false&source=webhook&roundId=${idx + 1}`,
+    ),
     roundResults: match.rounds.map((r) => r.result),
     combatants: mapCombatants(round0.units, effectiveDuration),
   };
@@ -268,7 +273,7 @@ export const sendWebhookAsync = async (stub: WebhookStub): Promise<WebhookOutcom
 
   const headers: Record<string, string> = {
     'content-type': 'application/json',
-    'x-idempotency-key': stub.idempotencyKey,
+    'x-idempotency-key': stub.id,
   };
 
   if (secret) {
@@ -281,7 +286,7 @@ export const sendWebhookAsync = async (stub: WebhookStub): Promise<WebhookOutcom
       event: 'webhook_unsigned',
       level: 'warning',
       dataType: stub.dataType,
-      idempotencyKey: stub.idempotencyKey,
+      matchId: stub.id,
       message: 'ENV_WEBHOOK_SECRET is not set; sending unsigned webhook',
     });
   }
@@ -301,7 +306,7 @@ export const sendWebhookAsync = async (stub: WebhookStub): Promise<WebhookOutcom
       logWebhookEvent({
         event: 'webhook_delivered',
         dataType: stub.dataType,
-        idempotencyKey: stub.idempotencyKey,
+        matchId: stub.id,
         status: response.status,
         durationMs: Date.now() - startedAt,
       });
@@ -313,7 +318,7 @@ export const sendWebhookAsync = async (stub: WebhookStub): Promise<WebhookOutcom
       event: 'webhook_failed',
       level: 'error',
       dataType: stub.dataType,
-      idempotencyKey: stub.idempotencyKey,
+      matchId: stub.id,
       status: response.status,
       durationMs: Date.now() - startedAt,
       error: `HTTP ${response.status}`,
@@ -325,7 +330,7 @@ export const sendWebhookAsync = async (stub: WebhookStub): Promise<WebhookOutcom
       event: 'webhook_failed',
       level: 'error',
       dataType: stub.dataType,
-      idempotencyKey: stub.idempotencyKey,
+      matchId: stub.id,
       durationMs: Date.now() - startedAt,
       error: e instanceof Error ? e.message : String(e),
     });

--- a/packages/cloud/src/webhooks.ts
+++ b/packages/cloud/src/webhooks.ts
@@ -15,7 +15,10 @@ import {
 } from '../../parser/dist/index';
 import { realmIdToRegion } from '../../shared/src/utils/realms';
 
-const WEBHOOK_PAYLOAD_VERSION = 1;
+// v2: dropped `id` and `link`. The match id is also the raw log's object name,
+// so exposing it (directly or via the match URL) hands out the log file itself.
+// `idempotencyKey` replaces `id` as the per-match dedupe handle.
+const WEBHOOK_PAYLOAD_VERSION = 2;
 const WEBHOOK_DEFAULT_TIMEOUT_MS = 10000;
 
 export type WebhookCombatantStats = {
@@ -64,9 +67,8 @@ export type WebhookCombatant = {
 export type WebhookStub = {
   version: number;
   dataType: 'ArenaMatch' | 'ShuffleMatch';
-  id: string;
+  idempotencyKey: string; // opaque, stable per match; NOT the match id
   wowVersion: WowVersion;
-  link: string | string[]; // string for match, string[] for shuffle
   startInfo: {
     timestamp: number;
     zoneId: string;
@@ -98,7 +100,7 @@ type WebhookStubBase = Pick<
   WebhookStub,
   | 'version'
   | 'dataType'
-  | 'id'
+  | 'idempotencyKey'
   | 'wowVersion'
   | 'result'
   | 'resultName'
@@ -119,6 +121,11 @@ const getWebhookUrl = (): string | undefined => {
 export const logWebhookEvent = (fields: Record<string, unknown>) => {
   console.log(JSON.stringify(fields));
 };
+
+// One-way key a partner can dedupe on without learning the match id (which
+// doubles as the raw log's storage object name). Match ids are md5 digests, so
+// the preimage is not enumerable.
+export const toIdempotencyKey = (matchId: string): string => crypto.createHash('sha256').update(matchId).digest('hex');
 
 // Player GUIDs are `Player-<realmId>-<hex>`; undefined for any malformed id.
 const parseRealmId = (guid: string): number | undefined => {
@@ -199,7 +206,7 @@ const mapCombatants = (units: Record<string, ICombatUnit>, effectiveDuration: nu
 const buildStubBase = (match: IArenaMatch | IShuffleMatch, atomic: AtomicArenaCombat): WebhookStubBase => ({
   version: WEBHOOK_PAYLOAD_VERSION,
   dataType: match.dataType,
-  id: match.id,
+  idempotencyKey: toIdempotencyKey(match.id),
   wowVersion: match.wowVersion,
   result: match.result,
   resultName: (CombatResult[match.result] ?? 'unknown').toLowerCase(),
@@ -227,7 +234,6 @@ export const createWebhookStubFromArenaMatch = (match: IArenaMatch): WebhookStub
     playerId: match.playerId,
     playerTeamId: match.playerTeamId,
     region: playerRegion(match.playerId),
-    link: `https://wowarenalogs.com/match?id=${match.id}&viewerIsOwner=false&source=webhook`,
     combatants: mapCombatants(match.units, effectiveDuration),
   };
 };
@@ -242,10 +248,6 @@ export const createWebhookStubFromShuffleMatch = (match: IShuffleMatch): Webhook
     playerId: round0.playerId,
     playerTeamId: round0.playerTeamId,
     region: playerRegion(round0.playerId),
-    link: match.rounds.map(
-      (_r, idx) =>
-        `https://wowarenalogs.com/match?id=${match.id}&viewerIsOwner=false&source=webhook&roundId=${idx + 1}`,
-    ),
     roundResults: match.rounds.map((r) => r.result),
     combatants: mapCombatants(round0.units, effectiveDuration),
   };
@@ -266,7 +268,7 @@ export const sendWebhookAsync = async (stub: WebhookStub): Promise<WebhookOutcom
 
   const headers: Record<string, string> = {
     'content-type': 'application/json',
-    'x-idempotency-key': stub.id,
+    'x-idempotency-key': stub.idempotencyKey,
   };
 
   if (secret) {
@@ -279,7 +281,7 @@ export const sendWebhookAsync = async (stub: WebhookStub): Promise<WebhookOutcom
       event: 'webhook_unsigned',
       level: 'warning',
       dataType: stub.dataType,
-      matchId: stub.id,
+      idempotencyKey: stub.idempotencyKey,
       message: 'ENV_WEBHOOK_SECRET is not set; sending unsigned webhook',
     });
   }
@@ -299,7 +301,7 @@ export const sendWebhookAsync = async (stub: WebhookStub): Promise<WebhookOutcom
       logWebhookEvent({
         event: 'webhook_delivered',
         dataType: stub.dataType,
-        matchId: stub.id,
+        idempotencyKey: stub.idempotencyKey,
         status: response.status,
         durationMs: Date.now() - startedAt,
       });
@@ -311,7 +313,7 @@ export const sendWebhookAsync = async (stub: WebhookStub): Promise<WebhookOutcom
       event: 'webhook_failed',
       level: 'error',
       dataType: stub.dataType,
-      matchId: stub.id,
+      idempotencyKey: stub.idempotencyKey,
       status: response.status,
       durationMs: Date.now() - startedAt,
       error: `HTTP ${response.status}`,
@@ -323,7 +325,7 @@ export const sendWebhookAsync = async (stub: WebhookStub): Promise<WebhookOutcom
       event: 'webhook_failed',
       level: 'error',
       dataType: stub.dataType,
-      matchId: stub.id,
+      idempotencyKey: stub.idempotencyKey,
       durationMs: Date.now() - startedAt,
       error: e instanceof Error ? e.message : String(e),
     });

--- a/packages/cloud/src/writeMatchStubHandler.ts
+++ b/packages/cloud/src/writeMatchStubHandler.ts
@@ -75,7 +75,7 @@ export async function handler(file: any, _context: any) {
     }
     if (arenaMatch.startInfo.isRanked) {
       try {
-        await publishWebhookStubAsync(createWebhookStubFromArenaMatch(arenaMatch));
+        await publishWebhookStubAsync(createWebhookStubFromArenaMatch(arenaMatch), arenaMatch.id);
       } catch (e) {
         console.error(e);
       }
@@ -109,7 +109,7 @@ export async function handler(file: any, _context: any) {
     console.timeEnd('writing shuffle match data');
     if (shuffleMatch.startInfo.bracket === 'Rated Solo Shuffle') {
       try {
-        await publishWebhookStubAsync(createWebhookStubFromShuffleMatch(shuffleMatch));
+        await publishWebhookStubAsync(createWebhookStubFromShuffleMatch(shuffleMatch), shuffleMatch.id);
       } catch (e) {
         console.error(e);
       }

--- a/packages/cloud/test/test_webhooks.ts
+++ b/packages/cloud/test/test_webhooks.ts
@@ -1,7 +1,7 @@
 import crypto from 'crypto';
 import http from 'http';
 
-import { sendWebhookAsync, toIdempotencyKey, WebhookStub } from '../src/webhooks';
+import { sendWebhookAsync, toWebhookMatchKey, WebhookStub } from '../src/webhooks';
 
 const TEST_SECRET = 'test-webhook-secret';
 
@@ -32,12 +32,15 @@ async function main() {
   process.env.ENV_WEBHOOK_URL = `http://127.0.0.1:${port}`;
   process.env.ENV_WEBHOOK_SECRET = TEST_SECRET;
 
+  // The internal match id must never reach the wire; the stub carries a one-way key instead.
   const matchId = 'test-match-1';
+  const webhookId = toWebhookMatchKey(matchId);
   const sampleStub: WebhookStub = {
-    version: 2,
+    version: 1,
     dataType: 'ArenaMatch',
-    idempotencyKey: toIdempotencyKey(matchId),
+    id: webhookId,
     wowVersion: 'retail',
+    link: `https://wowarenalogs.com/match?id=${webhookId}`,
     startInfo: { timestamp: 1, zoneId: '1552', bracket: '3v3', isRanked: true },
     endInfo: { winningTeamId: '0', timestamp: 2, matchDurationInSeconds: 120, team0MMR: 1500, team1MMR: 1510 },
     playerId: 'player-1',
@@ -63,13 +66,8 @@ async function main() {
     if (received.headers['content-type'] !== 'application/json') {
       failures.push(`content-type was '${received.headers['content-type']}', expected 'application/json'`);
     }
-    if (received.headers['x-idempotency-key'] !== sampleStub.idempotencyKey) {
-      failures.push(
-        `x-idempotency-key was '${received.headers['x-idempotency-key']}', expected '${sampleStub.idempotencyKey}'`,
-      );
-    }
-    if (received.headers['x-idempotency-key'] === matchId) {
-      failures.push('x-idempotency-key must not be the raw match id');
+    if (received.headers['x-idempotency-key'] !== sampleStub.id) {
+      failures.push(`x-idempotency-key was '${received.headers['x-idempotency-key']}', expected '${sampleStub.id}'`);
     }
     const signature = received.headers['x-signature'];
     if (typeof signature !== 'string' || !signature.startsWith('sha256=')) {
@@ -84,14 +82,8 @@ async function main() {
     if (received.body !== JSON.stringify(sampleStub)) {
       failures.push('received body did not match the sent stub');
     }
-    // The match id doubles as the raw log's object name; neither it nor a match
-    // URL may appear anywhere in the delivered payload.
-    const parsedBody = JSON.parse(received.body) as Record<string, unknown>;
-    if ('id' in parsedBody || 'link' in parsedBody) {
-      failures.push('payload must not contain `id` or `link`');
-    }
-    if (received.body.includes(matchId) || received.body.includes('wowarenalogs.com/match')) {
-      failures.push('payload leaks the match id or a match URL');
+    if (received.body.includes(matchId) || received.headers['x-idempotency-key'] === matchId) {
+      failures.push('delivery leaks the internal match id');
     }
   }
 

--- a/packages/cloud/test/test_webhooks.ts
+++ b/packages/cloud/test/test_webhooks.ts
@@ -1,7 +1,7 @@
 import crypto from 'crypto';
 import http from 'http';
 
-import { sendWebhookAsync, WebhookStub } from '../src/webhooks';
+import { sendWebhookAsync, toIdempotencyKey, WebhookStub } from '../src/webhooks';
 
 const TEST_SECRET = 'test-webhook-secret';
 
@@ -32,12 +32,12 @@ async function main() {
   process.env.ENV_WEBHOOK_URL = `http://127.0.0.1:${port}`;
   process.env.ENV_WEBHOOK_SECRET = TEST_SECRET;
 
+  const matchId = 'test-match-1';
   const sampleStub: WebhookStub = {
-    version: 1,
+    version: 2,
     dataType: 'ArenaMatch',
-    id: 'test-match-1',
+    idempotencyKey: toIdempotencyKey(matchId),
     wowVersion: 'retail',
-    link: 'https://wowarenalogs.com/match?id=test-match-1',
     startInfo: { timestamp: 1, zoneId: '1552', bracket: '3v3', isRanked: true },
     endInfo: { winningTeamId: '0', timestamp: 2, matchDurationInSeconds: 120, team0MMR: 1500, team1MMR: 1510 },
     playerId: 'player-1',
@@ -63,8 +63,13 @@ async function main() {
     if (received.headers['content-type'] !== 'application/json') {
       failures.push(`content-type was '${received.headers['content-type']}', expected 'application/json'`);
     }
-    if (received.headers['x-idempotency-key'] !== sampleStub.id) {
-      failures.push(`x-idempotency-key was '${received.headers['x-idempotency-key']}', expected '${sampleStub.id}'`);
+    if (received.headers['x-idempotency-key'] !== sampleStub.idempotencyKey) {
+      failures.push(
+        `x-idempotency-key was '${received.headers['x-idempotency-key']}', expected '${sampleStub.idempotencyKey}'`,
+      );
+    }
+    if (received.headers['x-idempotency-key'] === matchId) {
+      failures.push('x-idempotency-key must not be the raw match id');
     }
     const signature = received.headers['x-signature'];
     if (typeof signature !== 'string' || !signature.startsWith('sha256=')) {
@@ -78,6 +83,15 @@ async function main() {
     }
     if (received.body !== JSON.stringify(sampleStub)) {
       failures.push('received body did not match the sent stub');
+    }
+    // The match id doubles as the raw log's object name; neither it nor a match
+    // URL may appear anywhere in the delivered payload.
+    const parsedBody = JSON.parse(received.body) as Record<string, unknown>;
+    if ('id' in parsedBody || 'link' in parsedBody) {
+      failures.push('payload must not contain `id` or `link`');
+    }
+    if (received.body.includes(matchId) || received.body.includes('wowarenalogs.com/match')) {
+      failures.push('payload leaks the match id or a match URL');
     }
   }
 

--- a/packages/shared/src/components/common/SearchDisabledNotice.tsx
+++ b/packages/shared/src/components/common/SearchDisabledNotice.tsx
@@ -1,0 +1,15 @@
+import { TbRocketOff } from 'react-icons/tb';
+
+import { SEARCH_DISABLED_MESSAGE, SEARCH_DISABLED_TITLE } from '../../utils/searchStatus';
+
+export function SearchDisabledNotice() {
+  return (
+    <div className="alert alert-warning shadow-lg animate-fadein">
+      <TbRocketOff size={28} className="shrink-0" />
+      <div>
+        <h3 className="font-bold">{SEARCH_DISABLED_TITLE}</h3>
+        <div className="text-sm">{SEARCH_DISABLED_MESSAGE}</div>
+      </div>
+    </div>
+  );
+}

--- a/packages/shared/src/components/pages/SearchPage.tsx
+++ b/packages/shared/src/components/pages/SearchPage.tsx
@@ -7,9 +7,11 @@ import { TbArrowBigUpLines, TbLoader, TbRocketOff } from 'react-icons/tb';
 
 import { useGetPublicMatchesQuery } from '../../graphql/__generated__/graphql';
 import { logAnalyticsEvent } from '../../utils/analytics';
+import { SEARCH_DISABLED } from '../../utils/searchStatus';
 import { CombatStubList } from '../CombatStubList';
 import { LocalRemoteHybridCombat } from '../CombatStubList/rows';
 import { QuerryError } from '../common/QueryError';
+import { SearchDisabledNotice } from '../common/SearchDisabledNotice';
 import { Bracket, BracketSelector } from '../MatchSearch/BracketSelector';
 import { RatingSelector } from '../MatchSearch/RatingSelector';
 import { SpecSelector } from '../MatchSearch/SpecSelector';
@@ -70,6 +72,7 @@ export const SearchPage = () => {
 
   const compQueryString = computeCompQueryString(filters.team1SpecIds, filters.team2SpecIds);
   const matchesQuery = useGetPublicMatchesQuery({
+    skip: SEARCH_DISABLED,
     variables: {
       wowVersion: 'retail',
       bracket: filters.bracket,
@@ -110,6 +113,15 @@ export const SearchPage = () => {
   }
   function clearAllFilters() {
     setFilters(DEFAULT_FILTERS);
+  }
+
+  if (SEARCH_DISABLED) {
+    return (
+      <div className="mt-2 px-2 sm:mt-4 sm:px-4">
+        <title>Find Matches</title>
+        <SearchDisabledNotice />
+      </div>
+    );
   }
 
   return (

--- a/packages/shared/src/graphql-server/resolvers/matches.ts
+++ b/packages/shared/src/graphql-server/resolvers/matches.ts
@@ -1,9 +1,11 @@
 import { Firestore } from '@google-cloud/firestore';
 import { WowVersion } from '@wowarenalogs/parser';
+import { ApolloError } from 'apollo-server-micro';
 import fs from 'fs';
 import moment from 'moment';
 import path from 'path';
 
+import { SEARCH_DISABLED, SEARCH_DISABLED_MESSAGE } from '../../utils/searchStatus';
 import { ApolloContext, CombatQueryResult, ICombatDataStub } from '../types';
 import { Constants } from '../utils/constants';
 const matchStubsCollection = 'match-stubs-prod';
@@ -20,6 +22,14 @@ function firestoreDocToMatchStub(stub: ICombatDataStub): ICombatDataStub {
   return stub;
 }
 
+// Guards every discovery query. Throwing before the Firestore read means a
+// disabled endpoint costs nothing to hit, however often it is called.
+function assertSearchEnabled() {
+  if (SEARCH_DISABLED) {
+    throw new ApolloError(SEARCH_DISABLED_MESSAGE, 'SEARCH_DISABLED');
+  }
+}
+
 export async function latestMatches(
   _parent: unknown,
   args: {
@@ -32,6 +42,7 @@ export async function latestMatches(
     count: number;
   },
 ): Promise<CombatQueryResult> {
+  assertSearchEnabled();
   const collectionReference = firestore.collection(matchStubsCollection);
 
   const now = moment().valueOf();
@@ -99,6 +110,7 @@ export async function latestMatches(
 }
 
 export async function matchesWithOwnerId(_parent: unknown, args: { ownerId: string }) {
+  assertSearchEnabled();
   const collectionReference = firestore.collection(matchStubsCollection);
   const matchDocs = await collectionReference
     .where('ownerId', '==', args.ownerId)
@@ -113,6 +125,7 @@ export async function recentMatchesWithCombatant(
   _parent: unknown,
   args: { combatantName: string; serverName: string; region: string },
 ) {
+  assertSearchEnabled();
   const collectionReference = firestore.collection(matchStubsCollection);
   const matchDocs = await collectionReference
     .where('combatantNames', 'array-contains', `${args.combatantName}-${args.serverName}`)
@@ -166,6 +179,7 @@ export async function userMatches(
   _parent: unknown,
   args: { userId: string; offset: number; count: number },
 ): Promise<CombatQueryResult> {
+  assertSearchEnabled();
   const collectionReference = firestore.collection(matchStubsCollection);
   const matchDocs = await collectionReference
     .where('ownerId', '==', `${args.userId}`)
@@ -185,6 +199,7 @@ export async function characterMatches(
   _parent: unknown,
   args: { realm: string; characterName: string; offset: number; count: number },
 ): Promise<CombatQueryResult> {
+  assertSearchEnabled();
   const collectionReference = firestore.collection(matchStubsCollection);
   const matchDocs = await collectionReference
     .where('combatantNames', 'array-contains', `${args.characterName}-${args.realm}`)

--- a/packages/shared/src/utils/searchStatus.ts
+++ b/packages/shared/src/utils/searchStatus.ts
@@ -1,0 +1,19 @@
+/**
+ * Kill switch for the public match discovery ("search") API and UI.
+ *
+ * While true, every GraphQL query that lets a caller enumerate matches they do
+ * not own (latestMatches, userMatches, characterMatches, recentMatchesWithCombatant,
+ * matchesWithOwnerId) rejects the request before touching Firestore, and the search
+ * page shows a discontinuation notice instead of the filter UI.
+ *
+ * myMatches and matchById are unaffected: they only return matches the caller
+ * already owns or already holds an id for.
+ */
+export const SEARCH_DISABLED = true;
+
+export const SEARCH_DISABLED_TITLE = 'Match search is discontinued';
+
+export const SEARCH_DISABLED_MESSAGE =
+  'Automated scraping of search results has driven our hosting costs up sharply, so match search is ' +
+  'discontinued until we can find a way to prevent it. Your own uploaded matches and any match shared ' +
+  'with you by link are still available.';

--- a/packages/web/app/(main)/matches/character/[characterName]/page.tsx
+++ b/packages/web/app/(main)/matches/character/[characterName]/page.tsx
@@ -3,7 +3,9 @@
 import { CombatStubList } from '@wowarenalogs/shared';
 import { LocalRemoteHybridCombat } from '@wowarenalogs/shared/src/components/CombatStubList/rows';
 import { QuerryError } from '@wowarenalogs/shared/src/components/common/QueryError';
+import { SearchDisabledNotice } from '@wowarenalogs/shared/src/components/common/SearchDisabledNotice';
 import { useGetCharacterMatchesLazyQuery } from '@wowarenalogs/shared/src/graphql/__generated__/graphql';
+import { SEARCH_DISABLED } from '@wowarenalogs/shared/src/utils/searchStatus';
 import _ from 'lodash';
 import { useParams, useSearchParams } from 'next/navigation';
 import { useEffect } from 'react';
@@ -23,6 +25,9 @@ export default function CharacterMatchesPage() {
   });
 
   useEffect(() => {
+    if (SEARCH_DISABLED) {
+      return;
+    }
     if (characterName && typeof characterName === 'string') {
       if (realm && typeof realm === 'string') {
         exec({
@@ -34,6 +39,14 @@ export default function CharacterMatchesPage() {
       }
     }
   }, [realm, characterName, exec]);
+
+  if (SEARCH_DISABLED) {
+    return (
+      <div className="transition-all p-2">
+        <SearchDisabledNotice />
+      </div>
+    );
+  }
 
   if (matchesQuery.loading) {
     return (

--- a/packages/web/app/(main)/matches/user/[userId]/page.tsx
+++ b/packages/web/app/(main)/matches/user/[userId]/page.tsx
@@ -3,7 +3,9 @@
 import { CombatStubList } from '@wowarenalogs/shared';
 import { LocalRemoteHybridCombat } from '@wowarenalogs/shared/src/components/CombatStubList/rows';
 import { QuerryError } from '@wowarenalogs/shared/src/components/common/QueryError';
+import { SearchDisabledNotice } from '@wowarenalogs/shared/src/components/common/SearchDisabledNotice';
 import { useGetUserMatchesLazyQuery } from '@wowarenalogs/shared/src/graphql/__generated__/graphql';
+import { SEARCH_DISABLED } from '@wowarenalogs/shared/src/utils/searchStatus';
 import _ from 'lodash';
 import { useParams } from 'next/navigation';
 import { useEffect } from 'react';
@@ -20,6 +22,9 @@ export default function UserMatchesPage() {
   });
 
   useEffect(() => {
+    if (SEARCH_DISABLED) {
+      return;
+    }
     if (userId && typeof userId === 'string') {
       exec({
         variables: {
@@ -28,6 +33,14 @@ export default function UserMatchesPage() {
       });
     }
   }, [userId, exec]);
+
+  if (SEARCH_DISABLED) {
+    return (
+      <div className="transition-all p-2">
+        <SearchDisabledNotice />
+      </div>
+    );
+  }
 
   if (matchesQuery.loading) {
     return (


### PR DESCRIPTION
## Why

Batch processes have been enumerating match ids through the public discovery queries. A match id is also the raw log's storage object name, so enumeration hands out the log files themselves. Hosting costs are up over 300% in the last two months as a result.

## What changes

**GraphQL API** (`packages/shared/src/graphql-server/resolvers/matches.ts`)
- `latestMatches`, `userMatches`, `characterMatches`, `recentMatchesWithCombatant` and `matchesWithOwnerId` now throw `SEARCH_DISABLED` before any Firestore read, so hitting them costs nothing.
- Controlled by one constant, `SEARCH_DISABLED` in `packages/shared/src/utils/searchStatus.ts`, so re-enabling is a one-line change.
- `myMatches` (own uploads) and `matchById` (viewing a match you already have a link to) are untouched. The schema is unchanged, so clients still compile.

**Web UI**
- `/search` renders a "Match search is discontinued" notice explaining that scraping drove costs up, and skips the query.
- The unlinked `/matches/character/*` and `/matches/user/*` history pages show the same notice instead of a bare error.

**Partner webhooks** (`packages/cloud`), interface unchanged
- Same fields, same `version: 1`, `x-idempotency-key` still equals payload `id`.
- The `id` value is now `sha256(matchId)` instead of the internal match id, and `link` is built from that same key. Dedupe semantics are preserved (stable per match across retries, unique), but the value cannot be used to fetch the raw log.
- `writeMatchStub` logs a `webhook_published` line with `matchId` and `webhookId` so we can still correlate a partner's report back to a match.
- `WEBHOOKS.md` notes that `id` is an opaque key.

## Verification
- `npm run lint` clean in `shared`, `web`, `cloud`.
- `tsc --noEmit` clean in `cloud`. Web typecheck error count is unchanged from `main` (all pre-existing, none in touched files).
- `npm run test:webhooks` passes, with a new assertion that neither the body nor the idempotency header contains the internal match id.

## Deploy notes
- The webhook `link` now points at `/match?id=<key>`, which does not resolve to a match page. The partner sees the same shape as before, but the link is no longer clickable.
- Web and cloud deploy independently; the API disable takes effect with the next web deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UNKjfTk54noQeCdHdppfux
